### PR TITLE
feat(omnigraph/rest): `jsonStringify` flag to serialize nested query params as JSON

### DIFF
--- a/.changeset/tough-zoos-travel.md
+++ b/.changeset/tough-zoos-travel.md
@@ -1,0 +1,36 @@
+---
+'@graphql-mesh/json-schema': patch
+'@omnigraph/json-schema': patch
+'@graphql-mesh/transport-rest': patch
+---
+
+New option for query string parameters `jsonStringify`;
+
+Now either under the operation or globally, you can set `jsonStringify` to `true` to stringify nested query string parameters as JSON.
+
+```yaml
+operations:
+  - type: Query
+    field: books
+    method: GET
+    path: /books
+    queryStringOptions:
+      jsonStringify: true
+    queryParamArgMap:
+      page: page
+    argTypeMap:
+      page:
+        type: object
+        additionalProperties: false
+        properties:
+          limit:
+            type: integer
+          offset:
+            type: integer
+    responseSample:
+      books:
+        - title: "Book 1"
+        - title: "Book 2"
+```
+
+Then the URL will be `/books?page={"limit":10,"offset":0}`, as you can see `page` is stringified as JSON.

--- a/e2e/auto-type-merging/__snapshots__/auto-type-merging.test.ts.snap
+++ b/e2e/auto-type-merging/__snapshots__/auto-type-merging.test.ts.snap
@@ -97,6 +97,7 @@ directive @httpOperation(
   queryParamArgMap: ObjMap
   queryStringOptionsByParam: ObjMap
   jsonApiFields: Boolean
+  queryStringOptions: ObjMap
 ) repeatable on FIELD_DEFINITION
 
 directive @transport(

--- a/e2e/federation-mixed/__snapshots__/federation-mixed.test.ts.snap
+++ b/e2e/federation-mixed/__snapshots__/federation-mixed.test.ts.snap
@@ -99,6 +99,7 @@ directive @httpOperation(
   queryParamArgMap: ObjMap
   queryStringOptionsByParam: ObjMap
   jsonApiFields: Boolean
+  queryStringOptions: ObjMap
 ) repeatable on FIELD_DEFINITION
 
 directive @transport(

--- a/e2e/json-schema-subscriptions/__snapshots__/json-schema-subscriptions.test.ts.snap
+++ b/e2e/json-schema-subscriptions/__snapshots__/json-schema-subscriptions.test.ts.snap
@@ -23,7 +23,7 @@ directive @link(url: String, as: String, for: link__Purpose, import: [link__Impo
 
 directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITION | OBJECT | INPUT_OBJECT | ENUM | SCALAR
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) repeatable on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) repeatable on FIELD_DEFINITION
 
 directive @pubsubOperation(subgraph: String, pubsubTopic: String) repeatable on FIELD_DEFINITION
 

--- a/e2e/openapi-javascript-wiki/__snapshots__/openapi-javascript-wiki.test.ts.snap
+++ b/e2e/openapi-javascript-wiki/__snapshots__/openapi-javascript-wiki.test.ts.snap
@@ -26,7 +26,7 @@ directive @resolveRoot(subgraph: String) repeatable on FIELD_DEFINITION
 
 directive @resolveRootField(subgraph: String, field: String) repeatable on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) repeatable on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) repeatable on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 

--- a/e2e/openapi-subscriptions/__snapshots__/openapi-subscriptions.test.ts.snap
+++ b/e2e/openapi-subscriptions/__snapshots__/openapi-subscriptions.test.ts.snap
@@ -94,6 +94,7 @@ directive @httpOperation(
   queryParamArgMap: ObjMap
   queryStringOptionsByParam: ObjMap
   jsonApiFields: Boolean
+  queryStringOptions: ObjMap
 ) repeatable on FIELD_DEFINITION
 
 directive @pubsubOperation(subgraph: String, pubsubTopic: String)  repeatable on FIELD_DEFINITION

--- a/e2e/programmatic-batching/__snapshots__/programmatic-batching.test.ts.snap
+++ b/e2e/programmatic-batching/__snapshots__/programmatic-batching.test.ts.snap
@@ -20,7 +20,7 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) repeatable on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) repeatable on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 

--- a/examples/hello-world-esm/tests/__snapshots__/hello-world.test.ts.snap
+++ b/examples/hello-world-esm/tests/__snapshots__/hello-world.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Hello World should generate correct schema 1`] = `
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/examples/hello-world/tests/__snapshots__/hello-world.test.ts.snap
+++ b/examples/hello-world/tests/__snapshots__/hello-world.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Hello World should generate correct schema 1`] = `
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/examples/json-schema-covid/tests/__snapshots__/json-schema-covid.test.ts.snap
+++ b/examples/json-schema-covid/tests/__snapshots__/json-schema-covid.test.ts.snap
@@ -4,7 +4,7 @@ exports[`JSON Schema Covid should generate correct schema: json-schema-covid-sch
 """""""
 directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | INTERFACE | OBJECT
 
-directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
+directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptions: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
 
 directive @resolveTo(additionalArgs: ResolveToSourceArgs, filterBy: String, keyField: String, keysArg: String, pubsubTopic: String, requiredSelectionSet: String, result: String, resultType: String, sourceArgs: ResolveToSourceArgs, sourceFieldName: String!, sourceName: String!, sourceSelectionSet: String, sourceTypeName: String!) on FIELD_DEFINITION
 

--- a/examples/json-schema-example/tests/__snapshots__/json-schema-example.test.js.snap
+++ b/examples/json-schema-example/tests/__snapshots__/json-schema-example.test.js.snap
@@ -10,7 +10,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITION | OBJECT | INPUT_OBJECT | ENUM | SCALAR
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HttpMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HttpMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/examples/json-schema-fhir/tests/__snapshots__/fhir.test.js.snap
+++ b/examples/json-schema-fhir/tests/__snapshots__/fhir.test.js.snap
@@ -13,7 +13,7 @@ directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITI
 
 directive @regexp(subgraph: String, pattern: String) on SCALAR
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/examples/json-schema-subscriptions/tests/__snapshots__/json-schema-subscriptions.test.ts.snap
+++ b/examples/json-schema-subscriptions/tests/__snapshots__/json-schema-subscriptions.test.ts.snap
@@ -9,7 +9,7 @@ exports[`JSON Schema Subscriptions should generate correct schema 1`] = `
 
 directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITION | OBJECT | INPUT_OBJECT | ENUM | SCALAR
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @pubsubOperation(subgraph: String, pubsubTopic: String) on FIELD_DEFINITION
 

--- a/examples/openapi-javascript-wiki/tests/__snapshots__/javascript-wiki.test.js.snap
+++ b/examples/openapi-javascript-wiki/tests/__snapshots__/javascript-wiki.test.js.snap
@@ -14,7 +14,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @resolveRootField(subgraph: String, field: String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/examples/openapi-location-weather/tests/__snapshots__/location-weather.test.ts.snap
+++ b/examples/openapi-location-weather/tests/__snapshots__/location-weather.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Location Weather should generate correct schema: location-weather-schema 1`] = `
 "directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
-directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
+directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptions: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
 
 directive @resolveTo(additionalArgs: ResolveToSourceArgs, filterBy: String, keyField: String, keysArg: String, pubsubTopic: String, requiredSelectionSet: String, result: String, resultType: String, sourceArgs: ResolveToSourceArgs, sourceFieldName: String!, sourceName: String!, sourceSelectionSet: String, sourceTypeName: String!) on FIELD_DEFINITION
 

--- a/examples/programmatic-batching/tests/__snapshots__/programmatic-batching.spec.ts.snap
+++ b/examples/programmatic-batching/tests/__snapshots__/programmatic-batching.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Batching Example should generate correct schema 1`] = `
   mutation: Mutation
 }
 
-directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
+directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptions: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
 
 directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) on SCHEMA
 

--- a/examples/v1-next/integrations/fastify/supergraph.graphql
+++ b/examples/v1-next/integrations/fastify/supergraph.graphql
@@ -74,6 +74,7 @@ directive @httpOperation(
   queryParamArgMap: ObjMap
   queryStringOptionsByParam: ObjMap
   jsonApiFields: Boolean
+  queryStringOptions: ObjMap
 ) repeatable on FIELD_DEFINITION
 
 directive @transport(

--- a/packages/legacy/handlers/json-schema/yaml-config.graphql
+++ b/packages/legacy/handlers/json-schema/yaml-config.graphql
@@ -25,6 +25,11 @@ type QueryStringOptions @md {
   (default: false)
   """
   commaRoundTrip: Boolean
+  """
+  Stringify the nested objects as JSON
+  (default: false)
+  """
+  jsonStringify: Boolean
 }
 
 enum QueryStringArrayFormat {

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -1024,6 +1024,10 @@
         "commaRoundTrip": {
           "type": "boolean",
           "description": "Even if there is a single item in an array, this option treats them as arrays\n(default: false)"
+        },
+        "jsonStringify": {
+          "type": "boolean",
+          "description": "Stringify the nested objects as JSON\n(default: false)"
         }
       }
     },

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -538,6 +538,11 @@ export interface QueryStringOptions {
    * (default: false)
    */
   commaRoundTrip?: boolean;
+  /**
+   * Stringify the nested objects as JSON
+   * (default: false)
+   */
+  jsonStringify?: boolean;
 }
 export interface MongooseHandler {
   connectionString?: string;

--- a/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
+++ b/packages/loaders/json-schema/src/addExecutionLogicToComposer.ts
@@ -119,6 +119,7 @@ ${operationConfig.description || ''}
             queryParamArgMap: operationConfig.queryParamArgMap,
             queryStringOptionsByParam: operationConfig.queryStringOptionsByParam,
             jsonApiFields: operationConfig.jsonApiFields,
+            queryStringOptions: 'queryStringOptions' in operationConfig ? operationConfig.queryStringOptions : undefined,
           }),
         ),
       });

--- a/packages/loaders/json-schema/src/directives.ts
+++ b/packages/loaders/json-schema/src/directives.ts
@@ -152,6 +152,9 @@ export const HTTPOperationDirective = new GraphQLDirective({
     jsonApiFields: {
       type: GraphQLBoolean,
     },
+    queryStringOptions: {
+      type: ObjMapScalar,
+    },
   },
 });
 

--- a/packages/loaders/json-schema/src/types.ts
+++ b/packages/loaders/json-schema/src/types.ts
@@ -18,7 +18,7 @@ export interface JSONSchemaLoaderOptions extends BaseLoaderOptions {
   fetch?: MeshFetch;
   ignoreErrorResponses?: boolean;
   queryParams?: Record<string, string | number | boolean>;
-  queryStringOptions?: IStringifyOptions;
+  queryStringOptions?: IStringifyOptions & { jsonStringify?: boolean };
   handlerName?: string;
   bundle?: boolean;
   getScalarForFormat?: (format: string) => GraphQLScalarType | void;
@@ -75,7 +75,10 @@ export type JSONSchemaHTTPBaseOperationConfig = JSONSchemaBaseOperationConfig & 
 
   headers?: Record<string, string>;
   queryParamArgMap?: Record<string, string>;
-  queryStringOptionsByParam?: Record<string, IStringifyOptions & { destructObject?: boolean }>;
+  queryStringOptionsByParam?: Record<
+    string,
+    IStringifyOptions & { destructObject?: boolean; jsonStringify?: boolean }
+  >;
   queryParamsSample?: any;
 
   jsonApiFields?: boolean;

--- a/packages/loaders/json-schema/test/__snapshots__/query-params.test.ts.snap
+++ b/packages/loaders/json-schema/test/__snapshots__/query-params.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Query Params queryParamsSample with invalid param names: queryParamsSam
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/additionalProperties.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/additionalProperties.test.ts.snap
@@ -7,7 +7,7 @@ exports[`additionalProperties should generate the schema correctly: schema 1`] =
 
 directive @dictionary(subgraph: String) on FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/allof-properties.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/allof-properties.test.ts.snap
@@ -10,7 +10,7 @@ directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on IN
 
 directive @length(subgraph: String, min: Int, max: Int) on SCALAR
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/basket.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/basket.test.ts.snap
@@ -12,7 +12,7 @@ directive @regexp(subgraph: String, pattern: String) on SCALAR
 
 directive @typescript(subgraph: String, type: String) on SCALAR | ENUM
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/calendly.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/calendly.test.ts.snap
@@ -20,7 +20,7 @@ directive @length(subgraph: String, min: Int, max: Int) on SCALAR
 
 directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/cloudfunction.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/cloudfunction.test.ts.snap
@@ -6,7 +6,7 @@ exports[`OpenAPI Loader: Cloudfunction should generate correct schema: cloudfunc
   mutation: Mutation
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/cloudfunction_expanded.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/cloudfunction_expanded.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Cloudfunction should generate correct schema: cloudfunction-schema 1`] 
   mutation: Mutation
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Discriminator Mapping should generate correct schema: discriminator-map
 
 directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on INTERFACE | UNION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/docusign.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/docusign.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Docusign should generate correct schema: docusign-schema 1`] = `
   mutation: Mutation
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/escaped-values.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/escaped-values.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Escaped Values should generate the correct schema: escaped_values-schem
 
 directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api.test.ts.snap
@@ -10,7 +10,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @resolveRootField(subgraph: String, field: String) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @linkResolver(subgraph: String, linkResolverMap: ObjMap) on FIELD_DEFINITION
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api2.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api2.test.ts.snap
@@ -5,7 +5,7 @@ exports[`OpenAPI loader: Naming convention should generate the schema correctly 
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api4.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api4.test.ts.snap
@@ -7,7 +7,7 @@ exports[`OpenAPI loader: Handle anyOf and oneOf should generate the schema corre
 
 directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api5.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api5.test.ts.snap
@@ -7,7 +7,7 @@ exports[`OpenAPI Loader: Testing the naming convention should generate the schem
 
 directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api6.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api6.test.ts.snap
@@ -6,7 +6,7 @@ exports[`example_api6 should generate the schema correctly 1`] = `
   mutation: Mutation
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api8.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api8.test.ts.snap
@@ -5,7 +5,7 @@ exports[`OpenAPI loader: Empty upstream 404 response should generate the schema 
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api_combined.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api_combined.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Example API Combined should generate correct schema: example_oas_combin
 
 directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/government_social_work.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/government_social_work.test.ts.snap
@@ -10,7 +10,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID) repeatable on UNION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/looker.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/looker.test.ts.snap
@@ -16,7 +16,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID) repeatable on UNION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/mime-type-with-version.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/mime-type-with-version.test.ts.snap
@@ -18,7 +18,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @typescript(subgraph: String, type: String) on SCALAR | ENUM
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/multiple-responses-swagger.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/multiple-responses-swagger.test.ts.snap
@@ -10,7 +10,7 @@ directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID
 
 directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/nested-one-of.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/nested-one-of.test.ts.snap
@@ -10,7 +10,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @flatten(subgraph: String) on FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/nested_objects.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/nested_objects.test.ts.snap
@@ -7,7 +7,7 @@ exports[`OpanAPI: nested objects should generate the schema correctly 1`] = `
 
 directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID) repeatable on UNION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/non_string_links.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/non_string_links.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Links on non-object fields should generate the correct schema 1`] = `
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 

--- a/packages/loaders/openapi/tests/__snapshots__/oneof-without-descriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/oneof-without-descriminator.test.ts.snap
@@ -14,7 +14,7 @@ directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITI
 
 directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/pet.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/pet.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Pet should generate the correct schema: schema 1`] = `
 
 directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on INTERFACE | UNION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/required-allof.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/required-allof.test.ts.snap
@@ -9,7 +9,7 @@ directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on IN
 
 directive @length(subgraph: String, min: Int, max: Int) on SCALAR
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/openapi/tests/__snapshots__/spotify.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/spotify.test.ts.snap
@@ -18,7 +18,7 @@ directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on IN
 
 directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID) repeatable on UNION
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/loaders/raml/tests/__snapshots__/query-params.test.ts.snap
+++ b/packages/loaders/raml/tests/__snapshots__/query-params.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Query Parameters generates correct schema 1`] = `
   query: Query
 }
 
-directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean) on FIELD_DEFINITION
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
 directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
 

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -17,7 +17,7 @@ import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 import { Logger, MeshFetch, MeshFetchRequestInit } from '@graphql-mesh/types';
 import { DefaultLogger, getHeadersObj } from '@graphql-mesh/utils';
 import { createGraphQLError, memoize1 } from '@graphql-tools/utils';
-import { Blob, File, FormData } from '@whatwg-node/fetch';
+import { Blob, File, FormData, URLSearchParams } from '@whatwg-node/fetch';
 import { isFileUpload } from './isFileUpload.js';
 import { getJsonApiFieldsQuery } from './jsonApiFields.js';
 import { resolveDataByUnionInputType } from './resolveDataByUnionInputType.js';
@@ -55,7 +55,10 @@ export interface HTTPRootFieldResolverOpts {
   isBinary: boolean;
   requestBaseBody: any;
   queryParamArgMap: Record<string, string>;
-  queryStringOptionsByParam: Record<string, IStringifyOptions & { destructObject?: boolean }>;
+  queryStringOptionsByParam: Record<
+    string,
+    IStringifyOptions & { destructObject?: boolean; jsonStringify?: boolean }
+  >;
   jsonApiFields: boolean;
 }
 
@@ -263,7 +266,27 @@ export function addHTTPRootFieldResolver(
               schema,
             );
           }
-          const queryParamsString = qsStringify(queryParamObj, opts);
+          let queryParamsString: string;
+          if (opts.jsonStringify) {
+            const searchParams = new URLSearchParams();
+            for (const key in queryParamObj) {
+              const queryParamVal = queryParamObj[key];
+              if (Array.isArray(queryParamVal)) {
+                for (const value of queryParamVal) {
+                  if (typeof value === 'object') {
+                    searchParams.append(key, JSON.stringify(value));
+                  } else {
+                    searchParams.append(key, value);
+                  }
+                }
+              } else if (typeof queryParamVal === 'object') {
+                searchParams.append(key, JSON.stringify(queryParamVal));
+              }
+            }
+            queryParamsString = searchParams.toString();
+          } else {
+            queryParamsString = qsStringify(queryParamObj, opts);
+          }
           fullPath += fullPath.includes('?') ? '&' : '?';
           fullPath += queryParamsString;
         }

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -59,6 +59,7 @@ export interface HTTPRootFieldResolverOpts {
     string,
     IStringifyOptions & { destructObject?: boolean; jsonStringify?: boolean }
   >;
+  queryStringOptions: IStringifyOptions & { destructObject?: boolean; jsonStringify?: boolean };
   jsonApiFields: boolean;
 }
 
@@ -84,6 +85,7 @@ export function addHTTPRootFieldResolver(
     requestBaseBody,
     queryParamArgMap,
     queryStringOptionsByParam,
+    queryStringOptions,
     jsonApiFields,
   }: HTTPRootFieldResolverOpts,
   {
@@ -98,6 +100,7 @@ export function addHTTPRootFieldResolver(
   globalQueryStringOptions = {
     ...defaultQsOptions,
     ...globalQueryStringOptions,
+    ...queryStringOptions,
   };
   const returnNamedGraphQLType = getNamedType(field.type);
   field.resolve = async (root, args, context, info) => {

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -284,6 +284,8 @@ export function addHTTPRootFieldResolver(
                 }
               } else if (typeof queryParamVal === 'object') {
                 searchParams.append(key, JSON.stringify(queryParamVal));
+              } else if (typeof queryParamVal === 'string') {
+                searchParams.append(key, queryParamVal);
               }
             }
             queryParamsString = searchParams.toString();

--- a/packages/transports/rest/src/directives/process.ts
+++ b/packages/transports/rest/src/directives/process.ts
@@ -8,6 +8,7 @@ import {
   isSpecifiedScalarType,
   isUnionType,
 } from 'graphql';
+import { IStringifyOptions } from 'qs';
 import { ObjMapScalar } from '@graphql-mesh/transport-common';
 import { Logger, MeshFetch, MeshPubSub } from '@graphql-mesh/types';
 import { getDefDirectives, getDirectiveExtensions } from '@graphql-mesh/utils';
@@ -218,6 +219,7 @@ export function processDirectives(
                       ? JSON.parse(directiveAnnotation.args.queryStringOptionsByParam)
                       : directiveAnnotation.args.queryStringOptionsByParam,
                   jsonApiFields: directiveAnnotation.args.jsonApiFields,
+                  queryStringOptions: directiveAnnotation.args.queryStringOptions,
                 },
                 globalOptions as GlobalOptions,
               );

--- a/website/src/generated-markdown/JsonSchemaHandler.generated.md
+++ b/website/src/generated-markdown/JsonSchemaHandler.generated.md
@@ -3,8 +3,8 @@
 * `endpoint` (type: `String`)
 * `operationHeaders` (type: `JSON`)
 * `schemaHeaders` (type: `JSON`)
-* `operations` -  (required) Array of:
-  * `object`:
+* `operations` -  (required) Array of: 
+  * `object`: 
     * `field` (type: `String`, required) - This Field based on the field name of the URL path.
 Example: "https://MyAPIURL.com/FieldNameHere/",
 so we will set the "field: FieldNameHere".
@@ -64,7 +64,7 @@ queryParamArgMap:
 And the request body will be passed as binary with its mime type
 unless you define an explicit Content-Type header
     * `deprecated` (type: `Boolean`) - If true, `@deprecated` will be added to the field definition
-  * `object`:
+  * `object`: 
     * `field` (type: `String`, required)
     * `description` (type: `String`)
     * `type` (type: `String (Query | Mutation | Subscription)`, required)
@@ -81,15 +81,16 @@ the underlying HTTP request
     * `deprecated` (type: `Boolean`) - If true, `@deprecated` will be added to the field definition
 * `ignoreErrorResponses` (type: `Boolean`)
 * `queryParams` (type: `Any`)
-* `queryStringOptions` (type: `Object`):
+* `queryStringOptions` (type: `Object`): 
   * `indices` (type: `Boolean`) - When arrays are stringified, by default they are not given explicit indices:
 `a=b&a=c&a=d`
 You may override this by setting the indices option to true:
 `a[0]=b&a[1]=c&a[2]=d`
   * `arrayFormat` (type: `String (indices | brackets | repeat | comma)`) - You can configure how to format arrays in the query strings.
-  * `jsonStringify` (type: `Boolean`) - To stringify nested query string parameters as JSON
 
 Note: when using arrayFormat set to 'comma', you can also pass the commaRoundTrip option set to true or false, to append [] on single-item arrays, so that they can round trip through a parse.
   * `commaRoundTrip` (type: `Boolean`) - Even if there is a single item in an array, this option treats them as arrays
+(default: false)
+  * `jsonStringify` (type: `Boolean`) - Stringify the nested objects as JSON
 (default: false)
 * `timeout` (type: `Int`) - Timeout for the HTTP request in milliseconds

--- a/website/src/generated-markdown/JsonSchemaHandler.generated.md
+++ b/website/src/generated-markdown/JsonSchemaHandler.generated.md
@@ -3,8 +3,8 @@
 * `endpoint` (type: `String`)
 * `operationHeaders` (type: `JSON`)
 * `schemaHeaders` (type: `JSON`)
-* `operations` -  (required) Array of: 
-  * `object`: 
+* `operations` -  (required) Array of:
+  * `object`:
     * `field` (type: `String`, required) - This Field based on the field name of the URL path.
 Example: "https://MyAPIURL.com/FieldNameHere/",
 so we will set the "field: FieldNameHere".
@@ -64,7 +64,7 @@ queryParamArgMap:
 And the request body will be passed as binary with its mime type
 unless you define an explicit Content-Type header
     * `deprecated` (type: `Boolean`) - If true, `@deprecated` will be added to the field definition
-  * `object`: 
+  * `object`:
     * `field` (type: `String`, required)
     * `description` (type: `String`)
     * `type` (type: `String (Query | Mutation | Subscription)`, required)
@@ -81,12 +81,13 @@ the underlying HTTP request
     * `deprecated` (type: `Boolean`) - If true, `@deprecated` will be added to the field definition
 * `ignoreErrorResponses` (type: `Boolean`)
 * `queryParams` (type: `Any`)
-* `queryStringOptions` (type: `Object`): 
+* `queryStringOptions` (type: `Object`):
   * `indices` (type: `Boolean`) - When arrays are stringified, by default they are not given explicit indices:
 `a=b&a=c&a=d`
 You may override this by setting the indices option to true:
 `a[0]=b&a[1]=c&a[2]=d`
   * `arrayFormat` (type: `String (indices | brackets | repeat | comma)`) - You can configure how to format arrays in the query strings.
+  * `jsonStringify` (type: `Boolean`) - To stringify nested query string parameters as JSON
 
 Note: when using arrayFormat set to 'comma', you can also pass the commaRoundTrip option set to true or false, to append [] on single-item arrays, so that they can round trip through a parse.
   * `commaRoundTrip` (type: `Boolean`) - Even if there is a single item in an array, this option treats them as arrays

--- a/website/src/generated-markdown/QueryStringOptions.generated.md
+++ b/website/src/generated-markdown/QueryStringOptions.generated.md
@@ -8,3 +8,5 @@ You may override this by setting the indices option to true:
 Note: when using arrayFormat set to 'comma', you can also pass the commaRoundTrip option set to true or false, to append [] on single-item arrays, so that they can round trip through a parse.
 * `commaRoundTrip` (type: `Boolean`) - Even if there is a single item in an array, this option treats them as arrays
 (default: false)
+* `jsonStringify` (type: `Boolean`) - Stringify the nested objects as JSON
+(default: false)


### PR DESCRIPTION
New option for query string parameters `jsonStringify`;

Now either under the operation or globally, you can set `jsonStringify` to `true` to stringify nested query string parameters as JSON.

```yaml
operations:
  - type: Query
    field: books
    method: GET
    path: /books
    queryStringOptions:
      jsonStringify: true
    queryParamArgMap:
      page: page
    argTypeMap:
      page:
        type: object
        additionalProperties: false
        properties:
          limit:
            type: integer
          offset:
            type: integer
    responseSample:
      books:
        - title: "Book 1"
        - title: "Book 2"
```

Then the URL will be `/books?page={"limit":10,"offset":0}`, as you can see `page` is stringified as JSON.