### PR TITLE
Fix bare mode resolvers for Prefix and NamingConvention transforms

### DIFF
--- a/.changeset/short-fans-change.md
+++ b/.changeset/short-fans-change.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/transform-naming-convention': patch
+'@graphql-mesh/transform-prefix': patch
+---
+
+Fix bare mode resolvers for Prefix and NamingConvention transforms

--- a/packages/legacy/transforms/naming-convention/src/bareNamingConvention.ts
+++ b/packages/legacy/transforms/naming-convention/src/bareNamingConvention.ts
@@ -65,7 +65,7 @@ const defaultResolverComposer =
     // map result values from original value to new renamed value
     return resultMap
       ? Array.isArray(originalResult)
-        ? originalResult.map(result => resultMap[result as string] || originalResult)
+        ? originalResult.map(result => resultMap[result as string] || result)
         : resultMap[originalResult as string] || originalResult
       : originalResult;
   };
@@ -161,7 +161,7 @@ export default class NamingConventionTransform implements MeshTransform {
           ];
         },
       }),
-      ...((this.config.fieldNames || this.config.fieldArgumentNames) && {
+      ...((this.config.enumValues || this.config.fieldNames || this.config.fieldArgumentNames) && {
         [MapperKind.COMPOSITE_FIELD]: (fieldConfig, fieldName) => {
           const enumNamingConventionFn = NAMING_CONVENTIONS[this.config.enumValues];
           const fieldNamingConventionFn =
@@ -223,7 +223,7 @@ export default class NamingConventionTransform implements MeshTransform {
           fieldConfig.resolve = defaultResolverComposer(
             fieldConfig.resolve,
             fieldName,
-            argsMap,
+            Object.keys(argsMap).length ? argsMap : null,
             resultMap,
           );
 

--- a/packages/legacy/transforms/prefix/src/barePrefix.ts
+++ b/packages/legacy/transforms/prefix/src/barePrefix.ts
@@ -52,7 +52,9 @@ export default class BarePrefix implements MeshTransform {
           const existingResolver = type.resolveType;
           type.resolveType = async (data, context, info, abstractType) => {
             const typeName = await existingResolver(data, context, info, abstractType);
-            return this.prefix + typeName;
+            // an extended type might already implement the resolver of a previously
+            // transformed type, hence prefix would have already been applied
+            return typeName.startsWith(this.prefix) ? typeName : this.prefix + typeName;
           };
           const currentName = type.name;
           return renameType(type, this.prefix + currentName) as GraphQLAbstractType;


### PR DESCRIPTION
Hello @ardatan , been a while; so to remind you that you cannot get rid of me, here I am with fresh PR 🙂

## Description

This PR fixes the following issues with bare mode transforms.

### Prefix
- The built-in resolver was always applying the prefix to the resolved typeName. Sometimes the typeName might be an extension over a resolver of another field that already went through transformation; hence the prefix might be applied multiple times. This fix ensures the prefix is not applied more than once.

### Naming convention
- Bug in the built-in `defaultResolverComposer` causing the return value of an entire original result in place of a single array item
- Added processing of composite fields when enum config is available so that their types get the resolver composer attached
- Prevent mapping of arguments for fields where arguments are not affected by the given config

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests and linter rules pass locally with my changes