### PR TITLE
Test if serve command takes the artifacts or CDN

### DIFF
--- a/examples/federation-example/tests/polling.test.ts
+++ b/examples/federation-example/tests/polling.test.ts
@@ -43,6 +43,7 @@ describe('Polling Test', () => {
         }
       });
     });
+    changedSupergraph = true;
     const serveCmd = exec(`${join(__dirname, '../node_modules/.bin/mesh')} start`, {
       cwd,
       env: {
@@ -92,13 +93,13 @@ describe('Polling Test', () => {
               name: 'users',
             },
             {
-              name: 'topProducts',
+              name: 'topProductsNew',
             },
           ],
         },
       },
     });
-    changedSupergraph = true;
+    changedSupergraph = false;
     await new Promise(resolve => setTimeout(resolve, 3000));
     const resp2 = await fetch('http://127.0.0.1:4000/graphql', {
       method: 'POST',
@@ -132,7 +133,7 @@ describe('Polling Test', () => {
               name: 'users',
             },
             {
-              name: 'topProductsNew',
+              name: 'topProducts',
             },
           ],
         },


### PR DESCRIPTION
Related #6840 

First, the artifacts are built with the schema that has `topProducts` field here;
https://github.com/ardatan/graphql-mesh/pull/6859/files#diff-a331722228db3639d2070880786a8f657c2b13b1a23dcc67dcf4b2327a8fee40R38
Then, the field is renamed to `topProductsNew`, and `mesh start` runs after here;
https://github.com/ardatan/graphql-mesh/pull/6859/files#diff-a331722228db3639d2070880786a8f657c2b13b1a23dcc67dcf4b2327a8fee40R47
We have checked the introspection of initial run here;
https://github.com/ardatan/graphql-mesh/pull/6859/files#diff-a331722228db3639d2070880786a8f657c2b13b1a23dcc67dcf4b2327a8fee40R64
You can see it has `topProductsNew` as in the schema from the initial run but different then built artifacts;
https://github.com/ardatan/graphql-mesh/pull/6859/files#diff-a331722228db3639d2070880786a8f657c2b13b1a23dcc67dcf4b2327a8fee40R96
After that, polling is done then `topProductsNew` becomes `topProducts` again;
https://github.com/ardatan/graphql-mesh/pull/6859/files#diff-a331722228db3639d2070880786a8f657c2b13b1a23dcc67dcf4b2327a8fee40R104

This shows, it works correctly in contrast to the issue
