### PR TITLE
fix(transformer/naming-convention): Resolve unchanged arguments correctly

### DIFF
--- a/.changeset/good-actors-live.md
+++ b/.changeset/good-actors-live.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/transform-naming-convention": patch
+---
+
+Fixed issue that caused fields to be unresolvable after applying the naming convention in base mode, if the field has arguments that were not affected by the naming convention

--- a/packages/transforms/naming-convention/src/bareNamingConvention.ts
+++ b/packages/transforms/naming-convention/src/bareNamingConvention.ts
@@ -289,7 +289,7 @@ function argsFromArgMap(argMap: ArgsMap, args: any) {
   Object.keys(args).forEach(newArgName => {
     if (typeof newArgName !== 'string') return;
 
-    const argMapVal = argMap[newArgName];
+    const argMapVal = argMap[newArgName] ?? newArgName;
     const originalArgName = typeof argMapVal === 'string' ? argMapVal : argMapVal.originalName;
     const val = args[newArgName];
     if (Array.isArray(val) && typeof argMapVal !== 'string') {


### PR DESCRIPTION
## Description

This pull request fixes an bug, that led to resolving issues of fields that uses arguments, when the argument name was not changed after applying the naming convention. 

Fixes #6416 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] [naming-convention.spec.ts](https://github.com/soerenuhrbach/graphql-mesh/blob/e923b7f981fe286361b1573db0a6e2676624dd10/packages/transforms/naming-convention/test/naming-convention.spec.ts#L355C3-L413C6)

**Test Environment**:

- OS: macOS 14.0
- `@graphql-mesh/transform-naming-convention`: 0.96.2
- NodeJS: v18.18.0
## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

