### PR TITLE
docs: extend mesh plugin introductions docs

### DIFF
--- a/website/src/pages/docs/plugins/plugins-introduction.mdx
+++ b/website/src/pages/docs/plugins/plugins-introduction.mdx
@@ -100,6 +100,12 @@ Mesh provides each plugin with unique hooks:
 
 These hooks have access to all remote execution parameters (root, args, context, info etc).
 
+Mesh plugins also support all [envelop hooks](https://the-guild.dev/graphql/envelop/v4/plugins/lifecycle)
+and a custom plugin can make use of a mix of envelop hooks and the mesh specific hooks.
+
+Unlike envelop hooks `onFetch` and `onDelegate` do not have a `extendContext` function, but the same can
+be achieved by modifying the context object that is accessible in all hooks.
+
 Example Mesh Envelop plugin therefore can look like this:
 
 ```ts
@@ -117,6 +123,12 @@ export default function customMeshPlugin(options: MeshPluginOptions<YourConfig>)
     }
   }
 }
+```
+
+To use a custom plugin that is in the same codebase:
+```yaml filename=".meshrc.yaml"
+plugins:
+  - ./path/to/plugin: # path to custom plugin instead of just plugin name
 ```
 
 Usage of plugin and Native Envelop hooks are described in

--- a/website/src/pages/docs/plugins/plugins-introduction.mdx
+++ b/website/src/pages/docs/plugins/plugins-introduction.mdx
@@ -120,6 +120,9 @@ export default function customMeshPlugin(options: MeshPluginOptions<YourConfig>)
     },
     onDelegate(payload) {
       // your logic with payload
+    },
+    onExecute(payload) {
+      // your logic with payload
     }
   }
 }


### PR DESCRIPTION
## Description

I discovered some gaps in the documentation when writing my own custom mesh plugin - now trying to contribute to the docs in hope to help the next person :-) 

This is adding a few points to the plugin introduction docs; points covered are:
- consuming a plugin that is in same codebase and not a individually published package
- linking to envelop plugin lifecycle to show more clearly which other hooks are available
- explain how to update context from within a plugin hook

## Type of change

Please delete options that are not relevant.

- [ ] documentation update

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

N/A

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas - N/A 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version - N/A 
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
