### PR TITLE
fix(runtime): disable GraphQL JIT if there are nested input types

### DIFF
--- a/.changeset/spotty-chefs-collect.md
+++ b/.changeset/spotty-chefs-collect.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/runtime": patch
+---
+
+Disable GraphQL JIT if there are nested input types

--- a/packages/legacy/runtime/src/utils.ts
+++ b/packages/legacy/runtime/src/utils.ts
@@ -57,6 +57,7 @@ export const isGraphQLJitCompatible = memoize1(function isGraphQLJitCompatible(
             }
           }
         }
+        return true;
       }
       visitInputType(type);
       return type;

--- a/packages/legacy/runtime/src/utils.ts
+++ b/packages/legacy/runtime/src/utils.ts
@@ -1,4 +1,12 @@
-import { ASTNode, BREAK, getNamedType, GraphQLSchema, visit } from 'graphql';
+import {
+  ASTNode,
+  BREAK,
+  getNamedType,
+  GraphQLInputObjectType,
+  GraphQLInputType,
+  GraphQLSchema,
+  visit,
+} from 'graphql';
 import { getDocumentString } from '@envelop/core';
 import { MapperKind, mapSchema, memoize1 } from '@graphql-tools/utils';
 
@@ -33,16 +41,25 @@ export const isGraphQLJitCompatible = memoize1(function isGraphQLJitCompatible(
   let compatibleSchema = true;
   mapSchema(schema, {
     [MapperKind.INPUT_OBJECT_TYPE]: type => {
-      const fieldMap = type.getFields();
-      for (const fieldName in fieldMap) {
-        const fieldObj = fieldMap[fieldName];
-        const namedType = getNamedType(fieldObj.type);
-        if (namedType.name === type.name) {
+      const seenTypes = new Set<string>();
+      function visitInputType(type: GraphQLInputObjectType) {
+        if (seenTypes.has(type.toString())) {
           compatibleSchema = false;
-          return undefined;
+          return false;
+        }
+        seenTypes.add(type.toString());
+        const fields = type.getFields();
+        for (const field of Object.values(fields)) {
+          const fieldType = getNamedType(field.type) as GraphQLInputType;
+          if (fieldType instanceof GraphQLInputObjectType) {
+            if (!visitInputType(fieldType)) {
+              return false;
+            }
+          }
         }
       }
-      return undefined;
+      visitInputType(type);
+      return type;
     },
   });
   if (compatibleSchema) {

--- a/packages/legacy/runtime/test/isGraphQLJitCompatible.test.ts
+++ b/packages/legacy/runtime/test/isGraphQLJitCompatible.test.ts
@@ -1,0 +1,53 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { isGraphQLJitCompatible } from '../src/utils';
+
+describe('isGraphQLJitCompatible', () => {
+  it('should return false if the schema has recursive input types', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          hello(field: RecursiveInput): String
+        }
+        input RecursiveInput {
+          regularInput: String
+          recursiveInput: RecursiveInput
+        }
+      `,
+      resolvers: {},
+    });
+    expect(isGraphQLJitCompatible(schema)).toBeFalsy();
+  });
+  it('should return false if the schema has recursive input types nestedly', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          hello(field: RecursiveInput): String
+        }
+        input RecursiveInput {
+          regularInput: String
+          anotherInput: AnotherInput
+        }
+        input AnotherInput {
+          recursiveInput: RecursiveInput
+        }
+      `,
+      resolvers: {},
+    });
+    expect(isGraphQLJitCompatible(schema)).toBeFalsy();
+  });
+  it('should return true if the schema does not have recursive input types', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          hello(input: TestInput): String
+          hello2(input: TestInput): String
+        }
+        input TestInput {
+          field: String
+        }
+      `,
+      resolvers: {},
+    });
+    expect(isGraphQLJitCompatible(schema)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
GraphQL JIT should be disabled in case of nested input types
Workaround for https://github.com/zalando-incubator/graphql-jit/issues/81