### PR TITLE
allow to configure the yoga landing page display

### DIFF
--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -165,6 +165,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     graphqlEndpoint: config.graphqlEndpoint,
     maskedErrors: config.maskedErrors,
     healthCheckEndpoint: config.healthCheckEndpoint || '/healthcheck',
+    landingPage: config.landingPage,
   });
 
   fetchAPI ||= yoga.fetchAPI;

--- a/packages/serve-runtime/src/types.ts
+++ b/packages/serve-runtime/src/types.ts
@@ -143,6 +143,10 @@ interface MeshServeConfigWithoutSource<TContext extends Record<string, any>> {
    */
   graphiql?: YogaServerOptions<unknown, MeshServeContext & TContext>['graphiql'];
   /**
+   * Whether the landing page should be shown.
+   */
+  landingPage?: boolean;
+  /**
    * Enable and define a limit for [Request Batching](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md).
    */
   batching?: BatchingOptions;


### PR DESCRIPTION
## Description

Yoga by default displays a landing page on the root path `/`. This can be disabled in yoga options, but the options was not added to mesh config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)