### PR TITLE
Hot reloading is optional and therefore just a warning

### DIFF
--- a/.changeset/stale-rocks-hammer.md
+++ b/.changeset/stale-rocks-hammer.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/serve-cli": patch
+---
+
+Hot reloading is optional and therefore just a warning

--- a/packages/serve-cli/src/runServeCLI.ts
+++ b/packages/serve-cli/src/runServeCLI.ts
@@ -71,10 +71,9 @@ export async function runServeCLI(
     if (typeof unifiedGraphPath === 'string' && !unifiedGraphPath.includes('://')) {
       const parcelWatcher$ = import('@parcel/watcher');
       parcelWatcher$
-        .catch(e => {
-          httpHandler.logger.error(
+        .catch(() => {
+          httpHandler.logger.warn(
             `If you want to enable hot reloading on ${unifiedGraphPath}, install "@parcel/watcher"`,
-            e,
           );
         })
         .then(parcelWatcher => {


### PR DESCRIPTION
Logging at error level (and the error itself) is a bit too much for an optional feature.