### PR TITLE
feat(serve-runtime): new `useForwardHeaders` plugin

### DIFF
--- a/.changeset/ten-tables-think.md
+++ b/.changeset/ten-tables-think.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/serve-runtime": patch
+---
+
+New Plugin: useForwardHeaders

--- a/packages/serve-runtime/src/index.ts
+++ b/packages/serve-runtime/src/index.ts
@@ -5,3 +5,4 @@ export * from './useCustomFetch.js';
 export * from './inferResolvers.js';
 export * from './useStaticFiles.js';
 export * from './getProxyExecutor.js';
+export * from './useForwardHeaders.js';

--- a/packages/serve-runtime/src/types.ts
+++ b/packages/serve-runtime/src/types.ts
@@ -25,10 +25,22 @@ export type MeshServeConfig<TContext extends Record<string, any> = Record<string
   | MeshServeConfigWithProxy<TContext>;
 
 export interface MeshServeConfigContext {
+  /**
+   * WHATWG compatible Fetch implementation.
+   */
   fetch: MeshFetch;
   logger: Logger;
+  /**
+   * Current working directory.
+   */
   cwd: string;
+  /**
+   * Event bus for pub/sub.
+   */
   pubsub?: MeshPubSub;
+  /**
+   * Cache Storage
+   */
   cache?: KeyValueCache;
 }
 

--- a/packages/serve-runtime/src/useForwardHeaders.ts
+++ b/packages/serve-runtime/src/useForwardHeaders.ts
@@ -4,13 +4,13 @@ export interface ForwardHeadersPluginOptions {
   headerNames: string[];
 }
 
-export function useForwardHeaders(opts: ForwardHeadersPluginOptions): MeshServePlugin {
+export function useForwardHeaders(headerNames: string[]): MeshServePlugin {
   return {
     onFetch({ options, setOptions, context }) {
       const headers = {
         ...options.headers,
       };
-      for (const headerName of opts.headerNames) {
+      for (const headerName of headerNames) {
         const headerValue = context.headers[headerName];
         if (headerValue) {
           headers[headerName] = headerValue;

--- a/packages/serve-runtime/src/useForwardHeaders.ts
+++ b/packages/serve-runtime/src/useForwardHeaders.ts
@@ -1,0 +1,25 @@
+import { MeshServePlugin } from './types';
+
+export interface ForwardHeadersPluginOptions {
+  headerNames: string[];
+}
+
+export function useForwardHeaders(opts: ForwardHeadersPluginOptions): MeshServePlugin {
+  return {
+    onFetch({ options, setOptions, context }) {
+      const headers = {
+        ...options.headers,
+      };
+      for (const headerName of opts.headerNames) {
+        const headerValue = context.headers[headerName];
+        if (headerValue) {
+          headers[headerName] = headerValue;
+        }
+      }
+      setOptions({
+        ...options,
+        headers,
+      });
+    },
+  };
+}

--- a/packages/serve-runtime/tests/serve-runtime.spec.ts
+++ b/packages/serve-runtime/tests/serve-runtime.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { createSchema, createYoga } from 'graphql-yoga';
 import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
 import { buildHTTPExecutor } from '@graphql-tools/executor-http';

--- a/packages/serve-runtime/tests/useForwardHeaders.spec.ts
+++ b/packages/serve-runtime/tests/useForwardHeaders.spec.ts
@@ -26,11 +26,7 @@ describe('useForwardHeaders', () => {
       endpoint: 'https://example.com/graphql',
       fetch: upstream.fetch,
     },
-    plugins: () => [
-      useForwardHeaders({
-        headerNames: ['x-my-header', 'x-my-other'],
-      }),
-    ],
+    plugins: () => [useForwardHeaders(['x-my-header', 'x-my-other'])],
   });
 
   it('forwards headers', async () => {

--- a/packages/serve-runtime/tests/useForwardHeaders.spec.ts
+++ b/packages/serve-runtime/tests/useForwardHeaders.spec.ts
@@ -1,0 +1,64 @@
+import { createSchema, createYoga } from 'graphql-yoga';
+import { createServeRuntime } from '../src/createServeRuntime';
+import { useForwardHeaders } from '../src/useForwardHeaders';
+
+describe('useForwardHeaders', () => {
+  const upstream = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        scalar JSON
+
+        type Query {
+          headers: JSON
+        }
+      `,
+      resolvers: {
+        Query: {
+          headers(_root, _args, context) {
+            return Object.fromEntries(context.request.headers.entries());
+          },
+        },
+      },
+    }),
+  });
+  const serveRuntime = createServeRuntime({
+    proxy: {
+      endpoint: 'https://example.com/graphql',
+      fetch: upstream.fetch,
+    },
+    plugins: () => [
+      useForwardHeaders({
+        headerNames: ['x-my-header', 'x-my-other'],
+      }),
+    ],
+  });
+
+  it('forwards headers', async () => {
+    const response = await serveRuntime.fetch('http://localhost:4000/graphql', {
+      method: 'POST',
+      headers: {
+        'x-my-header': 'my-value',
+        'x-my-other': 'other-value',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: /* GraphQL */ `
+          query {
+            headers
+          }
+        `,
+      }),
+    });
+
+    const resJson = await response.json();
+
+    expect(resJson).toMatchObject({
+      data: {
+        headers: {
+          'x-my-other': 'other-value',
+          'x-my-header': 'my-value',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
New plugin for Mesh Serve runtime to forward headers to the upstream;

```ts
import { useForwardHeaders } from '@graphql-mesh/serve-cli';

plugins: () => [
   useForwardHeaders(
      ['x-my-header'],
   )
]
```