### PR TITLE
Fix: filter out disabled operations in Mongoose handler when generating schema (#6989)

### DIFF
--- a/.changeset/light-masks-clean.md
+++ b/.changeset/light-masks-clean.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/mongoose': patch
+---
+
+Fix: filter out disabled operations in Mongoose handler when generating schema

--- a/packages/legacy/handlers/mongoose/src/index.ts
+++ b/packages/legacy/handlers/mongoose/src/index.ts
@@ -97,11 +97,14 @@ export default class MongooseHandler implements MeshHandler {
 
           const resolversOption = modelConfig.options?.resolvers;
           function isResolverEnabled(operation): boolean {
-            return !resolversOption?.hasOwnProperty(operation) || resolversOption[operation] !== false;
+            return (
+              Object.prototype.hasOwnProperty.call(resolversOption, operation) ||
+              resolversOption[operation] !== false
+            );
           }
 
           const enabledQueryOperations = modelQueryOperations.filter(isResolverEnabled);
-          const enabledMuationOperations = modelMutationOperations.filter(isResolverEnabled);
+          const enabledMutationOperations = modelMutationOperations.filter(isResolverEnabled);
 
           await Promise.all([
             Promise.all(
@@ -112,7 +115,7 @@ export default class MongooseHandler implements MeshHandler {
               ),
             ),
             Promise.all(
-              enabledMuationOperations.map(async mutationOperation =>
+              enabledMutationOperations.map(async mutationOperation =>
                 schemaComposer.Mutation.addFields({
                   [`${modelConfig.name}_${mutationOperation}`]:
                     modelTC.getResolver(mutationOperation),


### PR DESCRIPTION
## Description

When disabling resolvers in the .meshrc configuration files, the Mongoose handler would still try to generate the schema, then fail.

Fixes #6989

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Before the fix, using a configuration similar to this one would cause an error:

```yaml
sources:
  - name: [redacted]
    handler:
      mongoose:
        connectionString: '{env.MONGO_DB_CONNECTION_STRING}'
        models:
          - name: MyModel
            path: ./src/models/my-model.ts#MyModel
            options:
              resolvers:
                count: false
```

```
 Failed to generate the schema Error: Type MyModel does not have resolver with name 'count'
    at ObjectTypeComposer.getResolver (/app/node_modules/graphql-compose/src/ObjectTypeComposer.ts:1306:13)
    at /app/node_modules/@graphql-mesh/mongoose/cjs/index.js:80:76
    at Array.map (<anonymous>)
    at /app/node_modules/@graphql-mesh/mongoose/cjs/index.js:78:44
    at async Promise.all (index 4)
    at async Promise.all (index 0)
    at async MongooseHandler.getMeshSource (/app/node_modules/@graphql-mesh/mongoose/cjs/index.js:55:9)
    at async /app/node_modules/@graphql-mesh/runtime/cjs/get-mesh.js:90:28
    at async Promise.allSettled (index 0)
    at async getMesh (/app/node_modules/@graphql-mesh/runtime/cjs/get-mesh.js:85:5)
```

**Test Environment**:

- OS: Ubuntu 22.10 and Debian Bullseye
- `@graphql-mesh/cli`: ^0.88.7,
- `@graphql-mesh/mongoose`: ^0.96.6,
- `@graphql-mesh/transform-filter-schema`: ^0.96.6,
- `@graphql-mesh/transform-naming-convention`: ^0.96.6,
- `@graphql-mesh/transform-rename`: ^0.96.6,
- NodeJS: 20.10.0

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X]  I have added a changeset using `yarn changeset` that bumps the version
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
