### PR TITLE
fix(hive): disable `autoDispose`

### DIFF
--- a/.changeset/late-ghosts-turn.md
+++ b/.changeset/late-ghosts-turn.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/plugin-hive': patch
+---
+
+Do not hook into `terminate` events of Node.js, because Mesh handles it already
+
+Hooking into those events cause a memory leak because plugins are initialized on each polling iteration in legacy Mesh CLI/Runtime

--- a/packages/plugins/hive/src/index.ts
+++ b/packages/plugins/hive/src/index.ts
@@ -105,7 +105,8 @@ export default function useMeshHive(
     usage,
     reporting,
     selfHosting,
-    autoDispose: ['SIGINT', 'SIGTERM'],
+    // Mesh already disposes the client below on Mesh's `destroy` event
+    autoDispose: false,
   });
   function onTerminate() {
     return hiveClient

--- a/packages/plugins/hive/tests/hive.test.ts
+++ b/packages/plugins/hive/tests/hive.test.ts
@@ -1,0 +1,26 @@
+import { PubSub } from '@graphql-mesh/utils';
+import useMeshHive from '../src';
+
+describe('Hive', () => {
+  let pubsub: PubSub;
+  beforeEach(() => {
+    pubsub = new PubSub();
+  });
+  afterEach(() => {
+    pubsub.publish('destroy', undefined);
+  });
+  it('does not hook into Node.js process', () => {
+    const spy = jest.spyOn(process, 'once');
+    useMeshHive({
+      enabled: true,
+      pubsub,
+      token: 'FAKE_TOKEN',
+    }).onPluginInit?.({
+      addPlugin: jest.fn(),
+      plugins: [],
+      setSchema: jest.fn(),
+      registerContextErrorHandler: jest.fn(),
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR disables `autoDispose` option in `createHiveClient` call inside Hive plugin, so Hive client can only be destroyed with Mesh's `destroy` event.
