### PR TITLE
[Rename Transformer]: Allow multiple rules for the same target when using mode 'bare'

### DIFF
--- a/.changeset/mean-laws-thank.md
+++ b/.changeset/mean-laws-thank.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/transform-rename": patch
+---
+
+Fixed a bug that caused not all rename rules to be applied to the single target in 'bare' mode

--- a/packages/transforms/rename/src/bareRename.ts
+++ b/packages/transforms/rename/src/bareRename.ts
@@ -95,14 +95,14 @@ export default class BareRename implements MeshTransform {
     }
   }
 
-  matchInMap(map: RenameMapObject, toMatch: string) {
+  matchInMap(map: RenameMapObject, toMatch: string): string {
     const mapKeyIsString = map.has(toMatch);
     const mapKeys = mapKeyIsString
       ? [toMatch]
       : [...map.keys()].filter(key => typeof key !== 'string' && key.test(toMatch));
     if (!mapKeys?.length) return null;
 
-    return mapKeys.reduce((newName: string, mapKey: string | RegExp) => {
+    return mapKeys.reduce<string>((newName: string, mapKey: string | RegExp) => {
       if (mapKeyIsString) {
         const str = map.get(mapKey);
         // avoid re-iterating over strings that have already been renamed

--- a/packages/transforms/rename/src/bareRename.ts
+++ b/packages/transforms/rename/src/bareRename.ts
@@ -97,17 +97,21 @@ export default class BareRename implements MeshTransform {
 
   matchInMap(map: RenameMapObject, toMatch: string) {
     const mapKeyIsString = map.has(toMatch);
-    const mapKey = mapKeyIsString
-      ? toMatch
-      : [...map.keys()].find(key => typeof key !== 'string' && key.test(toMatch));
-    if (!mapKey) return null;
+    const mapKeys = mapKeyIsString
+      ? [toMatch]
+      : [...map.keys()].filter(key => typeof key !== 'string' && key.test(toMatch));
+    if (!mapKeys?.length) return null;
 
-    const newName = mapKeyIsString ? map.get(mapKey) : toMatch.replace(mapKey, map.get(mapKey));
+    return mapKeys.reduce((newName: string, mapKey: string | RegExp) => {
+      if (mapKeyIsString) {
+        const str = map.get(mapKey);
+        // avoid re-iterating over strings that have already been renamed
+        map.delete(mapKey);
+        return str;
+      }
 
-    // avoid re-iterating over strings that have already been renamed
-    if (mapKeyIsString) map.delete(mapKey);
-
-    return newName;
+      return newName.replace(mapKey, map.get(mapKey));
+    }, toMatch);
   }
 
   renameType(type: any) {

--- a/packages/transforms/rename/test/bareRename.spec.ts
+++ b/packages/transforms/rename/test/bareRename.spec.ts
@@ -614,38 +614,38 @@ describe('rename', () => {
           {
             from: {
               type: 'Query',
-              field: '([A-Za-z]+)_(.*)' // -> remove prefix
+              field: '([A-Za-z]+)_(.*)', // -> remove prefix
             },
             to: {
               type: 'Query',
-              field: '$2'
+              field: '$2',
             },
-            useRegExpForFields: true
+            useRegExpForFields: true,
           },
           {
             from: {
               type: 'Query',
-              field: '(.*)(ForUser)' // -> remove suffix
+              field: '(.*)(ForUser)', // -> remove suffix
             },
             to: {
               type: 'Query',
-              field: '$1'
+              field: '$1',
             },
-            useRegExpForFields: true
+            useRegExpForFields: true,
           },
           {
             from: {
               type: 'Query',
-              field: 'Get(.*)' // -> remove verb
+              field: 'Get(.*)', // -> remove verb
             },
             to: {
               type: 'Query',
-              field: '$1'
+              field: '$1',
             },
-            useRegExpForFields: true
+            useRegExpForFields: true,
           },
-        ]
-      }
+        ],
+      },
     });
 
     const originalSchema = makeExecutableSchema({
@@ -661,12 +661,12 @@ describe('rename', () => {
       `,
       resolvers: {
         Query: {
-          User_GetCarts: () => ({ id: 'abc123433', amount: 0 }),
-        }
+          User_GetCartsForUser: () => ({ id: 'abc123433', amount: 0 }),
+        },
       },
     });
 
-    const newSchema = transform.transformSchema(schema, {} as any);
+    const newSchema = transform.transformSchema(originalSchema, {} as any);
     const queryType = newSchema.getType('Query') as GraphQLObjectType;
     const fieldMap = queryType.getFields();
 


### PR DESCRIPTION
## Description

This pull request solves  issue #6399 that caused that only one rename rule has been successfully applied to the target when using mode 'bare', although more rules for the target field / type were given. 

In addition to the bug fix, the pull request contains new unit tests to verify the expected behaviour for 'bare' and 'wrap' mode. 

Fixes #6399 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The bug fix has been tested by executing existing unit tests and adding new test cases for the given issue.

- [x] [bareRename.spec.ts](https://github.com/soerenuhrbach/graphql-mesh/blob/1fa6efc025b94514da962b59ebb05e9b5c094abd/packages/transforms/rename/test/bareRename.spec.ts#L609C1-L675C6)
- [x] [wrapRename.spec.ts](https://github.com/soerenuhrbach/graphql-mesh/blob/1fa6efc025b94514da962b59ebb05e9b5c094abd/packages/transforms/rename/test/wrapRename.spec.ts#L872C3-L937C6)
- [x] Executed all other unit tests successfully

**Test Environment**:

- OS: macOS 14.0
- `@graphql-mesh/transform-rename`: 0.96.2
- NodeJS: v18.18.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules