### PR TITLE
fix(supergraph): support WebSockets subscriptions protocol for subgraphs

### DIFF
--- a/.changeset/@graphql-mesh_supergraph-7149-dependencies.md
+++ b/.changeset/@graphql-mesh_supergraph-7149-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@graphql-mesh/supergraph": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-tools/url-loader@^8.0.2` ↗︎](https://www.npmjs.com/package/@graphql-tools/url-loader/v/8.0.2) (to `dependencies`)
+  - Added dependency [`@graphql-tools/utils@^10.2.2` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/10.2.2) (to `dependencies`)
+  - Removed dependency [`@graphql-tools/executor-http@^1.0.2` ↗︎](https://www.npmjs.com/package/@graphql-tools/executor-http/v/1.0.2) (from `dependencies`)

--- a/.changeset/forty-tools-shout.md
+++ b/.changeset/forty-tools-shout.md
@@ -1,0 +1,18 @@
+---
+'@graphql-mesh/supergraph': patch
+---
+
+Fix the support for WebSockets configuration for supergraph handler
+
+For example;
+```yaml filename="mesh.config.yaml"
+sources:
+  - name: MySupergraph
+    handler:
+      supergraph:
+        source: # ...
+        subgraphs:
+          - name: MySubgraph
+            subscriptionsEndpoint: ws://localhost:4000/graphql
+            subscriptionsProtocol: WS
+```

--- a/packages/legacy/handlers/supergraph/package.json
+++ b/packages/legacy/handlers/supergraph/package.json
@@ -41,8 +41,9 @@
   },
   "dependencies": {
     "@graphql-mesh/string-interpolation": "^0.5.4",
-    "@graphql-tools/executor-http": "^1.0.2",
     "@graphql-tools/federation": "^2.0.0",
+    "@graphql-tools/url-loader": "^8.0.2",
+    "@graphql-tools/utils": "^10.2.2",
     "lodash.get": "^4.4.2"
   },
   "publishConfig": {

--- a/packages/legacy/handlers/supergraph/tests/fixtures/service-author/typeDefs.graphql
+++ b/packages/legacy/handlers/supergraph/tests/fixtures/service-author/typeDefs.graphql
@@ -8,3 +8,17 @@ type Query {
   authors: [Author]
   author(id: ID!): Author
 }
+
+type Mutation {
+  createAuthor(name: String!, birthDate: String): Author
+  updateAuthor(id: ID!, name: String, birthDate: String): Author
+  deleteAuthor(id: ID!): Author
+}
+
+type Subscription {
+  authorCreated: Author
+  authorUpdated: Author
+  authorDeleted: Author
+}
+
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])

--- a/packages/legacy/handlers/supergraph/tests/fixtures/service-book/resolvers.ts
+++ b/packages/legacy/handlers/supergraph/tests/fixtures/service-book/resolvers.ts
@@ -1,3 +1,7 @@
+import { PubSub } from '@graphql-mesh/utils';
+
+const pubsub = new PubSub();
+
 export const resolvers = {
   Book: {
     __resolveReference(book: { id: string }) {
@@ -21,6 +25,43 @@ export const resolvers = {
     },
     books() {
       return books;
+    },
+  },
+  Mutation: {
+    createBook(_: any, { title, authorId }: { title: string; authorId: string }) {
+      const book = { id: String(books.length + 1), title, authorId };
+      books.push(book);
+      pubsub.publish('BOOK_CREATED', { bookCreated: book });
+      return book;
+    },
+    updateBook(_: any, { id, title }: { id: string; title: string }) {
+      const book = books.find(b => b.id === id);
+      if (!book) {
+        throw new Error('Book not found');
+      }
+      book.title = title;
+      pubsub.publish('BOOK_UPDATED', { bookUpdated: book });
+      return book;
+    },
+    deleteBook(_: any, { id }: { id: string }) {
+      const bookIndex = books.findIndex(b => b.id === id);
+      if (bookIndex === -1) {
+        throw new Error('Book not found');
+      }
+      const [book] = books.splice(bookIndex, 1);
+      pubsub.publish('BOOK_DELETED', { bookDeleted: book });
+      return book;
+    },
+  },
+  Subscription: {
+    bookCreated: {
+      subscribe: () => pubsub.asyncIterator('BOOK_CREATED'),
+    },
+    bookUpdated: {
+      subscribe: () => pubsub.asyncIterator('BOOK_UPDATED'),
+    },
+    bookDeleted: {
+      subscribe: () => pubsub.asyncIterator('BOOK_DELETED'),
     },
   },
 };

--- a/packages/legacy/handlers/supergraph/tests/fixtures/service-book/typeDefs.graphql
+++ b/packages/legacy/handlers/supergraph/tests/fixtures/service-book/typeDefs.graphql
@@ -5,12 +5,26 @@ type Book @key(fields: "id") {
   author: Author!
 }
 
-type Author @extends @key(fields: "id") {
-  id: ID! @external
+type Author @key(fields: "id") {
+  id: ID!
   books: [Book]
+}
+
+type Mutation {
+  createBook(title: String!, genre: String, authorId: ID!): Book
+  updateBook(id: ID!, title: String, genre: String, authorId: ID): Book
+  deleteBook(id: ID!): Book
 }
 
 type Query {
   books: [Book]
   book(id: ID!): Book
 }
+
+type Subscription {
+  bookCreated: Book
+  bookUpdated: Book
+  bookDeleted: Book
+}
+
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])

--- a/packages/legacy/handlers/supergraph/tests/fixtures/supergraph.graphql
+++ b/packages/legacy/handlers/supergraph/tests/fixtures/supergraph.graphql
@@ -1,57 +1,59 @@
 schema
-  @core(feature: "https://specs.apollo.dev/core/v0.2")
-  @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION) {
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
   query: Query
+  mutation: Mutation
+  subscription: Subscription
 }
 
-directive @core(as: String, feature: String!, for: core__Purpose) repeatable on SCHEMA
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
 directive @join__field(
   graph: join__Graph
-  provides: join__FieldSet
   requires: join__FieldSet
-) on FIELD_DEFINITION
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-directive @join__owner(graph: join__Graph!) on INTERFACE | OBJECT
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
 
-directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on INTERFACE | OBJECT
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-type Author
-  @join__owner(graph: AUTHORS)
-  @join__type(graph: AUTHORS, key: "id")
-  @join__type(graph: BOOKS, key: "id") {
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+type Author @join__type(graph: AUTHORS, key: "id") @join__type(graph: BOOKS, key: "id") {
+  id: ID!
+  name: String! @join__field(graph: AUTHORS)
   birthDate: String @join__field(graph: AUTHORS)
   books: [Book] @join__field(graph: BOOKS)
-  id: ID! @join__field(graph: AUTHORS)
-  name: String! @join__field(graph: AUTHORS)
 }
 
-type Book @join__owner(graph: BOOKS) @join__type(graph: BOOKS, key: "id") {
-  author: Author! @join__field(graph: BOOKS)
-  genre: String @join__field(graph: BOOKS)
-  id: ID! @join__field(graph: BOOKS)
-  title: String! @join__field(graph: BOOKS)
-}
-
-type Query {
-  author(id: ID!): Author @join__field(graph: AUTHORS)
-  authors: [Author] @join__field(graph: AUTHORS)
-  book(id: ID!): Book @join__field(graph: BOOKS)
-  books: [Book] @join__field(graph: BOOKS)
-}
-
-enum core__Purpose {
-  """
-  `EXECUTION` features provide metadata necessary to for operation execution.
-  """
-  EXECUTION
-
-  """
-  `SECURITY` features provide metadata necessary to securely resolve fields.
-  """
-  SECURITY
+type Book @join__type(graph: BOOKS, key: "id") {
+  id: ID!
+  title: String!
+  genre: String
+  author: Author!
 }
 
 scalar join__FieldSet
@@ -59,4 +61,43 @@ scalar join__FieldSet
 enum join__Graph {
   AUTHORS @join__graph(name: "authors", url: "http://authors/graphql")
   BOOKS @join__graph(name: "books", url: "http://books/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+  createAuthor(name: String!, birthDate: String): Author @join__field(graph: AUTHORS)
+  updateAuthor(id: ID!, name: String, birthDate: String): Author @join__field(graph: AUTHORS)
+  deleteAuthor(id: ID!): Author @join__field(graph: AUTHORS)
+  createBook(title: String!, genre: String, authorId: ID!): Book @join__field(graph: BOOKS)
+  updateBook(id: ID!, title: String, genre: String, authorId: ID): Book @join__field(graph: BOOKS)
+  deleteBook(id: ID!): Book @join__field(graph: BOOKS)
+}
+
+type Query @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+  authors: [Author] @join__field(graph: AUTHORS)
+  author(id: ID!): Author @join__field(graph: AUTHORS)
+  books: [Book] @join__field(graph: BOOKS)
+  book(id: ID!): Book @join__field(graph: BOOKS)
+}
+
+type Subscription @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+  authorCreated: Author @join__field(graph: AUTHORS)
+  authorUpdated: Author @join__field(graph: AUTHORS)
+  authorDeleted: Author @join__field(graph: AUTHORS)
+  bookCreated: Book @join__field(graph: BOOKS)
+  bookUpdated: Book @join__field(graph: BOOKS)
+  bookDeleted: Book @join__field(graph: BOOKS)
 }

--- a/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
+++ b/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
@@ -37,9 +37,7 @@ describe('Supergraph', () => {
     },
   };
   const libcurl = globalThis.libcurl;
-  let disposableStack: AsyncDisposableStack;
   beforeEach(() => {
-    disposableStack = new AsyncDisposableStack();
     globalThis.libcurl = null;
     const baseDir = __dirname;
     const cache = new LocalforageCache();
@@ -77,7 +75,6 @@ describe('Supergraph', () => {
   });
   afterEach(() => {
     globalThis.libcurl = libcurl;
-    return disposableStack.disposeAsync();
   });
   it('supports individual headers for each subgraph with interpolation', async () => {
     const handler = new SupergraphHandler({
@@ -289,6 +286,7 @@ describe('Supergraph', () => {
  getaddrinfo ENOTFOUND down-sdl-source.com`);
   });
   it('configures WebSockets for subscriptions correctly', async () => {
+    await using disposableStack = new AsyncDisposableStack();
     const authorsHttpServer = createServer(authorsServer);
     disposableStack.defer(
       () =>

--- a/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
+++ b/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
@@ -1,4 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import { createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
+import { ServerOptions } from 'graphql-ws/lib/server';
+import { useServer } from 'graphql-ws/lib/use/ws';
+import { YogaServerInstance } from 'graphql-yoga';
+import { WebSocketServer } from 'ws';
 import LocalforageCache from '@graphql-mesh/cache-localforage';
 import BareMerger from '@graphql-mesh/merger-bare';
 import { getMesh } from '@graphql-mesh/runtime';
@@ -30,7 +37,9 @@ describe('Supergraph', () => {
     },
   };
   const libcurl = globalThis.libcurl;
+  let disposableStack: AsyncDisposableStack;
   beforeEach(() => {
+    disposableStack = new AsyncDisposableStack();
     globalThis.libcurl = null;
     const baseDir = __dirname;
     const cache = new LocalforageCache();
@@ -68,6 +77,7 @@ describe('Supergraph', () => {
   });
   afterEach(() => {
     globalThis.libcurl = libcurl;
+    return disposableStack.disposeAsync();
   });
   it('supports individual headers for each subgraph with interpolation', async () => {
     const handler = new SupergraphHandler({
@@ -278,4 +288,141 @@ describe('Supergraph', () => {
  Failed to load supergraph SDL from http://down-sdl-source.com/my-sdl.graphql:
  getaddrinfo ENOTFOUND down-sdl-source.com`);
   });
+  it('configures WebSockets for subscriptions correctly', async () => {
+    const authorsHttpServer = createServer(authorsServer);
+    disposableStack.defer(
+      () =>
+        new Promise((resolve, reject) =>
+          authorsHttpServer.close(err => (err ? reject(err) : resolve())),
+        ),
+    );
+    useServer(
+      getGraphQLWSOptionsForYoga(authorsServer),
+      new WebSocketServer({
+        server: authorsHttpServer,
+        path: authorsServer.graphqlEndpoint,
+      }),
+    );
+    const booksHttpServer = createServer(booksServer);
+    disposableStack.defer(
+      () =>
+        new Promise((resolve, reject) =>
+          booksHttpServer.close(err => (err ? reject(err) : resolve())),
+        ),
+    );
+    useServer(
+      getGraphQLWSOptionsForYoga(booksServer),
+      new WebSocketServer({
+        server: booksHttpServer,
+        path: booksServer.graphqlEndpoint,
+      }),
+    );
+
+    await new Promise<void>(resolve => authorsHttpServer.listen(0, () => resolve()));
+    await new Promise<void>(resolve => booksHttpServer.listen(0, () => resolve()));
+    const handler = new SupergraphHandler({
+      ...baseHandlerConfig,
+      config: {
+        source: './fixtures/supergraph.graphql',
+        subgraphs: [
+          {
+            name: 'authors',
+            endpoint: `http://localhost:${(authorsHttpServer.address() as AddressInfo).port}${authorsServer.graphqlEndpoint}`,
+            operationHeaders: {
+              Authorization: AUTHORS_AUTH_HEADER,
+            },
+            subscriptionsProtocol: 'WS',
+          },
+          {
+            name: 'books',
+            endpoint: `http://localhost:${(booksHttpServer.address() as AddressInfo).port}${booksServer.graphqlEndpoint}`,
+            operationHeaders: {
+              Authorization: BOOKS_AUTH_HEADER,
+            },
+            subscriptionsProtocol: 'WS',
+          },
+        ],
+      },
+    });
+    const meshRuntime = await getMesh({
+      sources: [
+        {
+          name: 'supergraph',
+          handler,
+        },
+      ],
+      ...baseGetMeshConfig,
+    });
+    const subscriptionResult = await meshRuntime.subscribe(
+      /* GraphQL */ `
+        subscription {
+          bookCreated {
+            title
+            author {
+              name
+            }
+          }
+        }
+      `,
+      {},
+    );
+    if (!(Symbol.asyncIterator in subscriptionResult)) {
+      throw new Error('Subscription result is not an async iterable');
+    }
+    const subscriptionAsyncIterator = subscriptionResult[Symbol.asyncIterator]();
+    disposableStack.defer(() => subscriptionAsyncIterator.return() as Promise<any>);
+    const subscriptionIterationResult$ = subscriptionAsyncIterator.next();
+    // Wait for the subscription to be ready
+    await new Promise<void>(resolve => setTimeout(resolve, 30));
+    const mutationResult = await meshRuntime.execute(
+      /* GraphQL */ `
+        mutation {
+          createBook(title: "New Book", authorId: 1) {
+            title
+            author {
+              name
+            }
+          }
+        }
+      `,
+      {},
+    );
+    const subscriptionIterationResult = await subscriptionIterationResult$;
+    expect(subscriptionIterationResult.value.data).toEqual({
+      bookCreated: mutationResult?.data?.createBook,
+    });
+  });
 });
+
+function getGraphQLWSOptionsForYoga(
+  yogaApp: YogaServerInstance<any, any>,
+): ServerOptions<any, any> {
+  return {
+    execute: (args: any) => args.rootValue.execute(args),
+    subscribe: (args: any) => args.rootValue.subscribe(args),
+    onSubscribe: async (ctx, msg) => {
+      const { schema, execute, subscribe, contextFactory, parse, validate } = yogaApp.getEnveloped({
+        ...ctx,
+        req: ctx.extra.request,
+        socket: ctx.extra.socket,
+        params: msg.payload,
+      });
+
+      const args = {
+        schema,
+        operationName: msg.payload.operationName,
+        document: parse(msg.payload.query),
+        variableValues: msg.payload.variables,
+        contextValue: await contextFactory(),
+        rootValue: {
+          execute,
+          subscribe,
+        },
+      };
+
+      const errors = validate(args.schema, args.document);
+      if (errors.length) return errors;
+      return args;
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,8 +5459,9 @@ __metadata:
   resolution: "@graphql-mesh/supergraph@workspace:packages/legacy/handlers/supergraph"
   dependencies:
     "@graphql-mesh/string-interpolation": "npm:^0.5.4"
-    "@graphql-tools/executor-http": "npm:^1.0.2"
     "@graphql-tools/federation": "npm:^2.0.0"
+    "@graphql-tools/url-loader": "npm:^8.0.2"
+    "@graphql-tools/utils": "npm:^10.2.2"
     lodash.get: "npm:^4.4.2"
   peerDependencies:
     "@graphql-mesh/cross-helpers": ^0.4.3
@@ -6060,7 +6061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/executor-http@npm:^1.0.2, @graphql-tools/executor-http@npm:^1.0.6, @graphql-tools/executor-http@npm:^1.0.9":
+"@graphql-tools/executor-http@npm:^1.0.6, @graphql-tools/executor-http@npm:^1.0.9":
   version: 1.0.9
   resolution: "@graphql-tools/executor-http@npm:1.0.9"
   dependencies:
@@ -6520,7 +6521,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/url-loader@npm:^8.0.0, @graphql-tools/url-loader@npm:~8.0.0":
+"@graphql-tools/url-loader@npm:^8.0.0, @graphql-tools/url-loader@npm:^8.0.2, @graphql-tools/url-loader@npm:~8.0.0":
   version: 8.0.2
   resolution: "@graphql-tools/url-loader@npm:8.0.2"
   dependencies:


### PR DESCRIPTION

Fix the support for WebSockets configuration for supergraph handler

For example;
```yaml filename="mesh.config.yaml"
sources:
  - name: MySupergraph
    handler:
      supergraph:
        source: # ...
        subgraphs:
          - name: MySubgraph
            subscriptionsEndpoint: ws://localhost:4000/graphql
            subscriptionsProtocol: WS
```