### PR TITLE
Add string interpolator for mongoose handler config: connectionString

### DIFF
--- a/.changeset/nasty-peas-worry.md
+++ b/.changeset/nasty-peas-worry.md
@@ -2,4 +2,4 @@
 "@graphql-mesh/mongoose": patch
 ---
 
-Use string interpolation for connection string
+Use string interpolation for connection string. Remove deprecated logger and loggerLevel options

--- a/.changeset/nasty-peas-worry.md
+++ b/.changeset/nasty-peas-worry.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/mongoose": patch
+---
+
+Use string interpolation for connection string

--- a/packages/handlers/mongoose/src/index.ts
+++ b/packages/handlers/mongoose/src/index.ts
@@ -12,6 +12,7 @@ import {
   YamlConfig,
 } from '@graphql-mesh/types';
 import { loadFromModuleExportExpression } from '@graphql-mesh/utils';
+import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 
 const modelQueryOperations = [
   'findById',
@@ -62,7 +63,7 @@ export default class MongooseHandler implements MeshHandler {
 
   async getMeshSource(): Promise<MeshSource> {
     if (this.config.connectionString) {
-      connect(this.config.connectionString, {
+      connect(stringInterpolator.parse(this.config.connectionString, { env: process.env }) ?? this.config.connectionString, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
         logger: {

--- a/packages/handlers/mongoose/src/index.ts
+++ b/packages/handlers/mongoose/src/index.ts
@@ -63,7 +63,8 @@ export default class MongooseHandler implements MeshHandler {
 
   async getMeshSource(): Promise<MeshSource> {
     if (this.config.connectionString) {
-      connect(stringInterpolator.parse(this.config.connectionString, { env: process.env }) ?? this.config.connectionString, {
+      const interpolatedConnectionString = stringInterpolator.parse(this.config.connectionString, { env: process.env });
+      connect(interpolatedConnectionString, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
         logger: {

--- a/packages/handlers/mongoose/src/index.ts
+++ b/packages/handlers/mongoose/src/index.ts
@@ -2,6 +2,7 @@ import { specifiedDirectives } from 'graphql';
 import { SchemaComposer } from 'graphql-compose';
 import { composeWithMongoose, composeWithMongooseDiscriminators } from 'graphql-compose-mongoose';
 import { connect, ConnectOptions, disconnect, Document, Model } from 'mongoose';
+import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 import {
   ImportFn,
   Logger,
@@ -12,7 +13,6 @@ import {
   YamlConfig,
 } from '@graphql-mesh/types';
 import { loadFromModuleExportExpression } from '@graphql-mesh/utils';
-import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 
 const modelQueryOperations = [
   'findById',
@@ -63,30 +63,12 @@ export default class MongooseHandler implements MeshHandler {
 
   async getMeshSource(): Promise<MeshSource> {
     if (this.config.connectionString) {
-      const interpolatedConnectionString = stringInterpolator.parse(this.config.connectionString, { env: process.env });
+      const interpolatedConnectionString = stringInterpolator.parse(this.config.connectionString, {
+        env: process.env,
+      });
       connect(interpolatedConnectionString, {
         useNewUrlParser: true,
         useUnifiedTopology: true,
-        logger: {
-          className: this.name,
-          debug: this.logger.debug.bind(this.logger),
-          info: this.logger.info.bind(this.logger),
-          warn: this.logger.warn.bind(this.logger),
-          error: this.logger.error.bind(this.logger),
-          isDebug() {
-            return true;
-          },
-          isError() {
-            return true;
-          },
-          isInfo() {
-            return true;
-          },
-          isWarn() {
-            return true;
-          },
-        },
-        loggerLevel: 'debug',
       } as ConnectOptions).catch(e => this.logger.error(e));
 
       const id = this.pubsub.subscribe('destroy', () => {


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Add string interpolation on connectionString config value when connecting to mongo for the mongoose handler. On local development one might connect to the localhost but in staging or production, the environment variables should be available to select a different connection string. Also the connection string sometimes has credentials included and this should not be submitted to source code.

Related to Issue # 5296 (which seems to be already fixed)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

N/A

**Test Environment**:

N/A

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
