### PR TITLE
fix context undefined in useResponseCache ifDef enabled fn

### DIFF
--- a/.changeset/tidy-seahorses-bake.md
+++ b/.changeset/tidy-seahorses-bake.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/plugin-response-cache": patch
+---
+
+fix to ensure graphql request context is available within response cache if configuration definition

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -22,7 +22,7 @@ function generateSessionIdFactory(sessionIdDef: string) {
 function generateEnabledFactory(ifDef: string) {
   return function enabled(context: any) {
     // eslint-disable-next-line no-new-func
-    return new Function(`return ${ifDef}`)();
+    return new Function(["context"], `return ${ifDef}`)(context);
   };
 }
 

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -22,7 +22,7 @@ function generateSessionIdFactory(sessionIdDef: string) {
 function generateEnabledFactory(ifDef: string) {
   return function enabled(context: any) {
     // eslint-disable-next-line no-new-func
-    return new Function("context", `return ${ifDef}`)(context);
+    return new Function('context', `return ${ifDef}`)(context);
   };
 }
 

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -22,7 +22,7 @@ function generateSessionIdFactory(sessionIdDef: string) {
 function generateEnabledFactory(ifDef: string) {
   return function enabled(context: any) {
     // eslint-disable-next-line no-new-func
-    return new Function(["context"], `return ${ifDef}`)(context);
+    return new Function("context", `return ${ifDef}`)(context);
   };
 }
 


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Conntext not available when evaluating responseCache if function. Reason is that javascript function constructor does not inherit lexical scope. Instead we must pass the context as a named arg.

Fixes #6925 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
