### PR TITLE
Transpile only mesh config

### DIFF
--- a/.changeset/weak-comics-shop.md
+++ b/.changeset/weak-comics-shop.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/serve-cli": minor
+---
+
+Transpile only mesh config

--- a/packages/serve-cli/src/bin.ts
+++ b/packages/serve-cli/src/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { runServeCLI } from './runServeCLI.js';
-import 'ts-node/register';
+import 'ts-node/register/transpile-only';
 import 'dotenv/config';
 import 'json-bigint-patch';
 


### PR DESCRIPTION
I don't think its necessary to type-check the config. Type-checking is the responsibility of the user.

Also, helps with DX while prototyping/debugging.

Bonus points: **much** faster startup.