### PR TITLE
feat(cli/http): customize health check endpoint

### DIFF
--- a/.changeset/forty-drinks-carry.md
+++ b/.changeset/forty-drinks-carry.md
@@ -1,0 +1,16 @@
+---
+"@graphql-mesh/types": patch
+"@graphql-mesh/http": patch
+"@graphql-mesh/cli": patch
+---
+
+Previously GraphQL Yoga also had a health check endpoint in `/health` path while Mesh's health check endpoint is `/healthcheck`. Now they are both aligned.
+Also now you can customize the health check endpoint within Mesh Configuration using `serve.healthCheckEndpoint` key. Default value is `/healthcheck.
+
+```yaml
+serve:
+  healthCheckEndpoint: /health
+```
+
+**Action Required:**
+If you are using GraphQL Yoga's endpoint `/health`, instead of `/healthcheck`, you should update your health check endpoint to `/health` in the configuration like above to keep the behavior.

--- a/packages/legacy/cli/src/commands/serve/yaml-config.graphql
+++ b/packages/legacy/cli/src/commands/serve/yaml-config.graphql
@@ -66,6 +66,10 @@ type ServeConfig @md {
   Enable and define a limit for [Request Batching](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md)
   """
   batchingLimit: Int
+  """
+  Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)
+  """
+  healthCheckEndpoint: String
 }
 
 union Port = Int | String

--- a/packages/legacy/http/src/graphqlHandler.ts
+++ b/packages/legacy/http/src/graphqlHandler.ts
@@ -9,6 +9,7 @@ export const graphqlHandler = ({
   graphqlEndpoint,
   corsConfig,
   batchingLimit,
+  healthCheckEndpoint = '/healthcheck',
 }: {
   getBuiltMesh: () => Promise<MeshInstance>;
   playgroundTitle: string;
@@ -16,6 +17,7 @@ export const graphqlHandler = ({
   graphqlEndpoint: string;
   corsConfig: CORSOptions;
   batchingLimit?: number;
+  healthCheckEndpoint?: string;
 }) => {
   const getYogaForMesh = memoize1(function getYogaForMesh(mesh: MeshInstance) {
     return createYoga({
@@ -39,6 +41,7 @@ export const graphqlHandler = ({
       graphqlEndpoint,
       landingPage: false,
       batching: batchingLimit ? { limit: batchingLimit } : false,
+      healthCheckEndpoint,
     });
   });
   return (request: Request, ctx: any) =>

--- a/packages/legacy/http/src/index.ts
+++ b/packages/legacy/http/src/index.ts
@@ -28,6 +28,7 @@ export function createMeshHTTPHandler<TServerContext>({
     playground: playgroundEnabled = process.env.NODE_ENV !== 'production',
     endpoint: graphqlPath = '/graphql',
     batchingLimit,
+    healthCheckEndpoint = '/healthcheck',
     // TODO
     // trustProxy = 'loopback',
   } = rawServeConfig;
@@ -55,7 +56,7 @@ export function createMeshHTTPHandler<TServerContext>({
         {
           onRequest({ request, url, endResponse }): void | Promise<void> {
             switch (url.pathname) {
-              case '/healthcheck':
+              case healthCheckEndpoint:
                 endResponse(
                   new Response(null, {
                     status: 200,

--- a/packages/legacy/http/test/http.spec.ts
+++ b/packages/legacy/http/test/http.spec.ts
@@ -23,4 +23,41 @@ describe('http', () => {
   afterEach(() => {
     mesh.destroy();
   });
+  describe('health check', () => {
+    it('should return 200', async () => {
+      const httpHandler = createMeshHTTPHandler({
+        baseDir: __dirname,
+        getBuiltMesh: async () => mesh,
+      });
+      const response = await httpHandler.fetch('http://localhost:4000/healthcheck');
+      expect(response.status).toBe(200);
+    });
+    it('should return 503 when not ready', async () => {
+      let resolve: VoidFunction;
+      const readyPromise = new Promise<void>(r => {
+        resolve = r;
+      });
+      const httpHandler = createMeshHTTPHandler({
+        baseDir: __dirname,
+        getBuiltMesh: async () => {
+          await readyPromise;
+          return mesh;
+        },
+      });
+      const response = await httpHandler.fetch('http://localhost:4000/readiness');
+      expect(response.status).toBe(503);
+      resolve();
+    });
+    it('should be able to customize health check endpoint', async () => {
+      const httpHandler = createMeshHTTPHandler({
+        baseDir: __dirname,
+        getBuiltMesh: async () => mesh,
+        rawServeConfig: {
+          healthCheckEndpoint: '/custom-health-check',
+        },
+      });
+      const response = await httpHandler.fetch('http://localhost:4000/custom-health-check');
+      expect(response.status).toBe(200);
+    });
+  });
 });

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -169,6 +169,10 @@
         "batchingLimit": {
           "type": "integer",
           "description": "Enable and define a limit for [Request Batching](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md)"
+        },
+        "healthCheckEndpoint": {
+          "type": "string",
+          "description": "Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)"
         }
       }
     },

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -121,6 +121,10 @@ export interface ServeConfig {
    * Enable and define a limit for [Request Batching](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md)
    */
   batchingLimit?: number;
+  /**
+   * Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)
+   */
+  healthCheckEndpoint?: string;
 }
 /**
  * Configuration for CORS

--- a/website/src/generated-markdown/ServeConfig.generated.md
+++ b/website/src/generated-markdown/ServeConfig.generated.md
@@ -29,3 +29,4 @@ This feature can be disabled by passing `false` One of:
 * `trustProxy` (type: `String`) - Configure Express Proxy Handling
 [Learn more](https://expressjs.com/en/guide/behind-proxies.html)
 * `batchingLimit` (type: `Int`) - Enable and define a limit for [Request Batching](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md)
+* `healthCheckEndpoint` (type: `String`) - Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)


### PR DESCRIPTION
Closes #6455 

Previously GraphQL Yoga also had a health check endpoint in `/health` path while Mesh's health check endpoint is `/healthcheck`. Now they are both aligned.
Also now you can customize the health check endpoint within Mesh Configuration using `serve.healthCheckEndpoint` key. Default value is `/healthcheck.

```yaml
serve:
  healthCheckEndpoint: /health
```

**Action Required:**
If you are using GraphQL Yoga's endpoint `/health`, instead of `/healthcheck`, you should update your health check endpoint to `/health` in the configuration like above to keep the behavior.