### PR TITLE
Migrate tests from Stitching

### DIFF
--- a/packages/fusion/composition/src/compose.ts
+++ b/packages/fusion/composition/src/compose.ts
@@ -243,7 +243,11 @@ function addAnnotationsForSemanticConventions({
         const objectField = fieldMap[fieldName];
         const queryField = queryFields[queryFieldName];
         const objectFieldType = getNamedType(objectField.type);
-        const arg = queryField.args.find(arg => getNamedType(arg.type) === objectFieldType);
+        const arg = queryField.args.find(
+          arg =>
+            getNamedType(arg.type) === objectFieldType &&
+            (arg.name === pluralize(fieldName) || arg.name === fieldName),
+        );
         const queryFieldTypeName = getNamedType(queryField.type).name;
         const queryFieldNameSnakeCase = snakeCase(queryFieldName);
         const varName = `${type.name}_${fieldName}`;
@@ -284,6 +288,7 @@ function addAnnotationsForSemanticConventions({
           if (arg) {
             switch (queryFieldNameSnakeCase) {
               case snakeCase(type.name):
+              case snakeCase(`_${type.name}`):
               case snakeCase(`get_${type.name}_by_${fieldName}`):
               case snakeCase(`${type.name}_by_${fieldName}`): {
                 const operationName = pascalCase(`${type.name}_by_${fieldName}`);
@@ -299,6 +304,7 @@ function addAnnotationsForSemanticConventions({
                 break;
               }
               case snakeCase(pluralTypeName):
+              case snakeCase(`_${pluralTypeName}`):
               case snakeCase(`get_${pluralTypeName}_by_${fieldName}`):
               case snakeCase(`${pluralTypeName}_by_${fieldName}`):
               case snakeCase(`get_${pluralTypeName}_by_${fieldName}s`):

--- a/packages/fusion/execution/src/query-planning.ts
+++ b/packages/fusion/execution/src/query-planning.ts
@@ -26,14 +26,7 @@ import {
 import _ from 'lodash';
 import { DirectiveAnnotation } from '@graphql-tools/utils';
 import { FlattenedFieldNode, FlattenedSelectionSet } from './flattenSelections.js';
-import { parseAndCache } from './parseAndPrintWithCache.js';
-import {
-  GlobalResolverConfig,
-  RegularResolverConfig,
-  ResolverKind,
-  ResolverRefConfig,
-  ResolverVariableConfig,
-} from './types.js';
+import { ResolverKind, ResolverVariableConfig } from './types.js';
 
 // Resolution direction is from parentSubgraph to resolverDirective.subgraph
 export function createResolveNode({
@@ -687,7 +680,9 @@ export function visitFieldNodeForTypeResolvers(
       otherConditionFn: d => d.args?.subgraph === fieldSubgraph,
     });
     if (!resolverDirective) {
-      throw new Error(`No resolver directive found for ${fieldSubgraph}`);
+      throw new Error(
+        `No resolver directive found for the type from ${parentSubgraph} to ${fieldSubgraph}`,
+      );
     }
     const {
       newFieldNode: newFieldNodeForSubgraph,

--- a/packages/fusion/execution/tests/cases/computed-fields/__snapshots__/computed-fields.spec.ts.snap
+++ b/packages/fusion/execution/tests/cases/computed-fields/__snapshots__/computed-fields.spec.ts.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Computed fields composes correctly 1`] = `
+"schema {
+  query: Query
+}
+
+type Product @source(subgraph: "products", name: "Product") @source(subgraph: "metadata", name: "Product") @resolver(subgraph: "products", operation: "query ProductsByUpcs($Product_upc: [ID!]!) { products(upcs: $Product_upc) }", kind: "BATCH") @resolver(subgraph: "metadata", operation: "\\n      query ProductMetadata($Product_key: [ProductKey]) {\\n        _products(keys: $Product_key)\\n      }\\n    ", kind: "BATCH") @variable(subgraph: "products", name: "Product_upc", select: "upc") @variable(subgraph: "metadata", name: "Product_key", value: "{ categoryId: $Product_categoryId, metadataIds: $Product_metadataIds }") {
+  categoryId: ID @source(subgraph: "products", name: "categoryId", type: "ID")
+  metadataIds: [ID!] @source(subgraph: "products", name: "metadataIds", type: "[ID!]")
+  name: String! @source(subgraph: "products", name: "name", type: "String!")
+  price: Float! @source(subgraph: "products", name: "price", type: "Float!")
+  upc: ID! @source(subgraph: "products", name: "upc", type: "ID!")
+  category: Category @deprecated(reason: "gateway access only") @source(subgraph: "metadata", name: "category", type: "Category") @variable(subgraph: "products", name: "Product_categoryId", select: "categoryId")
+  metadata: [Metadata] @deprecated(reason: "gateway access only") @source(subgraph: "metadata", name: "metadata", type: "[Metadata]") @variable(subgraph: "products", name: "Product_metadataIds", select: "metadataIds")
+}
+
+type Query {
+  products(upcs: [ID!]!): [Product]! @resolver(subgraph: "products", operation: "query products($upcs: [ID!]!) { products(upcs: $upcs) }") @source(subgraph: "products", name: "products", type: "[Product]!")
+  _products(keys: [ProductKey!]!): [Product]! @resolver(subgraph: "metadata", operation: "query _products($keys: [ProductKey!]!) { _products(keys: $keys) }") @source(subgraph: "metadata", name: "_products", type: "[Product]!")
+}
+
+type Category @source(subgraph: "metadata", name: "Category") {
+  id: ID! @source(subgraph: "metadata", name: "id", type: "ID!")
+  name: String! @source(subgraph: "metadata", name: "name", type: "String!")
+}
+
+interface Metadata @source(subgraph: "metadata", name: "Metadata") {
+  id: ID! @source(subgraph: "metadata", name: "id", type: "ID!")
+  name: String! @source(subgraph: "metadata", name: "name", type: "String!")
+}
+
+type GeoLocation implements Metadata @source(subgraph: "metadata", name: "GeoLocation") {
+  id: ID! @source(subgraph: "metadata", name: "id", type: "ID!")
+  name: String! @source(subgraph: "metadata", name: "name", type: "String!")
+  lat: Float! @source(subgraph: "metadata", name: "lat", type: "Float!")
+  lon: Float! @source(subgraph: "metadata", name: "lon", type: "Float!")
+}
+
+type SportsTeam implements Metadata @source(subgraph: "metadata", name: "SportsTeam") {
+  id: ID! @source(subgraph: "metadata", name: "id", type: "ID!")
+  name: String! @source(subgraph: "metadata", name: "name", type: "String!")
+  location: GeoLocation @source(subgraph: "metadata", name: "location", type: "GeoLocation")
+}
+
+type TelevisionSeries implements Metadata @source(subgraph: "metadata", name: "TelevisionSeries") {
+  id: ID! @source(subgraph: "metadata", name: "id", type: "ID!")
+  name: String! @source(subgraph: "metadata", name: "name", type: "String!")
+  season: Int @source(subgraph: "metadata", name: "season", type: "Int")
+}
+
+input ProductKey @source(subgraph: "metadata", name: "ProductKey") {
+  categoryId: ID @source(subgraph: "metadata", name: "categoryId", type: "ID")
+  metadataIds: [ID!] @source(subgraph: "metadata", name: "metadataIds", type: "[ID!]")
+}"
+`;
+
+exports[`Computed fields plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "products": [
+      {
+        "id": 0,
+        "resolverDependencies": [
+          {
+            "batch": true,
+            "id": 1,
+            "resolverDependencyFieldMap": {
+              "metadata": [],
+            },
+            "resolverOperationDocument": "query ProductMetadata($__variable_1: ID, $__variable_2: ID) {
+  __export: _products(
+    keys: {categoryId: $__variable_1, metadataIds: $__variable_2}
+  ) {
+    category {
+      name
+    }
+    metadata {
+      __typename
+      name
+      name
+    }
+  }
+}",
+            "subgraph": "metadata",
+          },
+        ],
+        "resolverOperationDocument": "query products {
+  __export: products(upcs: [1, 2, 3, 4]) {
+    name
+    price
+    __variable_1: categoryId
+    __variable_2: metadataIds
+  }
+}",
+        "subgraph": "products",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;

--- a/packages/fusion/execution/tests/cases/computed-fields/computed-fields.spec.ts
+++ b/packages/fusion/execution/tests/cases/computed-fields/computed-fields.spec.ts
@@ -1,0 +1,194 @@
+import { GraphQLObjectType, parse } from 'graphql';
+import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
+import { getExecutorForFusiongraph } from '@graphql-mesh/fusion-runtime';
+import { createDefaultExecutor } from '@graphql-mesh/transport-common';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import {
+  createExecutablePlanForOperation,
+  serializeExecutableOperationPlan,
+} from '../../../src/operations';
+import { metadataSchema } from './services/metadata';
+import { productsSchema } from './services/products';
+
+describe('Computed fields', () => {
+  const fusiongraph = composeSubgraphs([
+    {
+      name: 'products',
+      schema: productsSchema,
+    },
+    {
+      name: 'metadata',
+      schema: metadataSchema,
+    },
+  ]);
+  // Add directives
+  const productType = fusiongraph.getType('Product') as GraphQLObjectType;
+  const productTypeExts = (productType.extensions ||= {} as any);
+  const productTypeDirectives = (productTypeExts.directives ||= [] as any);
+  const resolverDirectives = (productTypeDirectives.resolver ||= [] as any);
+  resolverDirectives.push({
+    subgraph: 'metadata',
+    operation: /* GraphQL */ `
+      query ProductMetadata($Product_key: [ProductKey]) {
+        _products(keys: $Product_key)
+      }
+    `,
+    kind: 'BATCH',
+  });
+  const variableDirectives = (productTypeDirectives.variable ||= [] as any);
+  variableDirectives.push({
+    subgraph: 'metadata',
+    name: 'Product_key',
+    value: '{ categoryId: $Product_categoryId, metadataIds: $Product_metadataIds }',
+  });
+  const fieldMap = productType.getFields();
+  const metadataField = fieldMap['metadata'];
+  const metadataFieldExts = (metadataField.extensions ||= {} as any);
+  const metadataFieldDirectives = (metadataFieldExts.directives ||= {} as any);
+  const metadataFieldVariableDirectives = (metadataFieldDirectives.variable ||= [] as any);
+  metadataFieldVariableDirectives.push({
+    subgraph: 'products',
+    name: 'Product_metadataIds',
+    select: 'metadataIds',
+  });
+  const categoryField = fieldMap['category'];
+  const categoryFieldExts = (categoryField.extensions ||= {} as any);
+  const categoryFieldDirectives = (categoryFieldExts.directives ||= {} as any);
+  const categoryFieldVariableDirectives = (categoryFieldDirectives.variable ||= [] as any);
+  categoryFieldVariableDirectives.push({
+    subgraph: 'products',
+    name: 'Product_categoryId',
+    select: 'categoryId',
+  });
+  it('composes correctly', () => {
+    expect(printSchemaWithDirectives(fusiongraph)).toMatchSnapshot();
+  });
+  const { fusiongraphExecutor } = getExecutorForFusiongraph({
+    fusiongraph,
+    transports() {
+      return {
+        getSubgraphExecutor({ subgraphName }) {
+          switch (subgraphName) {
+            case 'products':
+              return createDefaultExecutor(productsSchema);
+            case 'metadata':
+              return createDefaultExecutor(metadataSchema);
+          }
+        },
+      };
+    },
+  });
+  const exampleQuery = parse(/* GraphQL */ `
+    query {
+      products(upcs: [1, 2, 3, 4]) {
+        name
+        price
+        category {
+          name
+        }
+        metadata {
+          __typename
+          name
+          ... on GeoLocation {
+            name
+            lat
+            lon
+          }
+          ... on SportsTeam {
+            location {
+              name
+              lat
+              lon
+            }
+          }
+          ... on TelevisionSeries {
+            season
+          }
+        }
+      }
+    }
+  `);
+  it('plans correctly', async () => {
+    const plan = createExecutablePlanForOperation({
+      fusiongraph,
+      document: exampleQuery,
+    });
+    expect(serializeExecutableOperationPlan(plan)).toMatchSnapshot();
+  });
+  it('executes correctly', async () => {
+    const result = await fusiongraphExecutor({
+      document: exampleQuery,
+    });
+    expect(result).toEqual({
+      data: {
+        products: [
+          {
+            category: null,
+            metadata: [],
+            name: 'iPhone',
+            price: 699.99,
+          },
+          {
+            category: {
+              name: 'Cooking',
+            },
+            metadata: [
+              {
+                __typename: 'TelevisionSeries',
+                name: 'Great British Baking Show',
+                season: 7,
+              },
+              {
+                __typename: 'GeoLocation',
+                lat: 55.3781,
+                lon: 3.436,
+                name: 'Great Britain',
+              },
+            ],
+            name: 'The Best Baking Cookbook',
+            price: 15.99,
+          },
+          {
+            category: {
+              name: 'Travel',
+            },
+            metadata: [
+              {
+                __typename: 'GeoLocation',
+                lat: 38.4161,
+                lon: 63.6167,
+                name: 'Argentina',
+              },
+            ],
+            name: 'Argentina Guidebook',
+            price: 24.99,
+          },
+          {
+            category: {
+              name: 'Sports',
+            },
+            metadata: [
+              {
+                __typename: 'GeoLocation',
+                lat: 53.4621,
+                lon: 2.2766,
+                name: 'Old Trafford, Greater Manchester, England',
+              },
+              {
+                __typename: 'SportsTeam',
+                location: {
+                  lat: 53.4621,
+                  lon: 2.2766,
+                  name: 'Old Trafford, Greater Manchester, England',
+                },
+                name: 'Manchester United',
+              },
+            ],
+            name: 'Soccer Jersey',
+            price: 47.99,
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/fusion/execution/tests/cases/computed-fields/services/metadata.ts
+++ b/packages/fusion/execution/tests/cases/computed-fields/services/metadata.ts
@@ -1,0 +1,105 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const metadatas = [
+  {
+    id: '1',
+    __typename: 'GeoLocation',
+    name: 'Old Trafford, Greater Manchester, England',
+    lat: 53.4621,
+    lon: 2.2766,
+  },
+  { id: '2', __typename: 'SportsTeam', name: 'Manchester United', locationId: '1' },
+  { id: '3', __typename: 'TelevisionSeries', name: 'Great British Baking Show', season: 7 },
+  { id: '4', __typename: 'GeoLocation', name: 'Great Britain', lat: 55.3781, lon: 3.436 },
+  { id: '5', __typename: 'GeoLocation', name: 'Argentina', lat: 38.4161, lon: 63.6167 },
+];
+
+const categories = [
+  { id: '1', name: 'Sports' },
+  { id: '2', name: 'Cooking' },
+  { id: '3', name: 'Travel' },
+];
+
+export const metadataSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Category {
+      id: ID!
+      name: String!
+    }
+
+    interface Metadata {
+      id: ID!
+      name: String!
+    }
+
+    type GeoLocation implements Metadata {
+      id: ID!
+      name: String!
+      lat: Float!
+      lon: Float!
+    }
+
+    type SportsTeam implements Metadata {
+      id: ID!
+      name: String!
+      location: GeoLocation
+    }
+
+    type TelevisionSeries implements Metadata {
+      id: ID!
+      name: String!
+      season: Int
+    }
+
+    type Product {
+      category: Category @deprecated(reason: "gateway access only") # @computed(selectionSet: "{ categoryId }")
+      metadata: [Metadata] @deprecated(reason: "gateway access only") # @computed(selectionSet: "{ metadataIds }")
+    }
+
+    input ProductKey {
+      categoryId: ID
+      metadataIds: [ID!]
+    }
+
+    type Query {
+      _products(keys: [ProductKey!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      _products: (root, { keys }) => keys,
+    },
+    Product: {
+      metadata(product) {
+        return product.metadataIds
+          ? product.metadataIds.map(
+              (id: string) =>
+                metadatas.find(m => m.id === id) ||
+                new GraphQLError('Record not found', {
+                  extensions: {
+                    code: 'NOT_FOUND',
+                  },
+                }),
+            )
+          : null;
+      },
+      category(product) {
+        return product.categoryId ? categories.find(c => c.id === product.categoryId) : null;
+      },
+    },
+    SportsTeam: {
+      location(team) {
+        return (
+          metadatas.find(m => m.id === team.locationId) ||
+          new GraphQLError('Record not found', {
+            extensions: {
+              code: 'NOT_FOUND',
+            },
+          })
+        );
+      },
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/computed-fields/services/products.ts
+++ b/packages/fusion/execution/tests/cases/computed-fields/services/products.ts
@@ -1,0 +1,46 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const products = [
+  { upc: '1', name: 'iPhone', price: 699.99, categoryId: null, metadataIds: [] },
+  {
+    upc: '2',
+    name: 'The Best Baking Cookbook',
+    price: 15.99,
+    categoryId: '2',
+    metadataIds: ['3', '4'],
+  },
+  { upc: '3', name: 'Argentina Guidebook', price: 24.99, categoryId: '3', metadataIds: ['5'] },
+  { upc: '4', name: 'Soccer Jersey', price: 47.99, categoryId: '1', metadataIds: ['1', '2'] },
+];
+
+export const productsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      categoryId: ID
+      metadataIds: [ID!]
+      name: String!
+      price: Float!
+      upc: ID!
+    }
+
+    type Query {
+      products(upcs: [ID!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      products: (root, { upcs }) =>
+        upcs.map(
+          (upc: string) =>
+            products.find(p => p.upc === upc) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-arrays/__snapshots__/type-merging-arrays.spec.ts.snap
+++ b/packages/fusion/execution/tests/cases/type-merging-arrays/__snapshots__/type-merging-arrays.spec.ts.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Array-batched type merging composes the schema correctly 1`] = `
+"schema {
+  query: Query
+}
+
+type Manufacturer @source(subgraph: "manufacturers", name: "Manufacturer") @source(subgraph: "products", name: "Manufacturer") @resolver(subgraph: "manufacturers", operation: "query ManufacturersByIds($Manufacturer_id: [ID!]!) { manufacturers(ids: $Manufacturer_id) }", kind: "BATCH") @resolver(subgraph: "products", operation: "query ManufacturersByIds($Manufacturer_id: [ID!]!) { _manufacturers(ids: $Manufacturer_id) }", kind: "BATCH") @variable(subgraph: "manufacturers", name: "Manufacturer_id", select: "id") @variable(subgraph: "products", name: "Manufacturer_id", select: "id") @variable(subgraph: "manufacturers", name: "Manufacturer_id", select: "id") @variable(subgraph: "products", name: "Manufacturer_id", select: "id") {
+  id: ID! @source(subgraph: "manufacturers", name: "id", type: "ID!") @source(subgraph: "products", name: "id", type: "ID!")
+  name: String! @source(subgraph: "manufacturers", name: "name", type: "String!")
+  products: [Product]! @source(subgraph: "products", name: "products", type: "[Product]!")
+}
+
+type Query {
+  manufacturers(ids: [ID!]!): [Manufacturer]! @resolver(subgraph: "manufacturers", operation: "query manufacturers($ids: [ID!]!) { manufacturers(ids: $ids) }") @source(subgraph: "manufacturers", name: "manufacturers", type: "[Manufacturer]!")
+  product(upc: ID!): Product @resolver(subgraph: "products", operation: "query product($upc: ID!) { product(upc: $upc) }") @source(subgraph: "products", name: "product", type: "Product")
+  products(upcs: [ID!]!): [Product]! @resolver(subgraph: "products", operation: "query products($upcs: [ID!]!) { products(upcs: $upcs) }") @source(subgraph: "products", name: "products", type: "[Product]!")
+  _manufacturers(ids: [ID!]!): [Manufacturer]! @resolver(subgraph: "products", operation: "query _manufacturers($ids: [ID!]!) { _manufacturers(ids: $ids) }") @source(subgraph: "products", name: "_manufacturers", type: "[Manufacturer]!")
+  storefront(id: ID!): Storefront @resolver(subgraph: "storefronts", operation: "query storefront($id: ID!) { storefront(id: $id) }") @source(subgraph: "storefronts", name: "storefront", type: "Storefront")
+}
+
+type Product @source(subgraph: "products", name: "Product") @source(subgraph: "storefronts", name: "Product") @resolver(subgraph: "products", operation: "query ProductByUpc($Product_upc: ID!) { product(upc: $Product_upc) }", kind: "FETCH") @resolver(subgraph: "products", operation: "query ProductsByUpcs($Product_upc: [ID!]!) { products(upcs: $Product_upc) }", kind: "BATCH") @variable(subgraph: "products", name: "Product_upc", select: "upc") @variable(subgraph: "storefronts", name: "Product_upc", select: "upc") {
+  manufacturer: Manufacturer @source(subgraph: "products", name: "manufacturer", type: "Manufacturer")
+  name: String! @source(subgraph: "products", name: "name", type: "String!")
+  price: Float! @source(subgraph: "products", name: "price", type: "Float!")
+  upc: ID! @source(subgraph: "products", name: "upc", type: "ID!") @source(subgraph: "storefronts", name: "upc", type: "ID!")
+}
+
+type Storefront @source(subgraph: "storefronts", name: "Storefront") @resolver(subgraph: "storefronts", operation: "query StorefrontById($Storefront_id: ID!) { storefront(id: $Storefront_id) }", kind: "FETCH") @variable(subgraph: "storefronts", name: "Storefront_id", select: "id") {
+  id: ID! @source(subgraph: "storefronts", name: "id", type: "ID!")
+  name: String! @source(subgraph: "storefronts", name: "name", type: "String!")
+  products: [Product]! @source(subgraph: "storefronts", name: "products", type: "[Product]!")
+}"
+`;
+
+exports[`Array-batched type merging errors plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "products": [
+      {
+        "id": 0,
+        "resolverDependencyFieldMap": {
+          "manufacturer": [
+            {
+              "batch": true,
+              "id": 1,
+              "resolverOperationDocument": "query ManufacturersByIds($__variable_1: [ID!]!) {
+  __export: manufacturers(ids: $__variable_1) {
+    name
+  }
+}",
+              "subgraph": "manufacturers",
+            },
+          ],
+        },
+        "resolverOperationDocument": "query products {
+  __export: products(upcs: ["6"]) {
+    upc
+    name
+    manufacturer {
+      __variable_1: id
+    }
+  }
+}",
+        "subgraph": "products",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;
+
+exports[`Array-batched type merging successful query plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "storefront": [
+      {
+        "id": 0,
+        "resolverDependencyFieldMap": {
+          "products": [
+            {
+              "batch": true,
+              "id": 1,
+              "resolverDependencyFieldMap": {
+                "manufacturer": [
+                  {
+                    "batch": true,
+                    "id": 2,
+                    "resolverOperationDocument": "query ManufacturersByIds($__variable_2: [ID!]!) {
+  __export: manufacturers(ids: $__variable_2) {
+    name
+  }
+}",
+                    "subgraph": "manufacturers",
+                  },
+                ],
+              },
+              "resolverOperationDocument": "query ProductsByUpcs($__variable_1: [ID!]!) {
+  __export: products(upcs: $__variable_1) {
+    name
+    manufacturer {
+      products {
+        upc
+        name
+      }
+      __variable_2: id
+    }
+  }
+}",
+              "subgraph": "products",
+            },
+          ],
+        },
+        "resolverOperationDocument": "query storefront {
+  __export: storefront(id: "2") {
+    id
+    name
+    products {
+      upc
+      __variable_1: upc
+    }
+  }
+}",
+        "subgraph": "storefronts",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;

--- a/packages/fusion/execution/tests/cases/type-merging-arrays/services/manufacturers.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-arrays/services/manufacturers.ts
@@ -1,0 +1,35 @@
+import { createGraphQLError, createSchema } from 'graphql-yoga';
+
+// data fixtures
+const manufacturers = [
+  { id: '1', name: 'Apple' },
+  { id: '2', name: 'Macmillan' },
+];
+
+export const manufacturersSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Manufacturer {
+      id: ID!
+      name: String!
+    }
+
+    type Query {
+      manufacturers(ids: [ID!]!): [Manufacturer]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      manufacturers(root, { ids }) {
+        return ids.map(
+          id =>
+            manufacturers.find(m => m.id === id) ||
+            createGraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        );
+      },
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-arrays/services/products.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-arrays/services/products.ts
@@ -1,0 +1,67 @@
+import { createGraphQLError, createSchema } from 'graphql-yoga';
+
+// data fixtures
+const products = [
+  { upc: '1', name: 'iPhone', price: 699.99, manufacturerId: '1' },
+  { upc: '2', name: 'Apple Watch', price: 399.99, manufacturerId: '2' },
+  { upc: '3', name: 'Super Baking Cookbook', price: 15.99, manufacturerId: '2' },
+  { upc: '4', name: 'Best Selling Novel', price: 7.99, manufacturerId: '2' },
+  { upc: '5', name: 'iOS Survival Guide', price: 24.99, manufacturerId: '1' },
+  { upc: '6', name: 'Baseball Glove', price: 17.99, manufacturerId: '99' }, // << invalid manufacturer!
+];
+
+export const productsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      manufacturer: Manufacturer
+      name: String!
+      price: Float!
+      upc: ID!
+    }
+
+    type Manufacturer {
+      id: ID!
+      products: [Product]!
+    }
+
+    type Query {
+      product(upc: ID!): Product
+      products(upcs: [ID!]!): [Product]!
+      _manufacturers(ids: [ID!]!): [Manufacturer]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      product(root, { upc }) {
+        return (
+          products.find(p => p.upc === upc) ||
+          createGraphQLError('Record not found', {
+            extensions: {
+              code: 'NOT_FOUND',
+            },
+          })
+        );
+      },
+      products(root, { upcs }) {
+        return upcs.map(
+          upc =>
+            products.find(p => p.upc === upc) ||
+            createGraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        );
+      },
+      _manufacturers(root, { ids }) {
+        return ids.map(id => ({ id, products: products.filter(p => p.manufacturerId === id) }));
+      },
+    },
+    Product: {
+      manufacturer: product => ({ id: product.manufacturerId }),
+    },
+    Manufacturer: {
+      products: manufacturer => products.filter(p => p.manufacturerId === manufacturer.id),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-arrays/services/storefronts.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-arrays/services/storefronts.ts
@@ -1,0 +1,39 @@
+import { createGraphQLError, createSchema } from 'graphql-yoga';
+
+// data fixtures
+const storefronts = [
+  { id: '1', name: 'eShoppe', productUpcs: ['1', '2'] },
+  { id: '2', name: 'BestBooks Online', productUpcs: ['3', '4', '5'] },
+];
+
+export const storeFrontsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Storefront {
+      id: ID!
+      name: String!
+      products: [Product]!
+    }
+
+    type Product {
+      upc: ID!
+    }
+
+    type Query {
+      storefront(id: ID!): Storefront
+    }
+  `,
+  resolvers: {
+    Query: {
+      storefront: (root, { id }) =>
+        storefronts.find(s => s.id === id) ||
+        createGraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+    },
+    Storefront: {
+      products: storefront => storefront.productUpcs.map(upc => ({ upc })),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-arrays/type-merging-arrays.spec.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-arrays/type-merging-arrays.spec.ts
@@ -1,0 +1,193 @@
+import { parse } from 'graphql';
+import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
+import { getExecutorForFusiongraph } from '@graphql-mesh/fusion-runtime';
+import { createServeRuntime } from '@graphql-mesh/serve-runtime';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import {
+  createExecutablePlanForOperation,
+  planOperation,
+  serializeExecutableOperationPlan,
+} from '../../../src/operations';
+import { manufacturersSchema } from './services/manufacturers';
+import { productsSchema } from './services/products';
+import { storeFrontsSchema } from './services/storefronts';
+
+describe('Array-batched type merging', () => {
+  const fusiongraph = composeSubgraphs([
+    {
+      name: 'manufacturers',
+      schema: manufacturersSchema,
+    },
+    {
+      name: 'products',
+      schema: productsSchema,
+    },
+    {
+      name: 'storefronts',
+      schema: storeFrontsSchema,
+    },
+  ]);
+  it('composes the schema correctly', () => {
+    expect(printSchemaWithDirectives(fusiongraph)).toMatchSnapshot();
+  });
+  const { fusiongraphExecutor } = getExecutorForFusiongraph({
+    fusiongraph,
+    transports() {
+      return {
+        getSubgraphExecutor({ subgraphName }) {
+          switch (subgraphName) {
+            case 'manufacturers':
+              return createDefaultExecutor(manufacturersSchema);
+            case 'products':
+              return createDefaultExecutor(productsSchema);
+            case 'storefronts':
+              return createDefaultExecutor(storeFrontsSchema);
+          }
+        },
+      };
+    },
+  });
+  const exampleQueries = {
+    'successful query': {
+      query: /* GraphQL */ `
+        query {
+          storefront(id: "2") {
+            id
+            name
+            products {
+              upc
+              name
+              manufacturer {
+                products {
+                  upc
+                  name
+                }
+                name
+              }
+            }
+          }
+        }
+      `,
+      expectedResult: {
+        data: {
+          storefront: {
+            id: '2',
+            name: 'BestBooks Online',
+            products: [
+              {
+                manufacturer: {
+                  name: 'Macmillan',
+                  products: [
+                    {
+                      name: 'Apple Watch',
+                      upc: '2',
+                    },
+                    {
+                      name: 'Super Baking Cookbook',
+                      upc: '3',
+                    },
+                    {
+                      name: 'Best Selling Novel',
+                      upc: '4',
+                    },
+                  ],
+                },
+                name: 'Super Baking Cookbook',
+                upc: '3',
+              },
+              {
+                manufacturer: {
+                  name: 'Macmillan',
+                  products: [
+                    {
+                      name: 'Apple Watch',
+                      upc: '2',
+                    },
+                    {
+                      name: 'Super Baking Cookbook',
+                      upc: '3',
+                    },
+                    {
+                      name: 'Best Selling Novel',
+                      upc: '4',
+                    },
+                  ],
+                },
+                name: 'Best Selling Novel',
+                upc: '4',
+              },
+              {
+                manufacturer: {
+                  name: 'Apple',
+                  products: [
+                    {
+                      name: 'iPhone',
+                      upc: '1',
+                    },
+                    {
+                      name: 'iOS Survival Guide',
+                      upc: '5',
+                    },
+                  ],
+                },
+                name: 'iOS Survival Guide',
+                upc: '5',
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: {
+      query: /* GraphQL */ `
+        query {
+          products(upcs: ["6"]) {
+            upc
+            name
+            manufacturer {
+              name
+            }
+          }
+        }
+      `,
+      expectedResult: {
+        errors: [
+          {
+            message: 'Record not found',
+            path: ['products', 0, 'manufacturer', 'name'],
+            extensions: {
+              code: 'NOT_FOUND',
+            },
+          },
+        ],
+        data: {
+          products: [
+            {
+              upc: '6',
+              name: 'Baseball Glove',
+              manufacturer: null,
+            },
+          ],
+        },
+      },
+    },
+  };
+  Object.entries(exampleQueries).forEach(([name, { query, expectedResult }]) => {
+    describe(name, () => {
+      it('plans correctly', () => {
+        const plan = createExecutablePlanForOperation({
+          fusiongraph,
+          document: parse(query),
+        });
+        expect(serializeExecutableOperationPlan(plan)).toMatchSnapshot();
+      });
+      it(`gives correct results`, async () => {
+        const result = await fusiongraphExecutor({
+          document: parse(query),
+        });
+        expect(result).toMatchObject(expectedResult);
+      });
+    });
+  });
+});

--- a/packages/fusion/execution/tests/cases/type-merging-interfaces/__snapshots__/type-merging-interfaces.spec.ts.snap
+++ b/packages/fusion/execution/tests/cases/type-merging-interfaces/__snapshots__/type-merging-interfaces.spec.ts.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cross-service interfaces composes the schema 1`] = `
+"schema {
+  query: Query
+}
+
+interface ProductOffering @source(subgraph: "products", name: "ProductOffering") @source(subgraph: "storefronts", name: "ProductOffering") {
+  id: ID! @source(subgraph: "products", name: "id", type: "ID!") @source(subgraph: "storefronts", name: "id", type: "ID!")
+  name: String! @source(subgraph: "products", name: "name", type: "String!")
+  price: Float! @source(subgraph: "products", name: "price", type: "Float!")
+}
+
+type Product implements ProductOffering @source(subgraph: "products", name: "Product") @source(subgraph: "storefronts", name: "Product") @resolver(subgraph: "products", operation: "query ProductsByIds($Product_id: [ID!]!) { products(ids: $Product_id) }", kind: "BATCH") @resolver(subgraph: "products", operation: "query ProductById($Product_id: ID!) { product(id: $Product_id) }", kind: "FETCH") @variable(subgraph: "products", name: "Product_id", select: "id") @variable(subgraph: "storefronts", name: "Product_id", select: "id") {
+  id: ID! @source(subgraph: "products", name: "id", type: "ID!") @source(subgraph: "storefronts", name: "id", type: "ID!")
+  name: String! @source(subgraph: "products", name: "name", type: "String!")
+  price: Float! @source(subgraph: "products", name: "price", type: "Float!")
+}
+
+type Query {
+  products(ids: [ID!]!): [Product]! @resolver(subgraph: "products", operation: "query products($ids: [ID!]!) { products(ids: $ids) }") @source(subgraph: "products", name: "products", type: "[Product]!")
+  product(id: ID!): Product @resolver(subgraph: "products", operation: "query product($id: ID!) { product(id: $id) }") @source(subgraph: "products", name: "product", type: "Product")
+  storefront(id: ID!): Storefront @resolver(subgraph: "storefronts", operation: "query storefront($id: ID!) { storefront(id: $id) }") @source(subgraph: "storefronts", name: "storefront", type: "Storefront")
+}
+
+type ProductDeal implements ProductOffering @source(subgraph: "storefronts", name: "ProductDeal") {
+  id: ID! @source(subgraph: "storefronts", name: "id", type: "ID!")
+  name: String! @source(subgraph: "storefronts", name: "name", type: "String!")
+  price: Float! @source(subgraph: "storefronts", name: "price", type: "Float!")
+  products: [Product]! @source(subgraph: "storefronts", name: "products", type: "[Product]!")
+}
+
+type Storefront @source(subgraph: "storefronts", name: "Storefront") @resolver(subgraph: "storefronts", operation: "query StorefrontById($Storefront_id: ID!) { storefront(id: $Storefront_id) }", kind: "FETCH") @variable(subgraph: "storefronts", name: "Storefront_id", select: "id") {
+  id: ID! @source(subgraph: "storefronts", name: "id", type: "ID!")
+  name: String! @source(subgraph: "storefronts", name: "name", type: "String!")
+  productOfferings: [ProductOffering]! @source(subgraph: "storefronts", name: "productOfferings", type: "[ProductOffering]!")
+}"
+`;
+
+exports[`Cross-service interfaces plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "storefront": [
+      {
+        "id": 0,
+        "resolverOperationDocument": "query storefront {
+  __export: storefront(id: "1") {
+    id
+    name
+    productOfferings {
+      __typename
+      id
+      __variable_1: id
+    }
+  }
+}",
+        "subgraph": "storefronts",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;

--- a/packages/fusion/execution/tests/cases/type-merging-interfaces/services/products.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-interfaces/services/products.ts
@@ -1,0 +1,53 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const products = [
+  { id: '1', name: 'iPhone', price: 699.99 },
+  { id: '2', name: 'Apple Watch', price: 399.99 },
+  { id: '3', name: 'Super Baking Cookbook', price: 15.99 },
+  { id: '4', name: 'Best Selling Novel', price: 7.99 },
+  { id: '5', name: 'iOS Survival Guide', price: 24.99 },
+];
+
+export const productsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    interface ProductOffering {
+      id: ID!
+      name: String!
+      price: Float!
+    }
+
+    type Product implements ProductOffering {
+      id: ID!
+      name: String!
+      price: Float!
+    }
+
+    type Query {
+      products(ids: [ID!]!): [Product]!
+      product(id: ID!): Product
+    }
+  `,
+  resolvers: {
+    Query: {
+      products: (root, { ids }) =>
+        ids.map(
+          (id: string) =>
+            products.find(p => p.id === id) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+      product: (_root, { id }) =>
+        products.find(p => p.id === id) ||
+        new GraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-interfaces/services/storefronts.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-interfaces/services/storefronts.ts
@@ -1,0 +1,79 @@
+import { GraphQLError, print } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const storefronts = [
+  {
+    id: '1',
+    name: 'eShoppe',
+    productOfferKeys: ['Product:1', 'ProductDeal:1', 'Product:2'],
+  },
+  {
+    id: '2',
+    name: 'BestBooks Online',
+    productOfferKeys: ['Product:3', 'Product:4', 'ProductDeal:2', 'Product:5'],
+  },
+];
+
+const productDeals = [
+  { id: '1', name: 'iPhone + Survival Guide', price: 679.99, productIds: ['1', '5'] },
+  { id: '2', name: 'Best Sellers', price: 19.99, productIds: ['3', '4'] },
+];
+
+export const storefrontsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    interface ProductOffering {
+      id: ID!
+    }
+
+    type Product implements ProductOffering {
+      id: ID!
+    }
+
+    type ProductDeal implements ProductOffering {
+      id: ID!
+      name: String!
+      price: Float!
+      products: [Product]!
+    }
+
+    type Storefront {
+      id: ID!
+      name: String!
+      productOfferings: [ProductOffering]!
+    }
+
+    type Query {
+      storefront(id: ID!): Storefront
+    }
+  `,
+  resolvers: {
+    Query: {
+      storefront: (_root, { id }) =>
+        storefronts.find(s => s.id === id) ||
+        new GraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+    },
+    Storefront: {
+      productOfferings(storefront, _args, _ctx, info) {
+        return storefront.productOfferKeys.map(key => {
+          const [__typename, id] = key.split(':');
+          const obj = __typename === 'Product' ? { id } : productDeals.find(d => d.id === id);
+          return obj
+            ? { __typename, ...obj }
+            : new GraphQLError('Record not found', {
+                extensions: {
+                  code: 'NOT_FOUND',
+                },
+              });
+        });
+      },
+    },
+    ProductDeal: {
+      products: deal => deal.productIds.map(id => ({ id })),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-interfaces/type-merging-interfaces.spec.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-interfaces/type-merging-interfaces.spec.ts
@@ -1,0 +1,112 @@
+import { parse } from 'graphql';
+import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
+import { getExecutorForFusiongraph } from '@graphql-mesh/fusion-runtime';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import {
+  createExecutablePlanForOperation,
+  serializeExecutableOperationPlan,
+} from '../../../src/operations';
+import { productsSchema } from './services/products';
+import { storefrontsSchema } from './services/storefronts';
+
+describe('Cross-service interfaces', () => {
+  const fusiongraph = composeSubgraphs([
+    {
+      name: 'products',
+      schema: productsSchema,
+    },
+    {
+      name: 'storefronts',
+      schema: storefrontsSchema,
+    },
+  ]);
+  const { fusiongraphExecutor } = getExecutorForFusiongraph({
+    fusiongraph,
+    transports() {
+      return {
+        getSubgraphExecutor({ subgraphName }) {
+          switch (subgraphName) {
+            case 'products':
+              return createDefaultExecutor(productsSchema);
+            case 'storefronts':
+              return createDefaultExecutor(storefrontsSchema);
+          }
+        },
+      };
+    },
+  });
+  it('composes the schema', async () => {
+    expect(printSchemaWithDirectives(fusiongraph)).toMatchSnapshot();
+  });
+  const exampleQuery = parse(/* GraphQL */ `
+    query {
+      storefront(id: "1") {
+        id
+        name
+        productOfferings {
+          __typename
+          id
+          name
+          price
+          ... on ProductDeal {
+            products {
+              name
+              price
+            }
+          }
+        }
+      }
+    }
+  `);
+  it('plans correctly', async () => {
+    const plan = createExecutablePlanForOperation({
+      fusiongraph,
+      document: exampleQuery,
+    });
+    expect(serializeExecutableOperationPlan(plan)).toMatchSnapshot();
+  });
+  it('should work', async () => {
+    const result = await fusiongraphExecutor({
+      document: exampleQuery,
+    });
+    expect(result).toEqual({
+      data: {
+        storefront: {
+          id: '1',
+          name: 'eShoppe',
+          productOfferings: [
+            {
+              __typename: 'Product',
+              id: '1',
+              name: 'iPhone',
+              price: 699.99,
+            },
+            {
+              __typename: 'ProductDeal',
+              id: '1',
+              name: 'iPhone + Survival Guide',
+              price: 679.99,
+              products: [
+                {
+                  name: 'iPhone',
+                  price: 699.99,
+                },
+                {
+                  name: 'iOS Survival Guide',
+                  price: 24.99,
+                },
+              ],
+            },
+            {
+              __typename: 'Product',
+              id: '2',
+              name: 'Apple Watch',
+              price: 399.99,
+            },
+          ],
+        },
+      },
+    });
+  });
+});

--- a/packages/fusion/execution/tests/cases/type-merging-multiple-keys/__snapshots__/type-merging-multiple-keys.test.ts.snap
+++ b/packages/fusion/execution/tests/cases/type-merging-multiple-keys/__snapshots__/type-merging-multiple-keys.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Type merging with multiple keys composes correctly 1`] = `
+"schema {
+  query: Query
+}
+
+type Product @source(subgraph: "catalog", name: "Product") @source(subgraph: "reviews", name: "Product") @source(subgraph: "vendors", name: "Product") @resolver(subgraph: "catalog", operation: "query ProductsByUpcs($Product_upc: [ID!]!) { productsByUpcs(upcs: $Product_upc) }", kind: "BATCH") @resolver(subgraph: "reviews", operation: "query ProductsByIds($Product_id: [ID!]!) { productsByIds(ids: $Product_id) }", kind: "BATCH") @resolver(subgraph: "vendors", operation: "query productsByKeys($Product_key: [ProductKey]) { productsByKeys(keys: $Product_key) }", kind: "BATCH") @variable(subgraph: "catalog", name: "Product_upc", select: "upc") @variable(subgraph: "vendors", name: "Product_upc", select: "upc") @variable(subgraph: "reviews", name: "Product_id", select: "id") @variable(subgraph: "vendors", name: "Product_id", select: "id") @variable(subgraph: "catalog", name: "Product_key", value: "{ upc: $upc }") @variable(subgraph: "reviews", name: "Product_key", value: "{ id: $id }") @variable(subgraph: "vendors", name: "Product_key", value: "{ upc: $upc, id: $id }") {
+  upc: ID! @source(subgraph: "catalog", name: "upc", type: "ID!") @source(subgraph: "vendors", name: "upc", type: "ID!")
+  msrp: Int! @source(subgraph: "catalog", name: "msrp", type: "Int!")
+  name: String @source(subgraph: "catalog", name: "name", type: "String")
+  weight: Int! @source(subgraph: "catalog", name: "weight", type: "Int!")
+  id: ID! @source(subgraph: "reviews", name: "id", type: "ID!") @source(subgraph: "vendors", name: "id", type: "ID!")
+  reviews: [Review] @source(subgraph: "reviews", name: "reviews", type: "[Review]")
+  retailPrice: Int @source(subgraph: "vendors", name: "retailPrice", type: "Int")
+  unitsInStock: Int @source(subgraph: "vendors", name: "unitsInStock", type: "Int")
+}
+
+type Query {
+  productsByUpcs(upcs: [ID!]!): [Product]! @resolver(subgraph: "catalog", operation: "query productsByUpcs($upcs: [ID!]!) { productsByUpcs(upcs: $upcs) }") @source(subgraph: "catalog", name: "productsByUpcs", type: "[Product]!")
+  review(id: ID!): Review @resolver(subgraph: "reviews", operation: "query review($id: ID!) { review(id: $id) }") @source(subgraph: "reviews", name: "review", type: "Review")
+  productsByIds(ids: [ID!]!): [Product]! @resolver(subgraph: "reviews", operation: "query productsByIds($ids: [ID!]!) { productsByIds(ids: $ids) }") @source(subgraph: "reviews", name: "productsByIds", type: "[Product]!")
+  productsByKeys(keys: [ProductKey!]!): [Product]! @resolver(subgraph: "vendors", operation: "query productsByKeys($keys: [ProductKey!]!) { productsByKeys(keys: $keys) }") @source(subgraph: "vendors", name: "productsByKeys", type: "[Product]!")
+}
+
+type Review @source(subgraph: "reviews", name: "Review") @resolver(subgraph: "reviews", operation: "query ReviewById($Review_id: ID!) { review(id: $Review_id) }", kind: "FETCH") @variable(subgraph: "reviews", name: "Review_id", select: "id") {
+  id: ID! @source(subgraph: "reviews", name: "id", type: "ID!")
+  body: String @source(subgraph: "reviews", name: "body", type: "String")
+  product: Product @source(subgraph: "reviews", name: "product", type: "Product")
+}
+
+input ProductKey @source(subgraph: "vendors", name: "ProductKey") {
+  id: ID @source(subgraph: "vendors", name: "id", type: "ID")
+  upc: ID @source(subgraph: "vendors", name: "upc", type: "ID")
+}"
+`;

--- a/packages/fusion/execution/tests/cases/type-merging-multiple-keys/services/catalog.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-multiple-keys/services/catalog.ts
@@ -1,0 +1,37 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+const products = [
+  { upc: '1', name: 'Table', price: 899, weight: 100 },
+  { upc: '2', name: 'Couch', price: 1299, weight: 1000 },
+  { upc: '3', name: 'Chair', price: 54, weight: 50 },
+];
+
+export const catalogSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      upc: ID!
+      msrp: Int!
+      name: String
+      weight: Int!
+    }
+
+    type Query {
+      productsByUpcs(upcs: [ID!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      productsByUpcs: (_root, { upcs }) =>
+        upcs.map(
+          (upc: string) =>
+            products.find(product => product.upc === upc) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-multiple-keys/services/reviews.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-multiple-keys/services/reviews.ts
@@ -1,0 +1,47 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+const reviews = [
+  { id: '1', productId: '101', body: 'Love it!' },
+  { id: '2', productId: '102', body: 'Too expensive.' },
+  { id: '3', productId: '103', body: 'Could be better.' },
+  { id: '4', productId: '101', body: 'Prefer something else.' },
+];
+
+export const reviewsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Review {
+      id: ID!
+      body: String
+      product: Product
+    }
+
+    type Product {
+      id: ID!
+      reviews: [Review]
+    }
+
+    type Query {
+      review(id: ID!): Review
+      productsByIds(ids: [ID!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Review: {
+      product: review => ({ id: review.productId }),
+    },
+    Product: {
+      reviews: product => reviews.filter(review => review.productId === product.id),
+    },
+    Query: {
+      review: (_root, { id }) =>
+        reviews.find(review => review.id === id) ||
+        new GraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+      productsByIds: (_root, { ids }) => ids.map((id: string) => ({ id })),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-multiple-keys/services/vendors.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-multiple-keys/services/vendors.ts
@@ -1,0 +1,42 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+const products = [
+  { id: '101', upc: '1', retailPrice: 879, unitsInStock: 23 },
+  { id: '102', upc: '2', retailPrice: 1279, unitsInStock: 77 },
+  { id: '103', upc: '3', retailPrice: 54, unitsInStock: 0 },
+];
+
+export const vendorsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      id: ID!
+      upc: ID!
+      retailPrice: Int
+      unitsInStock: Int
+    }
+
+    input ProductKey {
+      id: ID
+      upc: ID
+    }
+
+    type Query {
+      productsByKeys(keys: [ProductKey!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      productsByKeys: (_root, { keys }) =>
+        keys.map(
+          (k: { id: string; upc: string }) =>
+            products.find(p => p.id === k.id || p.upc === k.upc) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-multiple-keys/type-merging-multiple-keys.test.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-multiple-keys/type-merging-multiple-keys.test.ts
@@ -1,0 +1,193 @@
+import { parse } from 'graphql';
+import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
+import { getExecutorForFusiongraph } from '@graphql-mesh/fusion-runtime';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
+import { MapperKind, mapSchema, printSchemaWithDirectives } from '@graphql-tools/utils';
+import { catalogSchema } from './services/catalog';
+import { reviewsSchema } from './services/reviews';
+import { vendorsSchema } from './services/vendors';
+
+describe('Type merging with multiple keys', () => {
+  let fusiongraph = composeSubgraphs([
+    {
+      name: 'catalog',
+      schema: catalogSchema,
+    },
+    {
+      name: 'reviews',
+      schema: reviewsSchema,
+    },
+    {
+      name: 'vendors',
+      schema: vendorsSchema,
+    },
+  ]);
+  // Add directives
+  fusiongraph = mapSchema(fusiongraph, {
+    [MapperKind.OBJECT_TYPE]: type => {
+      if (type.name === 'Product') {
+        const typeExtensions: any = (type.extensions ||= {});
+        const directiveExtensions: any = (typeExtensions.directives ||= {});
+        const variableDirectives = (directiveExtensions.variable ||= []);
+        const resolverDirectives = (directiveExtensions.resolver ||= []);
+        variableDirectives.push(
+          {
+            subgraph: 'catalog',
+            name: 'Product_key',
+            value: '{ upc: $upc }',
+          },
+          {
+            subgraph: 'reviews',
+            name: 'Product_key',
+            value: '{ id: $id }',
+          },
+          {
+            subgraph: 'vendors',
+            name: 'Product_key',
+            value: '{ upc: $upc, id: $id }',
+          },
+        );
+        resolverDirectives.push({
+          subgraph: 'vendors',
+          operation:
+            'query productsByKeys($Product_key: [ProductKey]) { productsByKeys(keys: $Product_key) }',
+          kind: 'BATCH',
+        });
+      }
+      return type;
+    },
+  });
+  it('composes correctly', () => {
+    expect(printSchemaWithDirectives(fusiongraph)).toMatchSnapshot();
+  });
+  const { fusiongraphExecutor } = getExecutorForFusiongraph({
+    fusiongraph,
+    transports() {
+      return {
+        getSubgraphExecutor({ subgraphName }) {
+          switch (subgraphName) {
+            case 'catalog':
+              return createDefaultExecutor(catalogSchema);
+            case 'reviews':
+              return createDefaultExecutor(reviewsSchema);
+            case 'vendors':
+              return createDefaultExecutor(vendorsSchema);
+          }
+        },
+      };
+    },
+  });
+  it('should work', async () => {
+    const result = await fusiongraphExecutor({
+      document: parse(/* GraphQL */ `
+        query {
+          # catalog service
+          productsByUpcs(upcs: ["1"]) {
+            upc
+            name
+            retailPrice
+            reviews {
+              id
+              body
+            }
+          }
+
+          # vendors service
+          productsByKeys(keys: [{ upc: "1" }, { id: "101" }]) {
+            id
+            upc
+            name
+            retailPrice
+            reviews {
+              id
+              body
+            }
+          }
+
+          # reviews service
+          productsByIds(ids: ["101"]) {
+            id
+            name
+            retailPrice
+            reviews {
+              id
+              body
+            }
+          }
+        }
+      `),
+    });
+    expect(result).toEqual({
+      data: {
+        productsById: [
+          {
+            id: '101',
+            name: 'Table',
+            retailPrice: 879,
+            reviews: [
+              {
+                body: 'Love it!',
+                id: '1',
+              },
+              {
+                body: 'Prefer something else.',
+                id: '4',
+              },
+            ],
+          },
+        ],
+        productsByKey: [
+          {
+            id: '101',
+            name: 'Table',
+            retailPrice: 879,
+            reviews: [
+              {
+                body: 'Love it!',
+                id: '1',
+              },
+              {
+                body: 'Prefer something else.',
+                id: '4',
+              },
+            ],
+            upc: '1',
+          },
+          {
+            id: '101',
+            name: 'Table',
+            retailPrice: 879,
+            reviews: [
+              {
+                body: 'Love it!',
+                id: '1',
+              },
+              {
+                body: 'Prefer something else.',
+                id: '4',
+              },
+            ],
+            upc: '1',
+          },
+        ],
+        productsByUpc: [
+          {
+            name: 'Table',
+            retailPrice: 879,
+            reviews: [
+              {
+                body: 'Love it!',
+                id: '1',
+              },
+              {
+                body: 'Prefer something else.',
+                id: '4',
+              },
+            ],
+            upc: '1',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/fusion/execution/tests/cases/type-merging-nullables/__snapshots__/type-merging-nullables.spec.ts.snap
+++ b/packages/fusion/execution/tests/cases/type-merging-nullables/__snapshots__/type-merging-nullables.spec.ts.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nullable merges composes correctly 1`] = `
+"schema {
+  query: Query
+}
+
+type Product @source(subgraph: "products", name: "Product") @source(subgraph: "reviews", name: "Product") @resolver(subgraph: "products", operation: "query ProductsByUpcs($Product_upc: [ID!]!) { products(upcs: $Product_upc) }", kind: "BATCH") @resolver(subgraph: "reviews", operation: "query ProductsByUpcs($Product_upc: [ID!]!) { _products(upcs: $Product_upc) }", kind: "BATCH") @variable(subgraph: "products", name: "Product_upc", select: "upc") @variable(subgraph: "reviews", name: "Product_upc", select: "upc") @variable(subgraph: "products", name: "Product_upc", select: "upc") @variable(subgraph: "reviews", name: "Product_upc", select: "upc") {
+  upc: ID! @source(subgraph: "products", name: "upc", type: "ID!") @source(subgraph: "reviews", name: "upc", type: "ID!")
+  name: String! @source(subgraph: "products", name: "name", type: "String!")
+  price: Float! @source(subgraph: "products", name: "price", type: "Float!")
+  reviews: [Review] @source(subgraph: "reviews", name: "reviews", type: "[Review]")
+}
+
+type Query {
+  products(upcs: [ID!]!): [Product]! @resolver(subgraph: "products", operation: "query products($upcs: [ID!]!) { products(upcs: $upcs) }") @source(subgraph: "products", name: "products", type: "[Product]!")
+  reviews(ids: [ID!]!): [Review]! @resolver(subgraph: "reviews", operation: "query reviews($ids: [ID!]!) { reviews(ids: $ids) }") @source(subgraph: "reviews", name: "reviews", type: "[Review]!")
+  _users(ids: [ID!]!): [User]! @resolver(subgraph: "reviews", operation: "query _users($ids: [ID!]!) { _users(ids: $ids) }") @source(subgraph: "reviews", name: "_users", type: "[User]!")
+  _products(upcs: [ID!]!): [Product]! @resolver(subgraph: "reviews", operation: "query _products($upcs: [ID!]!) { _products(upcs: $upcs) }") @source(subgraph: "reviews", name: "_products", type: "[Product]!")
+  users(ids: [ID!]!): [User]! @resolver(subgraph: "users", operation: "query users($ids: [ID!]!) { users(ids: $ids) }") @source(subgraph: "users", name: "users", type: "[User]!")
+}
+
+type Review @source(subgraph: "reviews", name: "Review") @resolver(subgraph: "reviews", operation: "query ReviewsByIds($Review_id: [ID!]!) { reviews(ids: $Review_id) }", kind: "BATCH") @variable(subgraph: "reviews", name: "Review_id", select: "id") {
+  id: ID! @source(subgraph: "reviews", name: "id", type: "ID!")
+  body: String! @source(subgraph: "reviews", name: "body", type: "String!")
+  product: Product @source(subgraph: "reviews", name: "product", type: "Product")
+  user: User @source(subgraph: "reviews", name: "user", type: "User")
+}
+
+type User @source(subgraph: "reviews", name: "User") @source(subgraph: "users", name: "User") @resolver(subgraph: "reviews", operation: "query UsersByIds($User_id: [ID!]!) { _users(ids: $User_id) }", kind: "BATCH") @resolver(subgraph: "users", operation: "query UsersByIds($User_id: [ID!]!) { users(ids: $User_id) }", kind: "BATCH") @variable(subgraph: "reviews", name: "User_id", select: "id") @variable(subgraph: "users", name: "User_id", select: "id") @variable(subgraph: "reviews", name: "User_id", select: "id") @variable(subgraph: "users", name: "User_id", select: "id") {
+  id: ID! @source(subgraph: "reviews", name: "id", type: "ID!") @source(subgraph: "users", name: "id", type: "ID!")
+  reviews: [Review]! @source(subgraph: "reviews", name: "reviews", type: "[Review]!")
+  username: String! @source(subgraph: "users", name: "username", type: "String!")
+}"
+`;
+
+exports[`Nullable merges null product result plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "_products": [
+      {
+        "id": 0,
+        "resolverDependencyFieldMap": {
+          "reviews": [],
+        },
+        "resolverOperationDocument": "query _products {
+  __export: _products(upcs: ["DOES_NOT_EXIST"]) {
+    upc
+    reviews {
+      body
+    }
+  }
+}",
+        "subgraph": "reviews",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;
+
+exports[`Nullable merges null user result plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "_users": [
+      {
+        "id": 0,
+        "resolverDependencyFieldMap": {
+          "reviews": [],
+        },
+        "resolverOperationDocument": "query _users {
+  __export: _users(ids: ["DOES_NOT_EXIST"]) {
+    id
+    reviews {
+      body
+    }
+  }
+}",
+        "subgraph": "reviews",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;
+
+exports[`Nullable merges regular plans correctly 1`] = `
+{
+  "resolverDependencyFieldMap": {
+    "products": [
+      {
+        "id": 1,
+        "resolverDependencies": [
+          {
+            "batch": true,
+            "id": 2,
+            "resolverOperationDocument": "query ProductsByUpcs($__variable_3: [ID!]!) {
+  __export: _products(upcs: $__variable_3) {
+    reviews {
+      body
+    }
+  }
+}",
+            "subgraph": "reviews",
+          },
+        ],
+        "resolverOperationDocument": "query products {
+  __export: products(upcs: [2]) {
+    name
+    __variable_3: upc
+  }
+}",
+        "subgraph": "products",
+      },
+    ],
+    "users": [
+      {
+        "id": 0,
+        "resolverDependencies": [
+          {
+            "batch": true,
+            "id": 1,
+            "resolverOperationDocument": "query UsersByIds($__variable_1: [ID!]!) {
+  __export: _users(ids: $__variable_1) {
+    reviews {
+      body
+    }
+  }
+}",
+            "subgraph": "reviews",
+          },
+        ],
+        "resolverOperationDocument": "query users {
+  __export: users(ids: [2]) {
+    username
+    __variable_1: id
+  }
+}",
+        "subgraph": "users",
+      },
+    ],
+  },
+  "resolverOperationNodes": [],
+}
+`;

--- a/packages/fusion/execution/tests/cases/type-merging-nullables/services/products.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-nullables/services/products.ts
@@ -1,0 +1,36 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const products = [
+  { upc: '1', name: 'Cookbook', price: 15.99 },
+  { upc: '2', name: 'Toothbrush', price: 3.99 },
+];
+
+export const productsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      upc: ID!
+      name: String!
+      price: Float!
+    }
+
+    type Query {
+      products(upcs: [ID!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      products: (_root, { upcs }) =>
+        upcs.map(
+          (upc: string) =>
+            products.find(p => p.upc === upc) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-nullables/services/reviews.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-nullables/services/reviews.ts
@@ -1,0 +1,76 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const reviews = [{ id: '1', productUpc: '1', userId: '1', body: 'love it' }];
+
+export const reviewsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Review {
+      id: ID!
+      body: String!
+      product: Product
+      user: User
+    }
+
+    type User {
+      id: ID!
+      reviews: [Review]!
+    }
+
+    type Product {
+      upc: ID!
+      reviews: [Review]
+    }
+
+    type Query {
+      reviews(ids: [ID!]!): [Review]!
+      _users(ids: [ID!]!): [User]!
+      _products(upcs: [ID!]!): [Product]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      reviews: (_root, { ids }) =>
+        ids.map(
+          (id: string) =>
+            reviews.find(r => r.id === id) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+
+      // Users will _always_ return a stub record,
+      // regardless of whether there's a local representation of the user.
+      // We're trusting that remote services are sending in valid User IDs...
+      // Returning a stub record is necessary to fulfill the schema nullability requirement:
+      // type User {
+      //   reviews: [Review]!
+      // }
+      _users: (_root, { ids }) => ids.map((id: string) => ({ id })),
+
+      // Products will only build a stub record when there's a local record of it,
+      // otherwise, returning null without an error.
+      // This allows the reviews service to have no opinions about unknown products;
+      // it will neither confirm nor deny that they exist.
+      // Returning null is permitted by the schema nullability spec:
+      // type Product {
+      //   reviews: [Review]
+      // }
+      _products: (_root, { upcs }) =>
+        upcs.map((upc: string) => (reviews.find(r => r.productUpc === upc) ? { upc } : null)),
+    },
+    Review: {
+      product: review => ({ upc: review.productUpc }),
+      user: review => ({ id: review.userId }),
+    },
+    User: {
+      reviews: user => reviews.filter(r => r.userId === user.id),
+    },
+    Product: {
+      reviews: product => reviews.filter(r => r.productUpc === product.upc),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-nullables/services/users.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-nullables/services/users.ts
@@ -1,0 +1,35 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const users = [
+  { id: '1', username: 'hanshotfirst' },
+  { id: '2', username: 'bigvader23' },
+];
+
+export const usersSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type User {
+      id: ID!
+      username: String!
+    }
+
+    type Query {
+      users(ids: [ID!]!): [User]!
+    }
+  `,
+  resolvers: {
+    Query: {
+      users: (_root, { ids }) =>
+        ids.map(
+          (id: string) =>
+            users.find(u => u.id === id) ||
+            new GraphQLError('Record not found', {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+            }),
+        ),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-nullables/type-merging-nullables.spec.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-nullables/type-merging-nullables.spec.ts
@@ -1,0 +1,139 @@
+import { parse } from 'graphql';
+import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
+import { getExecutorForFusiongraph } from '@graphql-mesh/fusion-runtime';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import {
+  createExecutablePlanForOperation,
+  serializeExecutableOperationPlan,
+} from '../../../src/operations';
+import { productsSchema } from './services/products';
+import { reviewsSchema } from './services/reviews';
+import { usersSchema } from './services/users';
+
+describe('Nullable merges', () => {
+  const exampleQueries = [
+    {
+      name: 'regular',
+      query: /* GraphQL */ `
+        query {
+          users(ids: [2]) {
+            username
+            reviews {
+              body
+            }
+          }
+          products(upcs: [2]) {
+            name
+            reviews {
+              body
+            }
+          }
+        }
+      `,
+      result: {
+        data: {
+          users: [
+            {
+              username: 'bigvader23',
+              reviews: [],
+            },
+          ],
+          products: [
+            {
+              name: 'Toothbrush',
+              reviews: null,
+            },
+          ],
+        },
+      },
+    },
+    {
+      name: 'null user result',
+      query: /* GraphQL */ `
+        query {
+          _users(ids: ["DOES_NOT_EXIST"]) {
+            id
+            reviews {
+              body
+            }
+          }
+        }
+      `,
+      result: {
+        data: {
+          _users: [{ id: 'DOES_NOT_EXIST', reviews: [] }],
+        },
+      },
+    },
+    {
+      name: 'null product result',
+      query: /* GraphQL */ `
+        query {
+          _products(upcs: ["DOES_NOT_EXIST"]) {
+            upc
+            reviews {
+              body
+            }
+          }
+        }
+      `,
+      result: {
+        data: {
+          _products: [null],
+        },
+      },
+    },
+  ];
+  const fusiongraph = composeSubgraphs([
+    {
+      name: 'products',
+      schema: productsSchema,
+    },
+    {
+      name: 'reviews',
+      schema: reviewsSchema,
+    },
+    {
+      name: 'users',
+      schema: usersSchema,
+    },
+  ]);
+  it('composes correctly', () => {
+    expect(printSchemaWithDirectives(fusiongraph)).toMatchSnapshot();
+  });
+  const { fusiongraphExecutor } = getExecutorForFusiongraph({
+    fusiongraph,
+    transports() {
+      return {
+        getSubgraphExecutor({ subgraphName }) {
+          switch (subgraphName) {
+            case 'products':
+              return createDefaultExecutor(productsSchema);
+            case 'reviews':
+              return createDefaultExecutor(reviewsSchema);
+            case 'users':
+              return createDefaultExecutor(usersSchema);
+          }
+        },
+      };
+    },
+  });
+  for (const { name, query, result: expectedResult } of exampleQueries) {
+    describe(name, () => {
+      it(`plans correctly`, async () => {
+        const plan = createExecutablePlanForOperation({
+          fusiongraph,
+          document: parse(query),
+        });
+        expect(serializeExecutableOperationPlan(plan)).toMatchSnapshot();
+      });
+      it(`gives the correct result`, async () => {
+        const result = await fusiongraphExecutor({
+          document: parse(query),
+        });
+        expect(result).toEqual(expectedResult);
+      });
+    });
+  }
+});

--- a/packages/fusion/execution/tests/cases/type-merging-single-records/__snapshots__/type-merging-single-records.spec.ts.snap
+++ b/packages/fusion/execution/tests/cases/type-merging-single-records/__snapshots__/type-merging-single-records.spec.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Single-record type merging composes the schema correctly 1`] = `
+"schema {
+  query: Query
+}
+
+type Manufacturer @source(subgraph: "manufacturers", name: "Manufacturer") @source(subgraph: "products", name: "Manufacturer") @resolver(subgraph: "manufacturers", operation: "query ManufacturerById($Manufacturer_id: ID!) { manufacturer(id: $Manufacturer_id) }", kind: "FETCH") @resolver(subgraph: "products", operation: "query ManufacturerById($Manufacturer_id: ID!) { _manufacturer(id: $Manufacturer_id) }", kind: "FETCH") @variable(subgraph: "manufacturers", name: "Manufacturer_id", select: "id") @variable(subgraph: "products", name: "Manufacturer_id", select: "id") @variable(subgraph: "manufacturers", name: "Manufacturer_id", select: "id") @variable(subgraph: "products", name: "Manufacturer_id", select: "id") {
+  id: ID! @source(subgraph: "manufacturers", name: "id", type: "ID!") @source(subgraph: "products", name: "id", type: "ID!")
+  name: String! @source(subgraph: "manufacturers", name: "name", type: "String!")
+  products: [Product]! @source(subgraph: "products", name: "products", type: "[Product]!")
+}
+
+type Query {
+  manufacturer(id: ID!): Manufacturer @resolver(subgraph: "manufacturers", operation: "query manufacturer($id: ID!) { manufacturer(id: $id) }") @source(subgraph: "manufacturers", name: "manufacturer", type: "Manufacturer")
+  product(upc: ID!): Product @resolver(subgraph: "products", operation: "query product($upc: ID!) { product(upc: $upc) }") @source(subgraph: "products", name: "product", type: "Product")
+  _manufacturer(id: ID!): Manufacturer @resolver(subgraph: "products", operation: "query _manufacturer($id: ID!) { _manufacturer(id: $id) }") @source(subgraph: "products", name: "_manufacturer", type: "Manufacturer")
+  storefront(id: ID!): Storefront @resolver(subgraph: "storefronts", operation: "query storefront($id: ID!) { storefront(id: $id) }") @source(subgraph: "storefronts", name: "storefront", type: "Storefront")
+}
+
+type Product @source(subgraph: "products", name: "Product") @source(subgraph: "storefronts", name: "Product") @resolver(subgraph: "products", operation: "query ProductByUpc($Product_upc: ID!) { product(upc: $Product_upc) }", kind: "FETCH") @variable(subgraph: "products", name: "Product_upc", select: "upc") @variable(subgraph: "storefronts", name: "Product_upc", select: "upc") {
+  manufacturer: Manufacturer @source(subgraph: "products", name: "manufacturer", type: "Manufacturer")
+  name: String! @source(subgraph: "products", name: "name", type: "String!")
+  price: Float! @source(subgraph: "products", name: "price", type: "Float!")
+  upc: ID! @source(subgraph: "products", name: "upc", type: "ID!") @source(subgraph: "storefronts", name: "upc", type: "ID!")
+}
+
+type Storefront @source(subgraph: "storefronts", name: "Storefront") @resolver(subgraph: "storefronts", operation: "query StorefrontById($Storefront_id: ID!) { storefront(id: $Storefront_id) }", kind: "FETCH") @variable(subgraph: "storefronts", name: "Storefront_id", select: "id") {
+  id: ID! @source(subgraph: "storefronts", name: "id", type: "ID!")
+  name: String! @source(subgraph: "storefronts", name: "name", type: "String!")
+  products: [Product]! @source(subgraph: "storefronts", name: "products", type: "[Product]!")
+}"
+`;

--- a/packages/fusion/execution/tests/cases/type-merging-single-records/services/manufacturers.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-single-records/services/manufacturers.ts
@@ -1,0 +1,32 @@
+import { createSchema } from 'graphql-yoga';
+import { createGraphQLError } from '@graphql-tools/utils';
+
+// data fixtures
+const manufacturers = [
+  { id: '1', name: 'Apple' },
+  { id: '2', name: 'Macmillan' },
+];
+
+export const manufacturersSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Manufacturer {
+      id: ID!
+      name: String!
+    }
+
+    type Query {
+      manufacturer(id: ID!): Manufacturer
+    }
+  `,
+  resolvers: {
+    Query: {
+      manufacturer: (root, { id }) =>
+        manufacturers.find(m => m.id === id) ||
+        createGraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-single-records/services/products.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-single-records/services/products.ts
@@ -1,0 +1,53 @@
+import { createSchema } from 'graphql-yoga';
+import { createGraphQLError } from '@graphql-tools/utils';
+
+// data fixtures
+const products = [
+  { upc: '1', name: 'iPhone', price: 699.99, manufacturerId: '1' },
+  { upc: '2', name: 'Apple Watch', price: 399.99, manufacturerId: '1' },
+  { upc: '3', name: 'Super Baking Cookbook', price: 15.99, manufacturerId: '2' },
+  { upc: '4', name: 'Best Selling Novel', price: 7.99, manufacturerId: '2' },
+  { upc: '5', name: 'iOS Survival Guide', price: 24.99, manufacturerId: '1' },
+];
+
+export const productsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Product {
+      manufacturer: Manufacturer
+      name: String!
+      price: Float!
+      upc: ID!
+    }
+
+    type Manufacturer {
+      id: ID!
+      products: [Product]!
+    }
+
+    type Query {
+      product(upc: ID!): Product
+      _manufacturer(id: ID!): Manufacturer
+    }
+  `,
+  resolvers: {
+    Query: {
+      product: (root, { upc }) =>
+        products.find(p => p.upc === upc) ||
+        createGraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+      _manufacturer: (root, { id }) => ({
+        id,
+        products: products.filter(p => p.manufacturerId === id),
+      }),
+    },
+    Product: {
+      manufacturer: product => ({ id: product.manufacturerId }),
+    },
+    Manufacturer: {
+      products: manufacturer => products.filter(p => p.manufacturerId === manufacturer.id),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-single-records/services/storefronts.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-single-records/services/storefronts.ts
@@ -1,0 +1,40 @@
+import { GraphQLError } from 'graphql';
+import { createSchema } from 'graphql-yoga';
+
+// data fixtures
+const storefronts = [
+  { id: '1', name: 'eShoppe', productUpcs: ['1', '2'] },
+  { id: '2', name: 'BestBooks Online', productUpcs: ['3', '4', '5'] },
+];
+
+export const storefrontsSchema = createSchema({
+  typeDefs: /* GraphQL */ `
+    type Storefront {
+      id: ID!
+      name: String!
+      products: [Product]!
+    }
+
+    type Product {
+      upc: ID!
+    }
+
+    type Query {
+      storefront(id: ID!): Storefront
+    }
+  `,
+  resolvers: {
+    Query: {
+      storefront: (root, { id }) =>
+        storefronts.find(s => s.id === id) ||
+        new GraphQLError('Record not found', {
+          extensions: {
+            code: 'NOT_FOUND',
+          },
+        }),
+    },
+    Storefront: {
+      products: storefront => storefront.productUpcs.map(upc => ({ upc })),
+    },
+  },
+});

--- a/packages/fusion/execution/tests/cases/type-merging-single-records/type-merging-single-records.spec.ts
+++ b/packages/fusion/execution/tests/cases/type-merging-single-records/type-merging-single-records.spec.ts
@@ -1,0 +1,176 @@
+import { parse, print } from 'graphql';
+import { composeSubgraphs } from '@graphql-mesh/fusion-composition';
+import { getExecutorForFusiongraph } from '@graphql-mesh/fusion-runtime';
+import { createBatchingExecutor } from '@graphql-tools/batch-execute';
+import { createDefaultExecutor } from '@graphql-tools/delegate';
+import { Executor, printSchemaWithDirectives } from '@graphql-tools/utils';
+import { manufacturersSchema } from './services/manufacturers';
+import { productsSchema } from './services/products';
+import { storefrontsSchema } from './services/storefronts';
+
+describe('Single-record type merging', () => {
+  const fusiongraph = composeSubgraphs([
+    {
+      name: 'manufacturers',
+      schema: manufacturersSchema,
+    },
+    {
+      name: 'products',
+      schema: productsSchema,
+    },
+    {
+      name: 'storefronts',
+      schema: storefrontsSchema,
+    },
+  ]);
+  it('composes the schema correctly', () => {
+    expect(printSchemaWithDirectives(fusiongraph)).toMatchSnapshot();
+  });
+  let cnt = 0;
+  const { fusiongraphExecutor } = getExecutorForFusiongraph({
+    fusiongraph,
+    transports() {
+      return {
+        getSubgraphExecutor({ subgraphName }) {
+          switch (subgraphName) {
+            case 'manufacturers':
+              return createDefaultExecutor(manufacturersSchema);
+            case 'products':
+              const productsExecutor = createDefaultExecutor(productsSchema);
+              const wrappedProductExecutor: Executor = function wrappedProductExecutor(...args) {
+                cnt++;
+                return productsExecutor(...args);
+              };
+              return createBatchingExecutor(wrappedProductExecutor);
+            case 'storefronts':
+              return createDefaultExecutor(storefrontsSchema);
+          }
+        },
+      };
+    },
+  });
+  it('example query', async () => {
+    const result = await fusiongraphExecutor({
+      document: parse(/* GraphQL */ `
+        query {
+          storefront(id: "2") {
+            id
+            name
+            products {
+              upc
+              name
+              manufacturer {
+                products {
+                  upc
+                  name
+                }
+                name
+              }
+            }
+          }
+        }
+      `),
+    });
+    expect(result).toEqual({
+      data: {
+        storefront: {
+          id: '2',
+          name: 'BestBooks Online',
+          products: [
+            {
+              manufacturer: {
+                name: 'Macmillan',
+                products: [
+                  {
+                    name: 'Super Baking Cookbook',
+                    upc: '3',
+                  },
+                  {
+                    name: 'Best Selling Novel',
+                    upc: '4',
+                  },
+                ],
+              },
+              name: 'Super Baking Cookbook',
+              upc: '3',
+            },
+            {
+              manufacturer: {
+                name: 'Macmillan',
+                products: [
+                  {
+                    name: 'Super Baking Cookbook',
+                    upc: '3',
+                  },
+                  {
+                    name: 'Best Selling Novel',
+                    upc: '4',
+                  },
+                ],
+              },
+              name: 'Best Selling Novel',
+              upc: '4',
+            },
+            {
+              manufacturer: {
+                name: 'Apple',
+                products: [
+                  {
+                    name: 'iPhone',
+                    upc: '1',
+                  },
+                  {
+                    name: 'Apple Watch',
+                    upc: '2',
+                  },
+                  {
+                    name: 'iOS Survival Guide',
+                    upc: '5',
+                  },
+                ],
+              },
+              name: 'iOS Survival Guide',
+              upc: '5',
+            },
+          ],
+        },
+      },
+    });
+  });
+  it('should batch', async () => {
+    const result = await fusiongraphExecutor({
+      document: parse(/* GraphQL */ `
+        query {
+          storefront(id: "2") {
+            products {
+              upc
+              name
+            }
+          }
+        }
+      `),
+    });
+    expect(result).toEqual({
+      data: {
+        storefront: {
+          products: [
+            {
+              name: 'Super Baking Cookbook',
+              upc: '3',
+            },
+            {
+              name: 'Best Selling Novel',
+              upc: '4',
+            },
+            {
+              name: 'iOS Survival Guide',
+              upc: '5',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(cnt).toBe(1);
+  });
+});


### PR DESCRIPTION
This PR migrates the tests from Schema Stitching repository to cover the query planning and execution cases that Stitching already covers.

- [ ] Single Record Type Merging
   - It sends an extra request which should be deduplicated by batching
- [ ] Computed Fields
   - It cannot plan the query because of the interfaces
- [ ] Array-batched type merging
   - The query planner doesn't show the batched paths correctly
   - The error messages have the wrong path
- [ ] Cross-service interfaces
  - The query planner fails when there are both shared fields and type-specific fields inside the field which has a return type of an interface
- [ ] Type Merging with multiple keys
  - When a type needs to be resolved with a key that doesn't exist in the parent subgraph, it should fetch that key from another subgraph.
- [ ] Nullable merges
 - If a field is unable to resolve, the field should be null not undefined.