### PR TITLE
Fix headers not being usable in sessionId template

### DIFF
--- a/.changeset/fuzzy-pants-play.md
+++ b/.changeset/fuzzy-pants-play.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-response-cache': patch
+---
+
+Fix headers not being usable in sessionId

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -1,8 +1,9 @@
-import { KeyValueCache, MeshPluginOptions, YamlConfig } from '@graphql-mesh/types';
 import { Plugin } from '@envelop/core';
-import { useResponseCache, UseResponseCacheParameter } from '@graphql-yoga/plugin-response-cache';
-import { hashObject, stringInterpolator } from '@graphql-mesh/string-interpolation';
 import { process } from '@graphql-mesh/cross-helpers';
+import { hashObject, stringInterpolator } from '@graphql-mesh/string-interpolation';
+import { KeyValueCache, MeshPluginOptions, YamlConfig } from '@graphql-mesh/types';
+import { getHeadersObj } from '@graphql-mesh/utils';
+import { useResponseCache, UseResponseCacheParameter } from '@graphql-yoga/plugin-response-cache';
 
 const defaultBuildResponseCacheKey: UseResponseCacheParameter['buildResponseCacheKey'] =
   async params => hashObject(params);
@@ -14,8 +15,9 @@ function generateSessionIdFactory(sessionIdDef: string) {
     };
   }
   return function session(context: any) {
+    const headers = getHeadersObj(context.headers);
     return stringInterpolator.parse(sessionIdDef, {
-      context,
+      context: { ...context, headers },
       env: process.env,
     });
   };


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Makes headers usable in session id when using node's fetch.

Fixes #5102
Related #4109

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has only been tested locally, I was not able to write a proper test case with a fetch Request object.

However you can reproduce it with the steps from #5102.

**Test Environment**:

- OS: MacOS
- `@graphql-mesh/plugin-response-cache`: 0.2.7
- NodeJS: 16.x

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
