### PR TITLE
fix: support empty responses with 200 status

### DIFF
--- a/.changeset/tame-files-brake.md
+++ b/.changeset/tame-files-brake.md
@@ -1,0 +1,5 @@
+---
+'@omnigraph/json-schema': patch
+---
+
+Fixed issue where empty 200 response would throw an error

--- a/packages/loaders/json-schema/src/addRootFieldResolver.ts
+++ b/packages/loaders/json-schema/src/addRootFieldResolver.ts
@@ -290,7 +290,7 @@ export function addHTTPRootFieldResolver(
       if (isScalarType(returnNamedGraphQLType)) {
         operationLogger.debug(` => Return type is not a JSON so returning ${responseText}`);
         return responseText;
-      } else if (response.status === 204) {
+      } else if (response.status === 204 || (response.status === 200 && responseText === '')) {
         responseJson = {};
       } else if (response.status.toString().startsWith('2')) {
         logger.debug(`Unexpected response in ${field.name};\n\t${responseText}`);

--- a/packages/loaders/openapi/tests/empty-response.test.ts
+++ b/packages/loaders/openapi/tests/empty-response.test.ts
@@ -1,0 +1,44 @@
+import { execute, GraphQLSchema, parse } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { Request, Response } from '@whatwg-node/fetch';
+import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
+
+let createdSchema: GraphQLSchema;
+
+describe('Empty JSON response', () => {
+  /**
+   * Set up the schema first and run example API server
+   */
+  beforeAll(async () => {
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      async fetch(input, init) {
+        return new Response(undefined, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': '0',
+          },
+          status: 200,
+        });
+      },
+      source: './fixtures/empty-response.yml',
+      cwd: __dirname,
+    });
+  });
+
+  it('should not throw when response content length is 0', async () => {
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(/* GraphQL */ `
+        mutation {
+          deleteUser
+        }
+      `),
+    });
+
+    expect(result).toEqual({
+      data: {
+        deleteUser: {},
+      },
+    });
+  });
+});

--- a/packages/loaders/openapi/tests/empty-response.test.ts
+++ b/packages/loaders/openapi/tests/empty-response.test.ts
@@ -1,6 +1,5 @@
 import { execute, GraphQLSchema, parse } from 'graphql';
-import { printSchemaWithDirectives } from '@graphql-tools/utils';
-import { Request, Response } from '@whatwg-node/fetch';
+import { Response } from '@whatwg-node/fetch';
 import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
 
 let createdSchema: GraphQLSchema;

--- a/packages/loaders/openapi/tests/fixtures/empty-response.yml
+++ b/packages/loaders/openapi/tests/fixtures/empty-response.yml
@@ -1,0 +1,37 @@
+---
+openapi: '3.0.1'
+info:
+  description: 'Schema'
+  version: '1.0.0'
+  title: 'MyAPI'
+paths:
+  /user:
+    delete:
+      summary: 'Delete user'
+      description: 'Deletes a user'
+      operationId: deleteUser
+      responses:
+        '200':
+          description: Created
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorList'
+components:
+  schemas:
+    errorList:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/error'
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Certain APIs will return empty responses together with 200 errors. This works correctly in grapql-mesh if there is only a 200 response defined. When there are other (error) responses defined with a schema these requests will throw an `Unexpected response` error.

This PR makes the root field resolver more forgiving and will return an an empty object, just like 204 responses are handled.

Fixes
https://github.com/wundergraph/wundergraph/issues/1196

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
