### PR TITLE
chore: form explode with oneof query parameters

### DIFF
--- a/packages/loaders/openapi/tests/fixtures/form-explode.yml
+++ b/packages/loaders/openapi/tests/fixtures/form-explode.yml
@@ -1,0 +1,48 @@
+openapi: 3.0.0
+info:
+  title: Api
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      parameters:
+        - in: query
+          name: intent
+          required: true
+          style: form
+          explode: true
+          schema:
+            type: object
+            discriminator: idtype
+            title: Intent
+            oneOf:
+              - title: User Intent
+                properties:
+                  idtype:
+                    type: string
+                    enum: ['user']
+                    default: 'user'
+                  user_id:
+                    type: string
+                required: [user_id]
+                additionalProperties: false
+              - title: Wallet Intent
+                properties:
+                  idtype:
+                    type: string
+                    enum: ['wallet']
+                    default: 'wallet'
+                  wallet_id:
+                    type: string
+                required: [wallet_id]
+                additionalProperties: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  url:
+                    type: string

--- a/packages/loaders/openapi/tests/form-explode-oneof.test.ts
+++ b/packages/loaders/openapi/tests/form-explode-oneof.test.ts
@@ -1,0 +1,54 @@
+import { execute, GraphQLSchema, parse } from 'graphql';
+import { Response } from '@whatwg-node/fetch';
+import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
+
+let createdSchema: GraphQLSchema;
+
+describe('OpenAPI loader: form explode with oneof query parameters', () => {
+  /**
+   * Set up the schema first and run example API server
+   */
+  beforeAll(async () => {
+    const endpoint = `http://localhost:3000/`;
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      async fetch(input, init) {
+        console.log(input);
+        return Response.json({
+          url: input,
+        });
+      },
+      endpoint,
+      source: './fixtures/form-explode.yml',
+      cwd: __dirname,
+    });
+  });
+
+  it('should serialize correct query parameters', async () => {
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(/* GraphQL */ `
+        query ($intent: Intent_Input!) {
+          test(intent: $intent) {
+            url
+          }
+        }
+      `),
+      variableValues: {
+        intent: {
+          User_Intent_Input: {
+            idtype: 'user',
+            user_id: '1',
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      data: {
+        test: {
+          url: 'http://localhost:3000/test?idtype=user&user_id=1',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
closes #6132 

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Query parameter schema's that use oneOf together with form explode aren't serialized correctly.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
