### PR TITLE
Fix generating logger import code and improve documentation

### DIFF
--- a/.changeset/orange-seas-knock.md
+++ b/.changeset/orange-seas-knock.md
@@ -3,4 +3,4 @@
 '@graphql-mesh/types': patch
 ---
 
-Fix importing a logger using the `logger` configuration option and update docs
+Fix incorrect import code generated based on the `logger` configuration option and the documentation suggesting to pass a logger instance instead of a file path.

--- a/.changeset/orange-seas-knock.md
+++ b/.changeset/orange-seas-knock.md
@@ -3,4 +3,4 @@
 '@graphql-mesh/types': patch
 ---
 
-Fix incorrect import code generated based on the `logger` configuration option and the documentation suggesting to pass a logger instance instead of a file path.
+`logger` configuration option only accepts a string

--- a/.changeset/orange-seas-knock.md
+++ b/.changeset/orange-seas-knock.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/config': patch
+'@graphql-mesh/types': patch
+---
+
+Fix importing a logger using the `logger` configuration option and update docs

--- a/packages/legacy/config/src/utils.ts
+++ b/packages/legacy/config/src/utils.ts
@@ -271,7 +271,7 @@ export async function resolveLogger(
   code: string;
   logger: Logger;
 }> {
-  if (typeof loggerConfig === 'string') {
+  if (loggerConfig) {
     const { moduleName, resolved: logger } = await getPackage<Logger>({
       name: loggerConfig,
       type: 'logger',
@@ -279,9 +279,14 @@ export async function resolveLogger(
       cwd,
       additionalPrefixes: additionalPackagePrefixes,
     });
+
+    const processedModuleName = moduleName.startsWith('.')
+      ? path.join('..', moduleName)
+      : moduleName;
+
     return {
       logger,
-      importCode: `import logger from ${JSON.stringify(moduleName)};`,
+      importCode: `import logger from ${JSON.stringify(processedModuleName)};`,
       code: '',
     };
   }

--- a/packages/legacy/config/yaml-config.graphql
+++ b/packages/legacy/config/yaml-config.graphql
@@ -39,9 +39,9 @@ type Query {
   """
   persistedOperations: PersistedOperationsConfig
   """
-  Logger instance that matches `Console` interface of NodeJS
+  Path to a file exporting a logger instance compatible with the `Logger` type from `@graphql-mesh/types`
   """
-  logger: Any
+  logger: String
   """
   Path to a custom W3 Compatible Fetch Implementation
   """

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -4382,20 +4382,8 @@
       "description": "Configure persisted operations options"
     },
     "logger": {
-      "anyOf": [
-        {
-          "type": "object",
-          "additionalProperties": true
-        },
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "additionalItems": true
-        }
-      ],
-      "description": "Logger instance that matches `Console` interface of NodeJS"
+      "type": "string",
+      "description": "Path to a file exporting a logger instance compatible with the `Logger` type from `@graphql-mesh/types`"
     },
     "customFetch": {
       "anyOf": [

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -51,9 +51,9 @@ export interface Config {
   documents?: string[];
   persistedOperations?: PersistedOperationsConfig;
   /**
-   * Logger instance that matches `Console` interface of NodeJS
+   * Path to a file exporting a logger instance compatible with the `Logger` type from `@graphql-mesh/types`
    */
-  logger?: any;
+  logger?: string;
   /**
    * Path to a custom W3 Compatible Fetch Implementation
    */


### PR DESCRIPTION
## Description

The `logger` option was always meant as a path to a file exporting a logger instance not as the logger instance itself - it has to be this way so that code generation works and can correctly load the logger.

I've changed the documentation and typing of the `logger` option, as well as fixing the import path similarly to how other imports work (like `additionalEnvelopPlugins`).

Fixes #7107 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

I've built the library and used the built artifacts in my project with success - I'd appreciate hints on how to test this better.

**Test Environment**:

- OS: macOS 14.5
- `@graphql-mesh/cli`: v0.90.4
- NodeJS: v18.12.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
