### PR TITLE
fix(transformer/rename): Scalar types can now be renamed when using 'bare' mode

### DIFF
--- a/.changeset/good-suits-check.md
+++ b/.changeset/good-suits-check.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/transform-rename": patch
+---
+
+Fixed a bug where scalar types could not be renamed when using the 'bare' mode

--- a/packages/transforms/rename/src/bareRename.ts
+++ b/packages/transforms/rename/src/bareRename.ts
@@ -77,7 +77,7 @@ class ArgsMap {
 export default class BareRename implements MeshTransform {
   noWrap = true;
   typesMap: RenameMapObject;
-  typeThatCanRenameDefaults: (string | RegExp)[];
+  typesThatCanRenameDefaults: (string | RegExp)[];
   fieldsMap: Map<string, RenameMapObject>;
   argsMap: ArgsMap;
 
@@ -85,7 +85,7 @@ export default class BareRename implements MeshTransform {
     this.typesMap = new Map();
     this.fieldsMap = new Map();
     this.argsMap = new ArgsMap();
-    this.typeThatCanRenameDefaults = [];
+    this.typesThatCanRenameDefaults = [];
 
     for (const rename of config.renames) {
       const {
@@ -102,7 +102,7 @@ export default class BareRename implements MeshTransform {
       if (fromTypeName && toTypeName && fromTypeName !== toTypeName) {
         const typeKey = useRegExpForTypes ? new RegExp(fromTypeName, regExpFlags) : fromTypeName;
         this.typesMap.set(typeKey, toTypeName);
-        if (includeDefaults) this.typeThatCanRenameDefaults.push(typeKey);
+        if (includeDefaults) this.typesThatCanRenameDefaults.push(typeKey);
       }
       if (
         fromTypeName &&
@@ -158,7 +158,7 @@ export default class BareRename implements MeshTransform {
 
   renameType(type: any) {
     const typeName = type.toString();
-    const typeCanRenameDefaults = this.typeThatCanRenameDefaults.some(x =>
+    const typeCanRenameDefaults = this.typesThatCanRenameDefaults.some(x =>
       typeof x === 'string' ? x === typeName : x.test(typeName),
     );
     const newTypeName =


### PR DESCRIPTION
## Description

This change fixes a bug where scalar types could not be renamed when using 'bare' mode

Fixes #6410 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] [rename.spec.ts](https://github.com/ardatan/graphql-mesh/blob/f4853459ba763d5325fbf2bb3417ef4109dc64d3/packages/transforms/rename/test/rename.spec.ts#L811C5-L869C8)

**Test Environment**:

- OS: macOS 14.0
- `@graphql-mesh/transform-rename`: 0.96.2
- NodeJS: v18.18

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and  the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules