### PR TITLE
SOAP: Support more numeric types, handle enums better and support nonprefixed namespaces

### DIFF
--- a/.changeset/afraid-dancers-nail.md
+++ b/.changeset/afraid-dancers-nail.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Support documents without any prefixes on W3 definitions like `xsd` etc

--- a/.changeset/afraid-dancers-nail.md
+++ b/.changeset/afraid-dancers-nail.md
@@ -2,4 +2,19 @@
 "@omnigraph/soap": patch
 ---
 
-Support documents without any prefixes on W3 definitions like `xsd` etc
+Support documents without any prefixes on W3 definitions like `xs` etc.
+
+WSDL definitions might not have any prefix for W3 definitions as in here;
+```xml
+<xs:schema />
+```
+Unlike this one;
+```xml
+<schema />
+```
+
+Both are supported, previously it was throwing while looking for a namespace prefix for W3. Now it considers W3 to be the default/global namespace if there is no explicit prefix for it in the document.
+
+```xml
+<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+```

--- a/.changeset/proud-spoons-matter.md
+++ b/.changeset/proud-spoons-matter.md
@@ -2,4 +2,7 @@
 "@omnigraph/soap": patch
 ---
 
-Support new numeric types; `integer`, `negativeInteger`, `nonNegativeInteger`, `nonPositiveInteger` and `positiveInteger`
+Support new numeric types; `integer`, `negativeInteger`, `nonNegativeInteger`, `nonPositiveInteger` and `positiveInteger` as scalar types
+
+See all the numeric types in SOAP;
+https://www.w3schools.com/xml/schema_dtypes_numeric.asp

--- a/.changeset/proud-spoons-matter.md
+++ b/.changeset/proud-spoons-matter.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Support new numeric types; `integer`, `negativeInteger`, `nonNegativeInteger`, `nonPositiveInteger` and `positiveInteger`

--- a/.changeset/shy-snakes-swim.md
+++ b/.changeset/shy-snakes-swim.md
@@ -2,4 +2,5 @@
 "@omnigraph/soap": patch
 ---
 
-Support extended enum types
+Support extended enum types, before it was supporting `string` only but it might be other types of enums which are not string.
+In GraphQL, there is not such a thing like `Enum<T>` so all enums are just enums.

--- a/.changeset/shy-snakes-swim.md
+++ b/.changeset/shy-snakes-swim.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/soap": patch
+---
+
+Support extended enum types

--- a/packages/loaders/soap/src/SOAPLoader.ts
+++ b/packages/loaders/soap/src/SOAPLoader.ts
@@ -27,6 +27,10 @@ import {
   GraphQLDateTime,
   GraphQLDuration,
   GraphQLHexadecimal,
+  GraphQLNegativeInt,
+  GraphQLNonNegativeInt,
+  GraphQLNonPositiveInt,
+  GraphQLPositiveInt,
   GraphQLTime,
   GraphQLUnsignedInt,
   GraphQLURL,
@@ -154,6 +158,11 @@ export class SOAPLoader {
       ['duration', GraphQLDuration],
       ['float', GraphQLFloat],
       ['int', GraphQLInt],
+      ['integer', GraphQLInt],
+      ['negativeInteger', GraphQLNegativeInt],
+      ['nonNegativeInteger', GraphQLNonNegativeInt],
+      ['nonPositiveInteger', GraphQLNonPositiveInt],
+      ['positiveInteger', GraphQLPositiveInt],
       ['hexBinary', GraphQLHexadecimal],
       ['long', GraphQLBigInt],
       ['gDay', GraphQLString],
@@ -330,7 +339,8 @@ export class SOAPLoader {
       definition.attributes.name ||
       [...definitionAliasMap.entries()].find(
         ([, namespace]) => namespace === definitionNamespace,
-      )[0];
+      )?.[0] ||
+      '';
     this.namespaceTypePrefixMap.set(definition.attributes.targetNamespace, typePrefix);
     if (definition.import) {
       for (const importObj of definition.import) {
@@ -573,7 +583,7 @@ export class SOAPLoader {
       const simpleTypeName = simpleType.attributes.name;
       const restrictionObj = simpleType.restriction[0];
       const prefix = this.namespaceTypePrefixMap.get(simpleTypeNamespace);
-      if (restrictionObj.attributes.base === 'string' && restrictionObj.enumeration) {
+      if (restrictionObj.enumeration) {
         const enumTypeName = `${prefix}_${simpleTypeName}`;
         const values: Record<string, Readonly<EnumTypeComposerValueConfigDefinition>> = {};
         for (const enumerationObj of restrictionObj.enumeration) {

--- a/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
+++ b/packages/loaders/soap/test/__snapshots__/examples.test.ts.snap
@@ -1,5 +1,124 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Examples should generate schema for axis: axis 1`] = `
+"directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String) on FIELD_DEFINITION
+
+type Query {
+  placeholder: Void
+}
+
+"""Represents NULL values"""
+scalar Void
+
+type Mutation {
+  impl_TestService_TestService_createTest(createTestRequest: impl_createTestRequestType_Input): impl_createTestResponseType
+}
+
+type impl_createTestResponseType {
+  name: String!
+  intCount: Int!
+  integerCount: Int!
+  doubleCount: Float!
+  floatCount: Float!
+  longCount: BigInt!
+  shortCount: Int!
+  unsignedIntCount: UnsignedInt!
+  unsignedLongCount: BigInt!
+  unsignedShortCount: UnsignedInt!
+  unsignedByteField: Byte!
+  booleanField: Boolean!
+  byteField: Byte!
+  dateField: Date!
+  dateTimeField: DateTime!
+  decimalField: Float!
+  nonNegIntField: NonNegativeInt!
+  nonPosIntField: NonPositiveInt!
+  posIntField: PositiveInt!
+  negIntField: NegativeInt!
+  weekday: impl_weekday!
+  status: impl_testStatusInfoType!
+  weekdays: impl_weekDays!
+}
+
+"""
+The \`BigInt\` scalar type represents non-fractional signed whole numeric values.
+"""
+scalar BigInt
+
+"""Integers that will have a value of 0 or more."""
+scalar UnsignedInt
+
+"""The \`Byte\` scalar type represents byte value as a Buffer"""
+scalar Byte
+
+"""
+A date string, such as 2007-12-03, compliant with the \`full-date\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar Date
+
+"""
+A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
+"""
+scalar DateTime
+
+"""Integers that will have a value of 0 or more."""
+scalar NonNegativeInt
+
+"""Integers that will have a value of 0 or less."""
+scalar NonPositiveInt
+
+"""Integers that will have a value greater than 0."""
+scalar PositiveInt
+
+"""Integers that will have a value less than 0."""
+scalar NegativeInt
+
+enum impl_weekday {
+  MONDAY
+  TUESDAY
+  WEDNESDAY
+  THURSDAY
+  FRIDAY
+}
+
+type impl_testStatusInfoType {
+  status: String!
+}
+
+type impl_weekDays {
+  option: [impl_weekday]!
+}
+
+input impl_createTestRequestType_Input {
+  name: String
+  intCount: Int
+  integerCount: Int
+  doubleCount: Float
+  floatCount: Float
+  longCount: BigInt
+  shortCount: Int
+  unsignedIntCount: UnsignedInt
+  unsignedLongCount: BigInt
+  unsignedShortCount: UnsignedInt
+  unsignedByteField: Byte
+  booleanField: Boolean
+  byteField: Byte
+  dateField: Date
+  dateTimeField: DateTime
+  decimalField: Float
+  nonNegIntField: NonNegativeInt
+  nonPosIntField: NonPositiveInt
+  posIntField: PositiveInt
+  negIntField: NegativeInt
+  weekday: impl_weekday
+  weekdays: impl_weekDays_Input
+}
+
+input impl_weekDays_Input {
+  option: [impl_weekday]
+}"
+`;
+
 exports[`Examples should generate schema for example1: example1 1`] = `
 "directive @soap(elementName: String, bindingNamespace: String, endpoint: String, subgraph: String) on FIELD_DEFINITION
 
@@ -44,7 +163,7 @@ input TodoService_UpdateFileClass_Input {
 }
 
 input tns_FileClass_Input {
-  Mode: String
+  Mode: tns_EntityMode
   ClassIntID: BigInt
   CreatedBy: String
   CreatedDtTm: DateTime
@@ -52,9 +171,16 @@ input tns_FileClass_Input {
   LastUpdatedBy: String
   LastUpdatedDtTm: DateTime
   Name: String
-  PeriodType: String
+  PeriodType: tns_PeriodType
   Retention: Int
   Timestamp: Byte
+}
+
+enum tns_EntityMode {
+  New
+  Deleted
+  Changed
+  Unchanged
 }
 
 """
@@ -66,6 +192,13 @@ scalar BigInt
 A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
 """
 scalar DateTime
+
+enum tns_PeriodType {
+  Days
+  Weeks
+  Months
+  Years
+}
 
 """The \`Byte\` scalar type represents byte value as a Buffer"""
 scalar Byte
@@ -147,7 +280,7 @@ type AdminServiceType_GetFileClassByClassIDResponse {
 }
 
 type tns_FileClass {
-  Mode: String!
+  Mode: tns_EntityMode!
   ClassIntID: BigInt!
   CreatedBy: String!
   CreatedDtTm: DateTime!
@@ -158,12 +291,19 @@ type tns_FileClass {
   LastUpdatedDtTm: DateTime!
   Name: String!
   NeedANotification: Boolean!
-  PeriodType: String!
+  PeriodType: tns_PeriodType!
   PreventPublishFlg: Boolean!
   Retention: Int!
   RetentionChanged: String!
   Subclasses: tns_FileSubclassList!
   Timestamp: Byte!
+}
+
+enum tns_EntityMode {
+  New
+  Deleted
+  Changed
+  Unchanged
 }
 
 """
@@ -176,12 +316,28 @@ type tns_EntityClassList {
 }
 
 type tns_EntityClass {
-  Mode: String!
+  Mode: tns_EntityMode!
   ClassIntID: BigInt!
   EntityClassIntID: BigInt!
   EntityIntID: BigInt!
-  EntityType: String!
+  EntityType: tns_EntityType!
   FirmIntID: BigInt!
+}
+
+enum tns_EntityType {
+  Firm
+  Office
+  Staff
+  StaffList
+  BusinessUnit
+  Client
+  ClientList
+  DocumentEntityType
+  OtherClient
+  ClientOtherEntity
+  OfficeBusinessUnit
+  NonClient
+  NonClientList
 }
 
 """
@@ -189,21 +345,28 @@ A field whose value matches /[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-
 """
 scalar tns_guid
 
+enum tns_PeriodType {
+  Days
+  Weeks
+  Months
+  Years
+}
+
 type tns_FileSubclassList {
   FileSubclass: [tns_FileSubclass]!
 }
 
 type tns_FileSubclass {
-  Mode: String!
+  Mode: tns_EntityMode!
   ClassIntID: BigInt!
   CreatedBy: String!
   CreatedDtTm: DateTime!
-  EffectivePeriodType: String!
+  EffectivePeriodType: tns_PeriodType!
   EffectiveRetention: Int!
   LastUpdatedBy: String!
   LastUpdatedDtTm: DateTime!
   Name: String!
-  PeriodType: String!
+  PeriodType: tns_PeriodType!
   Permanent: Boolean!
   Retention: Int!
   RetentionChanged: String!
@@ -242,7 +405,7 @@ input AdminServiceType_CreateFileClass_Input {
 }
 
 input tns_FileClass_Input {
-  Mode: String
+  Mode: tns_EntityMode
   ClassIntID: BigInt
   CreatedBy: String
   CreatedDtTm: DateTime
@@ -253,7 +416,7 @@ input tns_FileClass_Input {
   LastUpdatedDtTm: DateTime
   Name: String
   NeedANotification: Boolean
-  PeriodType: String
+  PeriodType: tns_PeriodType
   PreventPublishFlg: Boolean
   Retention: Int
   RetentionChanged: String
@@ -266,11 +429,11 @@ input tns_EntityClassList_Input {
 }
 
 input tns_EntityClass_Input {
-  Mode: String
+  Mode: tns_EntityMode
   ClassIntID: BigInt
   EntityClassIntID: BigInt
   EntityIntID: BigInt
-  EntityType: String
+  EntityType: tns_EntityType
   FirmIntID: BigInt
 }
 
@@ -279,16 +442,16 @@ input tns_FileSubclassList_Input {
 }
 
 input tns_FileSubclass_Input {
-  Mode: String
+  Mode: tns_EntityMode
   ClassIntID: BigInt
   CreatedBy: String
   CreatedDtTm: DateTime
-  EffectivePeriodType: String
+  EffectivePeriodType: tns_PeriodType
   EffectiveRetention: Int
   LastUpdatedBy: String
   LastUpdatedDtTm: DateTime
   Name: String
-  PeriodType: String
+  PeriodType: tns_PeriodType
   Permanent: Boolean
   Retention: Int
   RetentionChanged: String

--- a/packages/loaders/soap/test/examples.test.ts
+++ b/packages/loaders/soap/test/examples.test.ts
@@ -7,7 +7,7 @@ import { SOAPLoader } from '../src/index.js';
 
 const { readFile } = promises;
 
-const examples = ['example1', 'example2'];
+const examples = ['example1', 'example2', 'axis'];
 
 describe('Examples', () => {
   examples.forEach(example => {

--- a/packages/loaders/soap/test/fixtures/axis.wsdl
+++ b/packages/loaders/soap/test/fixtures/axis.wsdl
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="urn:com.guild:operations/test" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="urn:com.guild:operations/test" xmlns:intf="urn:com.guild:operations/test" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<!--WSDL created by Apache Axis version: 1.4
+Built on Apr 22, 2006 (06:55:48 PDT)-->
+ <wsdl:types>
+  <schema elementFormDefault="qualified" targetNamespace="urn:com.guild:operations/test" xmlns="http://www.w3.org/2001/XMLSchema">
+   <simpleType name="weekday">
+    <restriction base="xsd:NMTOKEN">
+     <enumeration value="MONDAY"/>
+     <enumeration value="TUESDAY"/>
+     <enumeration value="WEDNESDAY"/>
+     <enumeration value="THURSDAY"/>
+     <enumeration value="FRIDAY"/>
+    </restriction>
+   </simpleType>
+   <complexType name="weekDays">
+    <sequence>
+     <element maxOccurs="unbounded" minOccurs="0" name="option" type="impl:weekday"/>
+    </sequence>
+   </complexType>
+   <complexType name="createTestRequestType">
+    <sequence>
+     <element maxOccurs="1" minOccurs="0" name="name" type="xsd:string"/>
+     <element maxOccurs="1" minOccurs="0" name="intCount" type="xsd:int"/>
+     <element maxOccurs="1" minOccurs="0" name="integerCount" type="xsd:integer"/>
+     <element maxOccurs="1" minOccurs="0" name="doubleCount" type="xsd:double"/>
+     <element maxOccurs="1" minOccurs="0" name="floatCount" type="xsd:float"/>
+     <element maxOccurs="1" minOccurs="0" name="longCount" type="xsd:long"/>
+     <element maxOccurs="1" minOccurs="0" name="shortCount" type="xsd:short"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedIntCount" type="xsd:unsignedInt"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedLongCount" type="xsd:unsignedLong"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedShortCount" type="xsd:unsignedShort"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedByteField" type="xsd:unsignedByte"/>
+     <element maxOccurs="1" minOccurs="0" name="booleanField" type="xsd:boolean"/>
+     <element maxOccurs="1" minOccurs="0" name="byteField" type="xsd:byte"/>
+     <element maxOccurs="1" minOccurs="0" name="dateField" type="xsd:date"/>
+     <element maxOccurs="1" minOccurs="0" name="dateTimeField" type="xsd:dateTime"/>
+     <element maxOccurs="1" minOccurs="0" name="decimalField" type="xsd:decimal"/>
+     <element maxOccurs="1" minOccurs="0" name="nonNegIntField" type="xsd:nonNegativeInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="nonPosIntField" type="xsd:nonPositiveInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="posIntField" type="xsd:positiveInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="negIntField" type="xsd:negativeInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="weekday" type="impl:weekday"/>
+     <element maxOccurs="1" minOccurs="0" name="weekdays" type="impl:weekDays"/>
+    </sequence>
+   </complexType>
+   <element name="createTestRequest" type="impl:createTestRequestType"/>
+   <complexType name="testStatusInfoType">
+    <sequence>
+     <element maxOccurs="1" minOccurs="0" name="status" type="xsd:string"/>
+    </sequence>
+   </complexType>
+   <complexType name="createTestResponseType">
+    <sequence>
+     <element maxOccurs="1" minOccurs="0" name="name" type="xsd:string"/>
+     <element maxOccurs="1" minOccurs="0" name="intCount" type="xsd:int"/>
+     <element maxOccurs="1" minOccurs="0" name="integerCount" type="xsd:integer"/>
+     <element maxOccurs="1" minOccurs="0" name="doubleCount" type="xsd:double"/>
+     <element maxOccurs="1" minOccurs="0" name="floatCount" type="xsd:float"/>
+     <element maxOccurs="1" minOccurs="0" name="longCount" type="xsd:long"/>
+     <element maxOccurs="1" minOccurs="0" name="shortCount" type="xsd:short"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedIntCount" type="xsd:unsignedInt"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedLongCount" type="xsd:unsignedLong"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedShortCount" type="xsd:unsignedShort"/>
+     <element maxOccurs="1" minOccurs="0" name="unsignedByteField" type="xsd:unsignedByte"/>
+     <element maxOccurs="1" minOccurs="0" name="booleanField" type="xsd:boolean"/>
+     <element maxOccurs="1" minOccurs="0" name="byteField" type="xsd:byte"/>
+     <element maxOccurs="1" minOccurs="0" name="dateField" type="xsd:date"/>
+     <element maxOccurs="1" minOccurs="0" name="dateTimeField" type="xsd:dateTime"/>
+     <element maxOccurs="1" minOccurs="0" name="decimalField" type="xsd:decimal"/>
+     <element maxOccurs="1" minOccurs="0" name="nonNegIntField" type="xsd:nonNegativeInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="nonPosIntField" type="xsd:nonPositiveInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="posIntField" type="xsd:positiveInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="negIntField" type="xsd:negativeInteger"/>
+     <element maxOccurs="1" minOccurs="0" name="weekday" type="impl:weekday"/>
+     <element maxOccurs="1" minOccurs="0" name="status" type="impl:testStatusInfoType"/>
+     <element maxOccurs="1" minOccurs="0" name="weekdays" type="impl:weekDays"/>
+    </sequence>
+   </complexType>
+   <element name="createTestResponse" type="impl:createTestResponseType"/>
+  </schema>
+ </wsdl:types>
+
+   <wsdl:message name="createTestRequest">
+
+      <wsdl:part element="impl:createTestRequest" name="createTestRequest"/>
+
+   </wsdl:message>
+
+   <wsdl:message name="createTestResponse">
+
+      <wsdl:part element="impl:createTestResponse" name="createTestResponse"/>
+
+   </wsdl:message>
+
+   <wsdl:portType name="TestServiceInterface">
+
+      <wsdl:operation name="createTest" parameterOrder="createTestRequest">
+
+         <wsdl:input message="impl:createTestRequest" name="createTestRequest"/>
+
+         <wsdl:output message="impl:createTestResponse" name="createTestResponse"/>
+
+      </wsdl:operation>
+
+   </wsdl:portType>
+
+   <wsdl:binding name="TestServiceSoapBinding" type="impl:TestServiceInterface">
+
+      <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+      <wsdl:operation name="createTest">
+
+         <wsdlsoap:operation soapAction=""/>
+
+         <wsdl:input name="createTestRequest">
+
+            <wsdlsoap:body use="literal"/>
+
+         </wsdl:input>
+
+         <wsdl:output name="createTestResponse">
+
+            <wsdlsoap:body use="literal"/>
+
+         </wsdl:output>
+
+      </wsdl:operation>
+
+   </wsdl:binding>
+
+   <wsdl:service name="TestService">
+
+      <wsdl:port binding="impl:TestServiceSoapBinding" name="TestService">
+
+         <wsdlsoap:address location="http://the-guild.dev/graphql/mesh/soap/TestService"/>
+
+      </wsdl:port>
+
+   </wsdl:service>
+
+</wsdl:definitions>


### PR DESCRIPTION
- Support documents without any prefixes on W3 definitions like `xsd` etc

WSDL definitions might not have any prefix for W3 definitions as in here;
```xml
<xs:schema />
```
Unlike this one;
```xml
<schema />
```

Both are supported, previously it was throwing while looking for a namespace prefix for W3. Now it considers W3 to be the default/global namespace if there is no explicit prefix for it in the document.

```xml
<wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
```

- Support new numeric types; `integer`, `negativeInteger`, `nonNegativeInteger`, `nonPositiveInteger` and `positiveInteger`

See all the numeric types in SOAP;
https://www.w3schools.com/xml/schema_dtypes_numeric.asp

- Support extended enum types, before it was supporting `string` only but it might be other types of enums which are not string.
In GraphQL, there is not such a thing like `Enum<T>` so all enums are just enums.
