### PR TITLE
Make schema generation consistent

### DIFF
--- a/.changeset/few-teachers-do.md
+++ b/.changeset/few-teachers-do.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/runtime": patch
+---
+
+Make schema generation consistent

--- a/examples/json-schema-covid/tests/__snapshots__/json-schema-covid.test.ts.snap
+++ b/examples/json-schema-covid/tests/__snapshots__/json-schema-covid.test.ts.snap
@@ -137,7 +137,6 @@ scalar JSON
 
 scalar ObjMap
 
-""""""
 type Query {
   """"""
   case(countryRegion: String): Case

--- a/packages/legacy/runtime/src/get-mesh.ts
+++ b/packages/legacy/runtime/src/get-mesh.ts
@@ -168,7 +168,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
   ];
   const wrappedFetchFn: MeshFetch = wrapFetchWithPlugins(initialPluginList);
   await Promise.allSettled(
-    sources.map(async apiSource => {
+    sources.map(async (apiSource, index) => {
       const apiName = apiSource.name;
       const sourceLogger = logger.child(apiName);
       sourceLogger.debug(`Generating the schema`);
@@ -199,7 +199,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
         }
 
         const rootTypeMap = getRootTypeMap(apiSchema);
-        rawSources.push({
+        rawSources[index] = {
           name: apiName,
           schema: apiSchema,
           executor: source.executor,
@@ -209,7 +209,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
           batch: 'batch' in source ? source.batch : true,
           merge: source.merge,
           createProxyingResolver: createProxyingResolverFactory(apiName, rootTypeMap),
-        });
+        };
       } catch (e: any) {
         sourceLogger.error(
           `Failed to generate the schema for the source "${apiName}"\n ${e.message}`,

--- a/packages/legacy/runtime/test/getMesh.test.ts
+++ b/packages/legacy/runtime/test/getMesh.test.ts
@@ -335,7 +335,7 @@ describe('getMesh', () => {
         suffixRootTypeNames: true,
         suffixFieldNames: true,
         suffixResponses: true,
-        delayFetch: true,
+        delayImport: true,
       }),
       ...new Array(2).fill(0).map((_, i) =>
         createGraphQLSource({

--- a/packages/legacy/runtime/test/getMesh.test.ts
+++ b/packages/legacy/runtime/test/getMesh.test.ts
@@ -39,6 +39,7 @@ describe('getMesh', () => {
     suffixRootTypeNames: boolean;
     suffixFieldNames: boolean;
     suffixResponses: boolean;
+    delayImport?: boolean;
   }
 
   function createGraphQLSchema(config: CreateSchemaConfiguration) {
@@ -96,6 +97,9 @@ describe('getMesh', () => {
         store,
         logger,
         async importFn(moduleId) {
+          if (config.delayImport) {
+            await new Promise(r => setTimeout(r, 1));
+          }
           if (moduleId.endsWith(`schema${config.suffix}.ts`)) {
             return createGraphQLSchema(config);
           }
@@ -322,5 +326,70 @@ describe('getMesh', () => {
     };
     expect(serializedOriginalError?.message).toContain('This is an error');
     expect(serializedOriginalError?.stack).toContain('at Object.throwMe (');
+  });
+
+  it('generated consistent schema', async () => {
+    const sources = [
+      createGraphQLSource({
+        suffix: 'Large',
+        suffixRootTypeNames: true,
+        suffixFieldNames: true,
+        suffixResponses: true,
+        delayFetch: true,
+      }),
+      ...new Array(2).fill(0).map((_, i) =>
+        createGraphQLSource({
+          suffix: i.toString(),
+          suffixRootTypeNames: true,
+          suffixFieldNames: true,
+          suffixResponses: true,
+        }),
+      ),
+    ];
+    const mesh1 = await getMesh({
+      cache,
+      pubsub,
+      logger,
+      sources,
+      merger,
+    });
+
+    const mesh2 = await getMesh({
+      cache,
+      pubsub,
+      logger,
+      sources,
+      merger,
+    });
+
+    expect(printSchemaWithDirectives(mesh1.schema)).toEqual(
+      printSchemaWithDirectives(mesh2.schema),
+    );
+
+    expect(printSchemaWithDirectives(mesh1.schema)).toMatchInlineSnapshot(`
+      "schema {
+        query: Query
+        mutation: Mutation
+        subscription: Subscription
+      }
+
+      type Query {
+        helloLarge: String
+        hello0: String
+        hello1: String
+      }
+
+      type Mutation {
+        byeLarge: String
+        bye0: String
+        bye1: String
+      }
+
+      type Subscription {
+        waveLarge: String
+        wave0: String
+        wave1: String
+      }"
+    `);
   });
 });


### PR DESCRIPTION
## Description

This makes generated schema deterministic, as it will always be ordered in the same way as the schemas passed to .meshrc.

Fixes #6947 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Previously:

https://github.com/ardatan/graphql-mesh/assets/5903616/8238c75d-9935-4874-8bd1-b729ce78b163

After

https://github.com/ardatan/graphql-mesh/assets/5903616/4950a55a-c2d4-4f7d-ad79-fd796635f9da


## How Has This Been Tested?

- [ ] getMesh.test.ts > generated consistent schema

**Test Environment**:

- OS: MacOS
- `@graphql-mesh/...`: runtime
- NodeJS: 21.x

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I don't think this is a breaking change - using index in this way will generate a consistent result. If one of the schema generation fails, the whole function throws an error, so the case of the array having undefined values is not possible.
