### PR TITLE
mesh build --throwOnInvalidConfig does not throw on invalid config

### DIFF
--- a/.changeset/flat-trains-smile.md
+++ b/.changeset/flat-trains-smile.md
@@ -1,5 +1,0 @@
----
-"@graphql-mesh/cli": patch
----
-
-Fixes the throwOnInvalidConfig flag

--- a/.changeset/flat-trains-smile.md
+++ b/.changeset/flat-trains-smile.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+Fixes the throwOnInvalidConfig flag

--- a/.changeset/thirty-balloons-cheat.md
+++ b/.changeset/thirty-balloons-cheat.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+Fix for honoring the --throwOnInvalidConfig flag

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -83,7 +83,7 @@ export async function findAndParseConfig(options?: ConfigProcessOptions) {
   }
 
   const config = results.config;
-  validateConfig(config, results.filepath, initialLoggerPrefix);
+  validateConfig(config, results.filepath, initialLoggerPrefix, restOptions.throwOnInvalidConfig);
   return processConfig(config, { dir, initialLoggerPrefix, importFn, ...restOptions });
 }
 

--- a/website/src/pages/docs/cli-commands.mdx
+++ b/website/src/pages/docs/cli-commands.mdx
@@ -58,8 +58,8 @@ yarn graphql-mesh dev --port 4002
 
 Builds artifacts required to use `mesh start` for a gateway (production) server or SDK.
 
-Can have `--throwOnInvalidConfig=true` to make CLI throw in case of an invalid configuration. By
-default, CLI gives a warning and continues.
+Can have `--throwOnInvalidConfig` to make CLI throw in case of an invalid configuration. By default,
+CLI gives a warning and continues.
 
 ### `mesh validate`
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

A missing argument to `validateConfig()` in `packages/cli/src/config.ts` is preventing the user-provided `--throwOnInvalidConfig` flag from taking effect.

Fixes https://github.com/ardatan/graphql-mesh/issues/6571

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- Test A
  - Add an invalid property to `.meshrc.yml`.
  - Run `mesh build`.
  - Observe that the CLI warns that the config is invalid.
- Test B
  - Add an invalid property to `.meshrc.yml`.
  - Run `mesh build --throwOnInvalidConfig`.
  - Observe that the CLI throws.

**Test Environment**:

- OS: macOS Sonoma 14.2.1
- `@graphql-mesh/cli`: 0.88.7
- NodeJS: v20.10.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
