### PR TITLE
Include necessary dependencies

### DIFF
--- a/.changeset/@graphql-mesh_serve-cli-6552-dependencies.md
+++ b/.changeset/@graphql-mesh_serve-cli-6552-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@graphql-mesh/serve-cli": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-mesh/cross-helpers@^0.4.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cross-helpers/v/0.4.1) (to `dependencies`)
+  - Added dependency [`@graphql-mesh/runtime@^0.97.5` ↗︎](https://www.npmjs.com/package/@graphql-mesh/runtime/v/0.97.5) (to `dependencies`)
+  - Added dependency [`@graphql-mesh/utils@^0.96.4` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.96.4) (to `dependencies`)

--- a/.changeset/clever-trees-sleep.md
+++ b/.changeset/clever-trees-sleep.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/serve-cli": patch
+---
+
+Include necessary dependencies

--- a/packages/serve-cli/package.json
+++ b/packages/serve-cli/package.json
@@ -44,8 +44,11 @@
     }
   },
   "dependencies": {
+    "@graphql-mesh/cross-helpers": "^0.4.1",
     "@graphql-mesh/fusion-runtime": "^0.0.1",
+    "@graphql-mesh/runtime": "^0.97.5",
     "@graphql-mesh/serve-runtime": "^0.0.1",
+    "@graphql-mesh/utils": "^0.96.4",
     "@graphql-tools/git-loader": "^8.0.3",
     "@graphql-tools/github-loader": "^8.0.0",
     "@graphql-tools/graphql-file-loader": "^8.0.0",


### PR DESCRIPTION
Added dependencies that are necessary to run serve-cli. Otherwise, the user has to manually install all of them one by one because the "missing dep" error happens only when running the CLI. Also goes against the documentation where you need to just install the CLI and you're off.