### PR TITLE
enhance(runtime): log unexpected errors to the console with their stack traces

### DIFF
--- a/.changeset/quiet-drinks-taste.md
+++ b/.changeset/quiet-drinks-taste.md
@@ -1,0 +1,7 @@
+---
+"@graphql-mesh/runtime": patch
+---
+
+Log unexpected non GraphQL errors with the stack trace
+
+Previously, it was not possible to see the stack trace of unexpected errors that were not related to GraphQL. This change logs the stack trace of such errors.

--- a/packages/legacy/runtime/src/utils.ts
+++ b/packages/legacy/runtime/src/utils.ts
@@ -7,7 +7,7 @@ import {
   GraphQLSchema,
   visit,
 } from 'graphql';
-import { getDocumentString } from '@envelop/core';
+import { getDocumentString, isGraphQLError } from '@envelop/core';
 import { MapperKind, mapSchema, memoize1 } from '@graphql-tools/utils';
 
 export const isStreamOperation = memoize1(function isStreamOperation(astNode: ASTNode): boolean {
@@ -74,3 +74,10 @@ export const isGraphQLJitCompatible = memoize1(function isGraphQLJitCompatible(
   }
   return false;
 });
+
+export function getOriginalError(error: Error) {
+  if (isGraphQLError(error)) {
+    return getOriginalError(error.originalError);
+  }
+  return error;
+}


### PR DESCRIPTION
Log unexpected non GraphQL errors with the stack trace

Previously, it was not possible to see the stack trace of unexpected errors that were not related to GraphQL. This change logs the stack trace of such errors.