### PR TITLE
Change executionRequest in onSubgraphExecute hook and use one transportKind argument instead of spreading it

### DIFF
--- a/.changeset/stupid-plums-fail.md
+++ b/.changeset/stupid-plums-fail.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/fusion-runtime": minor
+---
+
+Change transportEntry and executionRequest in onSubgraphExecute hook

--- a/.changeset/stupid-plums-fail.md
+++ b/.changeset/stupid-plums-fail.md
@@ -2,4 +2,4 @@
 "@graphql-mesh/fusion-runtime": minor
 ---
 
-Change transportEntry and executionRequest in onSubgraphExecute hook
+Change executionRequest in onSubgraphExecute hook and use one transportKind argument instead of spreading it

--- a/packages/fusion/runtime/src/index.ts
+++ b/packages/fusion/runtime/src/index.ts
@@ -167,7 +167,7 @@ export function getExecutorForFusiongraph({
     let executor: Executor = subgraphExecutorMap[subgraphName];
     if (executor == null) {
       transportBaseContext?.logger?.info(`Initializing executor for subgraph ${subgraphName}`);
-      const transportEntry = transportEntryMap[subgraphName];
+      let transportEntry = transportEntryMap[subgraphName];
       // eslint-disable-next-line no-inner-declarations
       function wrapExecutorWithHooks(currentExecutor: Executor) {
         if (onSubgraphExecuteHooks.length) {
@@ -180,7 +180,13 @@ export function getExecutorForFusiongraph({
                   fusiongraph,
                   subgraphName,
                   transportEntry,
+                  setTransportEntry(newTransportEntry) {
+                    transportEntry = newTransportEntry;
+                  },
                   executionRequest: subgraphExecReq,
+                  setExecutionRequest(newExecutionRequest) {
+                    subgraphExecReq = newExecutionRequest;
+                  },
                   executor: currentExecutor,
                   setExecutor(newExecutor) {
                     currentExecutor = newExecutor;
@@ -495,7 +501,9 @@ export interface OnFusiongraphExecutePayload {
   fusiongraph: GraphQLSchema;
   subgraphName: string;
   transportEntry: TransportEntry;
+  setTransportEntry(transportEntry: TransportEntry): void;
   executionRequest: ExecutionRequest;
+  setExecutionRequest(executionRequest: ExecutionRequest): void;
   executor: Executor;
   setExecutor(executor: Executor): void;
 }

--- a/packages/fusion/runtime/src/index.ts
+++ b/packages/fusion/runtime/src/index.ts
@@ -182,7 +182,7 @@ export function getExecutorForFusiongraph({
                   transportEntry,
                   executionRequest: subgraphExecReq,
                   executor: currentExecutor,
-                  setExecutor(newExecutor: Executor) {
+                  setExecutor(newExecutor) {
                     currentExecutor = newExecutor;
                   },
                 }),

--- a/packages/fusion/runtime/src/index.ts
+++ b/packages/fusion/runtime/src/index.ts
@@ -167,7 +167,7 @@ export function getExecutorForFusiongraph({
     let executor: Executor = subgraphExecutorMap[subgraphName];
     if (executor == null) {
       transportBaseContext?.logger?.info(`Initializing executor for subgraph ${subgraphName}`);
-      let transportEntry = transportEntryMap[subgraphName];
+      const transportEntry = transportEntryMap[subgraphName];
       // eslint-disable-next-line no-inner-declarations
       function wrapExecutorWithHooks(currentExecutor: Executor) {
         if (onSubgraphExecuteHooks.length) {
@@ -180,9 +180,6 @@ export function getExecutorForFusiongraph({
                   fusiongraph,
                   subgraphName,
                   transportEntry,
-                  setTransportEntry(newTransportEntry) {
-                    transportEntry = newTransportEntry;
-                  },
                   executionRequest: subgraphExecReq,
                   setExecutionRequest(newExecutionRequest) {
                     subgraphExecReq = newExecutionRequest;
@@ -500,8 +497,7 @@ export type OnSubgraphExecuteHook = (
 export interface OnFusiongraphExecutePayload {
   fusiongraph: GraphQLSchema;
   subgraphName: string;
-  transportEntry: TransportEntry;
-  setTransportEntry(transportEntry: TransportEntry): void;
+  transportEntry?: TransportEntry;
   executionRequest: ExecutionRequest;
   setExecutionRequest(executionRequest: ExecutionRequest): void;
   executor: Executor;

--- a/packages/fusion/runtime/src/index.ts
+++ b/packages/fusion/runtime/src/index.ts
@@ -179,10 +179,7 @@ export function getExecutorForFusiongraph({
                 onSubgraphExecuteHook({
                   fusiongraph,
                   subgraphName,
-                  transportKind: transportEntry?.kind,
-                  transportLocation: transportEntry?.location,
-                  transportHeaders: transportEntry?.headers,
-                  transportOptions: transportEntry?.options,
+                  transportEntry,
                   executionRequest: subgraphExecReq,
                   executor: currentExecutor,
                   setExecutor(newExecutor: Executor) {
@@ -497,10 +494,7 @@ export type OnSubgraphExecuteHook = (
 export interface OnFusiongraphExecutePayload {
   fusiongraph: GraphQLSchema;
   subgraphName: string;
-  transportKind: string;
-  transportLocation: string;
-  transportHeaders: Record<string, string>;
-  transportOptions: any;
+  transportEntry: TransportEntry;
   executionRequest: ExecutionRequest;
   executor: Executor;
   setExecutor(executor: Executor): void;

--- a/packages/fusion/runtime/src/index.ts
+++ b/packages/fusion/runtime/src/index.ts
@@ -136,8 +136,8 @@ export function getTransportExecutor(
   transportGetter: ReturnType<typeof createTransportGetter>,
   transportContext: TransportExecutorFactoryOpts,
 ): MaybePromise<Executor> {
-  transportContext.logger?.info(`Loading transport ${transportContext.transportEntry.kind}`);
-  const transport$ = transportGetter(transportContext.transportEntry.kind);
+  transportContext.logger?.info(`Loading transport ${transportContext.transportEntry?.kind}`);
+  const transport$ = transportGetter(transportContext.transportEntry?.kind);
   return mapMaybePromise(transport$, transport => transport.getSubgraphExecutor(transportContext));
 }
 

--- a/packages/fusion/runtime/src/index.ts
+++ b/packages/fusion/runtime/src/index.ts
@@ -136,8 +136,8 @@ export function getTransportExecutor(
   transportGetter: ReturnType<typeof createTransportGetter>,
   transportContext: TransportExecutorFactoryOpts,
 ): MaybePromise<Executor> {
-  transportContext.logger?.info(`Loading transport ${transportContext.transportEntry?.kind}`);
-  const transport$ = transportGetter(transportContext.transportEntry?.kind);
+  transportContext.logger?.info(`Loading transport ${transportContext.transportEntry.kind}`);
+  const transport$ = transportGetter(transportContext.transportEntry.kind);
   return mapMaybePromise(transport$, transport => transport.getSubgraphExecutor(transportContext));
 }
 


### PR DESCRIPTION
Because why not? And there'll be need to change the subgraph URL during runtime (or any other transport features).

Also, there's just one `transportKind` argument in the `onSubgraphExecute` instead of its spread.