### PR TITLE
fix typo in docu

### DIFF
--- a/website/src/pages/docs/plugins/max-tokens.mdx
+++ b/website/src/pages/docs/plugins/max-tokens.mdx
@@ -55,5 +55,5 @@ Then configure it in your `.meshrc.yml` file.
 ```yaml
 plugins:
   - maxTokens:
-      maxTokenCount: 1000 # Number of tokens allowed in a document
+      n: 1000 # Number of tokens allowed in a document
 ```


### PR DESCRIPTION
## Description

Fixing typo in docu. The config param name was wrong.

## Type of change

- [x] Docu fix

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation