### PR TITLE
Add double quote to prevent parsing as object literal

### DIFF
--- a/website/src/pages/docs/guides/dynamic-vars.mdx
+++ b/website/src/pages/docs/guides/dynamic-vars.mdx
@@ -19,7 +19,7 @@ sources:
   - name: MyGraphQLApi
     handler:
       graphql:
-        endpoint: {env.BASE_URL}/graphql
+        endpoint: "{env.BASE_URL}/graphql"
 ```
 
 ## Runtime variables
@@ -43,7 +43,7 @@ for the `subreddit` field and use it in the `path` of the operation:
         operations:
           - type: Query
             field: subreddit
-            path: /r/{args.subreddit}.json
+            path: "/r/{args.subreddit}.json"
             method: GET
             responseSample: https://www.reddit.com/r/AskReddit.json
             responseTypeName: Subreddit
@@ -79,7 +79,7 @@ sources:
         endpoint: https://graph.microsoft.com/v1.0/
         batch: json
         operationHeaders:
-          Authorization: Bearer {context.cookies.accessToken}
+          Authorization: "Bearer {context.cookies.accessToken}"
 ```
 
 If Mesh is initialized with a `context` object, it will be available as a variable as well. Other


### PR DESCRIPTION
## Description

Add double quote to docs to prevent parsing as object literal when copying from docs

` Mesh - Supergraph Failed to generate the schema TypeError: str.match is not a function
    at Interpolator.parseRules`

## Checklist:

- [x] I have made corresponding changes to the documentation

