### PR TITLE
Example using WebSocket for all operations with GraphQL handler

### DIFF
--- a/examples/graphql-websocket-only/.meshrc.yml
+++ b/examples/graphql-websocket-only/.meshrc.yml
@@ -1,0 +1,5 @@
+sources:
+  - name: GraphQL WebSocket only
+    handler:
+      graphql:
+        endpoint: ws://localhost:54000/graphql

--- a/examples/graphql-websocket-only/endpoint.js
+++ b/examples/graphql-websocket-only/endpoint.js
@@ -1,0 +1,48 @@
+const { GraphQLSchema, GraphQLObjectType, GraphQLString } = require('graphql');
+const { WebSocketServer } = require('ws');
+const { useServer } = require('graphql-ws/lib/use/ws');
+
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      hello: {
+        type: GraphQLString,
+        resolve: () => 'world',
+      },
+    },
+  }),
+  mutation: new GraphQLObjectType({
+    name: 'Mutation',
+    fields: {
+      dontChange: {
+        type: GraphQLString,
+        resolve: () => 'didntChange',
+      },
+    },
+  }),
+  subscription: new GraphQLObjectType({
+    name: 'Subscription',
+    fields: {
+      greetings: {
+        type: GraphQLString,
+        subscribe: async function* () {
+          for (const hi of ['Hi', 'Bonjour', 'Hola', 'Ciao', 'Zdravo']) {
+            yield { greetings: hi };
+            await new Promise(resolve => setTimeout(resolve, 1000));
+          }
+        },
+      },
+    },
+  }),
+});
+
+useServer(
+  { schema },
+  new WebSocketServer({
+    port: 54000,
+    path: '/graphql',
+  })
+);
+
+console.log('Listening on port 54000...');

--- a/examples/graphql-websocket-only/package.json
+++ b/examples/graphql-websocket-only/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "start:endpoint": "node endpoint.js",
+    "start:endpoint": "node -e 'require(\"./endpoint\").start()'",
     "start": "mesh dev",
     "test": "jest"
   },

--- a/examples/graphql-websocket-only/package.json
+++ b/examples/graphql-websocket-only/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "graphql-websocket-only",
+  "version": "1.0.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "start:endpoint": "node endpoint.js",
+    "start": "mesh dev",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@graphql-mesh/cli": "0.75.7",
+    "@graphql-mesh/graphql": "0.29.7",
+    "graphql": "16.5.0",
+    "graphql-ws": "5.10.0",
+    "ws": "8.8.1"
+  },
+  "devDependencies": {
+    "jest": "28.1.3"
+  }
+}

--- a/examples/graphql-websocket-only/sandbox.config.json
+++ b/examples/graphql-websocket-only/sandbox.config.json
@@ -1,0 +1,8 @@
+{
+  "infiniteLoopProtection": true,
+  "hardReloadOnChange": false,
+  "template": "node",
+  "container": {
+    "node": "16"
+  }
+}

--- a/examples/graphql-websocket-only/tests/graphql-websocket-only.test.js
+++ b/examples/graphql-websocket-only/tests/graphql-websocket-only.test.js
@@ -1,16 +1,30 @@
 const { join } = require('path');
+
+const { start: startEndpoint } = require('../endpoint');
+
 const { findAndParseConfig } = require('@graphql-mesh/cli');
 const { getMesh } = require('@graphql-mesh/runtime');
 
 const { introspectionFromSchema, lexicographicSortSchema } = require('graphql');
 
-const mesh$ = findAndParseConfig({
-  dir: join(__dirname, '..'),
-}).then(config => getMesh(config));
+let mesh$ = {},
+  stopEndpoint = () => {};
+beforeAll(async () => {
+  stopEndpoint = await startEndpoint();
+
+  mesh$ = await getMesh(
+    await findAndParseConfig({
+      dir: join(__dirname, '..'),
+    })
+  );
+});
+afterAll(async () => {
+  await stopEndpoint();
+});
 
 describe('GraphQL WebSocket only', () => {
-  it('should generate correct schema', async () => {
-    const { schema } = await mesh$;
+  it('should generate correct schema', () => {
+    const { schema } = mesh$;
     expect(
       introspectionFromSchema(lexicographicSortSchema(schema), {
         descriptions: false,

--- a/examples/graphql-websocket-only/tests/graphql-websocket-only.test.js
+++ b/examples/graphql-websocket-only/tests/graphql-websocket-only.test.js
@@ -1,0 +1,20 @@
+const { join } = require('path');
+const { findAndParseConfig } = require('@graphql-mesh/cli');
+const { getMesh } = require('@graphql-mesh/runtime');
+
+const { introspectionFromSchema, lexicographicSortSchema } = require('graphql');
+
+const mesh$ = findAndParseConfig({
+  dir: join(__dirname, '..'),
+}).then(config => getMesh(config));
+
+describe('GraphQL WebSocket only', () => {
+  it('should generate correct schema', async () => {
+    const { schema } = await mesh$;
+    expect(
+      introspectionFromSchema(lexicographicSortSchema(schema), {
+        descriptions: false,
+      })
+    ).toMatchSnapshot();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11203,6 +11203,11 @@ graphql-type-json@0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
+graphql-ws@5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.10.0.tgz#3fb47a4e809e0d2e7c197f1bca754fa9f31b940e"
+  integrity sha512-ewbPzHQdRZgNCPDH9Yr6xccSeZfk3fmpO/AGGGg4KkM5gc6oAOJQ10Oui1EqprhVOyRbOll9bw2qAkOiOwfTag==
+
 graphql-ws@5.9.1, graphql-ws@^5.4.1, graphql-ws@^5.6.2:
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.9.1.tgz#9c0fa48ceb695d61d574ed3ab21b426729e87f2d"


### PR DESCRIPTION
Asked: https://github.com/enisdenjo/graphql-ws/discussions/383#discussioncomment-3363137.

Currently the tests are failing because the `ws` protocol is not supported as a graphql handler's endpoint.