### PR TITLE
Standard error format in transports (REST, SOAP, GraphQL etc)

### DIFF
--- a/.changeset/stale-needles-invite.md
+++ b/.changeset/stale-needles-invite.md
@@ -1,0 +1,30 @@
+---
+'@graphql-mesh/transport-common': patch
+'@graphql-mesh/transport-rest': patch
+'@graphql-mesh/transport-soap': patch
+---
+
+Introduce a standard Upstream Error Format for HTTP-based sources;
+
+So all sources throw an error will have the extensions in the following format;
+
+```json
+{
+  "extensions": {
+    "request": { // The details of the request made to the upstream service
+      "endpoint": "https://api.example.com",
+      "method": "GET",
+    },
+    "response": { // The details of the HTTP response from the upstream service
+      "status": 401,
+      "statusText": "Unauthorized",
+      "headers": {
+        "content-type": "application/json"
+      },
+      "body": { // The raw body returned by the upstream service
+        "error-message": "Unauthorized access",
+      }
+    },
+  }
+}
+```

--- a/examples/openapi-location-weather/tests/__snapshots__/location-weather.test.ts.snap
+++ b/examples/openapi-location-weather/tests/__snapshots__/location-weather.test.ts.snap
@@ -1252,16 +1252,14 @@ type LightningObs {
 }
 
 type LightningObsGroup {
-  """Count of found lightning"""
+  """Count of lightning events."""
   count: Int
 
   """Latitude of point."""
   lat: Float
   lightning: [LightningObs]
 
-  """
-  Maximum number of lightning that can be returned. Either user, or system provided.
-  """
+  """Count of results in response (determined by limit parameter)."""
   limit: Int
 
   """Longitude of point."""

--- a/examples/v1-next/integrations/fastify/tests/fastify.spec.ts
+++ b/examples/v1-next/integrations/fastify/tests/fastify.spec.ts
@@ -64,15 +64,15 @@ describe('fastify', () => {
 
     const resJson = await response.json();
 
-    expect(resJson).toEqual({
+    expect(resJson).toMatchObject({
       data: { pet_by_petId: null },
       errors: [
         {
-          message: 'HTTP Error: 500, Could not invoke operation GET /pet/{args.petId}',
+          message: 'Upstream HTTP Error: 500, Could not invoke operation GET /pet/{args.petId}',
           path: ['pet_by_petId'],
           extensions: {
             request: { url: `http://localhost:${upstreamPort}/pet/pet500`, method: 'GET' },
-            responseJson: { error: 'Error' },
+            response: { body: { error: 'Error' } },
           },
         },
       ],

--- a/packages/loaders/openapi/tests/example_api.test.ts
+++ b/packages/loaders/openapi/tests/example_api.test.ts
@@ -1569,12 +1569,12 @@ describe('example_api', () => {
         method: 'GET',
         url: `http://localhost:3000/api/users/abcdef`,
       },
-      http: {
+      response: {
         status: 404,
         statusText: 'Not Found',
-      },
-      responseJson: {
-        message: 'Wrong username',
+        body: {
+          message: 'Wrong username',
+        },
       },
     });
   });

--- a/packages/loaders/openapi/tests/example_api8.test.ts
+++ b/packages/loaders/openapi/tests/example_api8.test.ts
@@ -41,7 +41,7 @@ describe('OpenAPI loader: Empty upstream 404 response', () => {
           "user": null,
         },
         "errors": [
-          [GraphQLError: HTTP Error: 404, Could not invoke operation GET /user],
+          [GraphQLError: Upstream HTTP Error: 404, Could not invoke operation GET /user],
         ],
       }
     `);

--- a/packages/transports/common/src/types.ts
+++ b/packages/transports/common/src/types.ts
@@ -41,6 +41,7 @@ export type TransportGetSubgraphExecutor<
 export type DisposableExecutor = Executor & Partial<Disposable | AsyncDisposable>;
 
 export interface UpstreamErrorExtensions {
+  subgraph?: string;
   request: {
     url?: string;
     method?: string;

--- a/packages/transports/common/src/types.ts
+++ b/packages/transports/common/src/types.ts
@@ -39,3 +39,17 @@ export type TransportGetSubgraphExecutor<
 > = (opts: TransportGetSubgraphExecutorOptions<Options>) => Executor | Promise<Executor>;
 
 export type DisposableExecutor = Executor & Partial<Disposable | AsyncDisposable>;
+
+export interface UpstreamErrorExtensions {
+  request: {
+    url?: string;
+    method?: string;
+    body?: unknown;
+  };
+  response: {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+  };
+}

--- a/packages/transports/rest/src/directives/getTypeResolverForAbstractType.ts
+++ b/packages/transports/rest/src/directives/getTypeResolverForAbstractType.ts
@@ -105,17 +105,18 @@ export function getTypeResolverForAbstractType({
       return typeName;
     }
     if (data.$response) {
-      const error = createGraphQLError(`HTTP Error: ${data.$statusCode}`, {
+      const error = createGraphQLError(`Upstream HTTP Error: ${data.$statusCode}`, {
         extensions: {
-          http: {
-            status: data.$statusCode,
-            headers: data.$response.header,
-          },
           request: {
             url: data.$url,
             method: data.$method,
           },
-          responseJson: data.$response,
+          response: {
+            status: data.$statusCode,
+            statusText: data.$statusText,
+            headers: data.$response.header,
+            body: data.$response,
+          },
         },
       });
       return error;

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -338,35 +338,36 @@ export function addHTTPRootFieldResolver(
         logger.debug(`Unexpected response in ${field.name};\n\t${responseText}`);
         return createGraphQLError(`Unexpected response in ${field.name}`, {
           extensions: {
-            http: {
-              status: response.status,
-              statusText: response.statusText,
-              headers: getHeadersObj(response.headers),
-            },
             request: {
               url: fullPath,
               method: httpMethod,
             },
-            responseText,
-            originalError: {
-              message: error.message,
-              stack: error.stack,
+            response: {
+              status: response.status,
+              statusText: response.statusText,
+              headers: getHeadersObj(response.headers),
+              body: responseText,
             },
+            originalError: error,
           },
         });
       } else {
         return createGraphQLError(
-          `HTTP Error: ${response.status}, Could not invoke operation ${httpMethod} ${path}`,
+          `Upstream HTTP Error: ${response.status}, Could not invoke operation ${httpMethod} ${path}`,
           {
             extensions: {
               request: {
                 url: fullPath,
                 method: httpMethod,
               },
-              responseText,
-              responseStatus: response.status,
-              responseStatusText: response.statusText,
-              responseHeaders: getHeadersObj(response.headers),
+              response: {
+                status: response.status,
+                statusText: response.statusText,
+                get headers() {
+                  return getHeadersObj(response.headers);
+                },
+                body: responseText,
+              },
             },
           },
         );
@@ -379,16 +380,18 @@ export function addHTTPRootFieldResolver(
           `HTTP Error: ${response.status}, Could not invoke operation ${httpMethod} ${path}`,
           {
             extensions: {
-              http: {
-                status: response.status,
-                statusText: response.statusText,
-                headers: getHeadersObj(response.headers),
-              },
               request: {
                 url: fullPath,
                 method: httpMethod,
               },
-              responseJson,
+              response: {
+                status: response.status,
+                statusText: response.statusText,
+                get headers() {
+                  return getHeadersObj(response.headers);
+                },
+                body: responseJson,
+              },
             },
           },
         );

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -298,17 +298,7 @@ export function addHTTPRootFieldResolver(
     operationLogger.debug(`=> Fetching `, fullPath, `=>`, requestInit);
     const fetch: typeof globalFetch = context?.fetch || globalFetch;
     if (!fetch) {
-      return createGraphQLError(
-        `You should have fetch defined in either the config or the context!`,
-        {
-          extensions: {
-            request: {
-              url: fullPath,
-              method: httpMethod,
-            },
-          },
-        },
-      );
+      return new TypeError(`You should have fetch defined in either the config or the context!`);
     }
     // Trick to pass `sourceName` to the `fetch` function for tracing
     const response = await fetch(fullPath, requestInit, context, {
@@ -335,9 +325,9 @@ export function addHTTPRootFieldResolver(
       } else if (response.status === 204 || (response.status === 200 && responseText === '')) {
         responseJson = {};
       } else if (response.status.toString().startsWith('2')) {
-        logger.debug(`Unexpected response in ${field.name};\n\t${responseText}`);
         return createGraphQLError(`Unexpected response in ${field.name}`, {
           extensions: {
+            subgraph: sourceName,
             request: {
               url: fullPath,
               method: httpMethod,
@@ -356,6 +346,7 @@ export function addHTTPRootFieldResolver(
           `Upstream HTTP Error: ${response.status}, Could not invoke operation ${httpMethod} ${path}`,
           {
             extensions: {
+              subgraph: sourceName,
               request: {
                 url: fullPath,
                 method: httpMethod,
@@ -377,9 +368,10 @@ export function addHTTPRootFieldResolver(
     if (!response.status.toString().startsWith('2')) {
       if (!isUnionType(returnNamedGraphQLType)) {
         return createGraphQLError(
-          `HTTP Error: ${response.status}, Could not invoke operation ${httpMethod} ${path}`,
+          `Upstream HTTP Error: ${response.status}, Could not invoke operation ${httpMethod} ${path}`,
           {
             extensions: {
+              subgraph: sourceName,
               request: {
                 url: fullPath,
                 method: httpMethod,

--- a/packages/transports/rest/src/directives/pubsubOperation.ts
+++ b/packages/transports/rest/src/directives/pubsubOperation.ts
@@ -21,9 +21,7 @@ export function processPubSubOperationAnnotations({
     const operationLogger = logger.child(`${info.parentType.name}.${field.name}`);
     const pubsub = context?.pubsub || globalPubsub;
     if (!pubsub) {
-      return createGraphQLError(
-        `You should have PubSub defined in either the config or the context!`,
-      );
+      return new TypeError(`You should have PubSub defined in either the config or the context!`);
     }
     const interpolationData = { root, args, context, info, env: process.env };
     let interpolatedPubSubTopic: string = stringInterpolator.parse(pubsubTopic, interpolationData);

--- a/packages/transports/soap/src/executor.ts
+++ b/packages/transports/soap/src/executor.ts
@@ -82,6 +82,7 @@ function normalizeResult(result: any) {
 type RootValueMethod = (args: any, context: any, info: GraphQLResolveInfo) => Promise<any>;
 
 interface SoapAnnotations {
+  subgraph: string;
   endpoint: string;
   bindingNamespace: string;
   elementName: string;
@@ -140,6 +141,7 @@ function createRootValueMethod({
     if (!response.ok) {
       return createGraphQLError(`Upstream HTTP Error: ${response.status}`, {
         extensions: {
+          subgraph: soapAnnotations.subgraph,
           request: {
             url: soapAnnotations.endpoint,
             method: 'POST',
@@ -162,6 +164,7 @@ function createRootValueMethod({
     } catch (e) {
       return createGraphQLError(`Invalid SOAP response: ${e.message}`, {
         extensions: {
+          subgraph: soapAnnotations.subgraph,
           request: {
             url: soapAnnotations.endpoint,
             method: 'POST',


### PR DESCRIPTION
Related https://github.com/ardatan/graphql-mesh/issues/7011
Also related https://github.com/ardatan/graphql-tools/pull/6217
Fixes https://github.com/ardatan/graphql-mesh/issues/7035

Introduce a standard Upstream Error Format for HTTP-based sources;

So all sources throw an error will have the extensions in the following format;

```json
{
  "extensions": {
    "request": { // The details of the request made to the upstream service
      "endpoint": "https://api.example.com",
      "method": "GET",
    },
    "response": { // The details of the HTTP response from the upstream service
      "status": 401,
      "statusText": "Unauthorized",
      "headers": {
        "content-type": "application/json"
      },
      "body": { // The raw body returned by the upstream service
        "error-message": "Unauthorized access",
      }
    },
  }
}
```