### PR TITLE
feat: allow self hosting endpoints from env vars

### DIFF
--- a/packages/plugins/hive/src/index.ts
+++ b/packages/plugins/hive/src/index.ts
@@ -72,6 +72,14 @@ export default function useMeshHive(
       logger: pluginOptions.logger,
     };
   }
+  let selfHosting: HivePluginOptions['selfHosting'];
+  if (pluginOptions.selfHosting) {
+    selfHosting = {
+      graphqlEndpoint: stringInterpolator.parse(pluginOptions.selfHosting.graphqlEndpoint, { env: process.env }),
+      usageEndpoint: stringInterpolator.parse(pluginOptions.selfHosting.usageEndpoint, { env: process.env }),
+      applicationUrl: stringInterpolator.parse(pluginOptions.selfHosting.applicationUrl, { env: process.env }),
+    }
+  }
   const hiveClient = createHive({
     enabled: true,
     debug: !!process.env.DEBUG,
@@ -79,7 +87,7 @@ export default function useMeshHive(
     agent,
     usage,
     reporting,
-    selfHosting: pluginOptions.selfHosting,
+    selfHosting,
   });
   const id = pluginOptions.pubsub.subscribe('destroy', () => {
     hiveClient


### PR DESCRIPTION
Allows that self hosting endpoint variables can be taken from env vars like nearly all other variables as well.

## Description

Fixes #6370 

Allows to source hosting information from env vars.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

- [x] Tested locally with a .env file
- [x] Tested entering direct strings.

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

None
