### PR TITLE
feat: allow to override custom scalars

### DIFF
--- a/packages/loaders/json-schema/src/getGraphQLSchemaFromDereferencedJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getGraphQLSchemaFromDereferencedJSONSchema.ts
@@ -6,11 +6,13 @@ import {
   AddExecutionLogicToComposerOptions,
 } from './addExecutionLogicToComposer.js';
 import { getComposerFromJSONSchema } from './getComposerFromJSONSchema.js';
+import { CustomSchemaComposer } from './types.js';
 
 export async function getGraphQLSchemaFromDereferencedJSONSchema(
   name: string,
   opts: Omit<AddExecutionLogicToComposerOptions, 'schemaComposer'> & {
     fullyDeferencedSchema: JSONSchemaObject;
+    customSchemaComposer?: CustomSchemaComposer;
   },
 ) {
   const {
@@ -21,11 +23,13 @@ export async function getGraphQLSchemaFromDereferencedJSONSchema(
     endpoint,
     queryParams,
     queryStringOptions,
+    customSchemaComposer,
   } = opts;
   logger.debug(`Generating GraphQL Schema from the bundled JSON Schema`);
   const visitorResult = await getComposerFromJSONSchema(
     fullyDeferencedSchema,
     logger.child('getComposerFromJSONSchema'),
+    customSchemaComposer,
   );
 
   const schemaComposerWithoutExecutionLogic = visitorResult.output;

--- a/packages/loaders/json-schema/src/types.ts
+++ b/packages/loaders/json-schema/src/types.ts
@@ -1,6 +1,7 @@
 import { OperationTypeNode } from 'graphql';
+import { SchemaComposer } from 'graphql-compose';
 import { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
-import { JSONSchema, JSONSchemaObject } from 'json-machete';
+import { JSONSchema, JSONSchemaObject, JSONSchemaVisitor } from 'json-machete';
 import { IStringifyOptions } from 'qs';
 import { ResolverData } from '@graphql-mesh/string-interpolation';
 import { Logger, MeshFetch, MeshPubSub } from '@graphql-mesh/types';
@@ -20,6 +21,7 @@ export interface JSONSchemaLoaderOptions extends BaseLoaderOptions {
   queryParams?: Record<string, string | number | boolean>;
   queryStringOptions?: IStringifyOptions;
   bundle?: boolean;
+  customSchemaComposer?: CustomSchemaComposer;
 }
 
 export interface JSONSchemaOperationResponseConfig {
@@ -107,3 +109,8 @@ export type OperationHeadersFactory = (
     method: HTTPMethod;
   },
 ) => PromiseOrValue<Record<string, string>>;
+
+export type CustomSchemaComposer = (
+  schema: JSONSchema,
+  composer: SchemaComposer,
+) => JSONSchemaVisitor;


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

We have a production application that uses a slightly different DateTime format than is expected from graphql-scalars, this causes issues with the execution of the schema. Instead of having to patch the graphql-scalars package it would be much more convenient to be able to configure custom overrides.

This pr proposes a possible solution.

```ts
loadGraphQLSchemaFromJSONSchemas(name, {
   customSchemaComposer: (schema, composer) => {
     if (schema.format === 'date-time') {
        return {
            const typeComposer = composer.getAnyTC(CustomDateTime);
            return {
              input: typeComposer,
              output: typeComposer,
              description: subSchema.description,
              nullable: subSchema.nullable,
              readOnly: subSchema.readOnly,
              writeOnly: subSchema.writeOnly,
              default: subSchema.default,
              deprecated: subSchema.deprecated,
            };
        } 
    }
  }
})
```

Please note that I haven't included any tests yet, since this is a proposal.

Thanks for your consideration :)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
