### PR TITLE
feat(serve-runtime): better defaults

### DIFF
--- a/.changeset/fifty-ears-camp.md
+++ b/.changeset/fifty-ears-camp.md
@@ -1,0 +1,12 @@
+---
+'@graphql-mesh/serve-runtime': patch
+'@graphql-mesh/serve-cli': patch
+---
+
+Change the default behavior of Serve Runtime
+
+If no `supergraph` or `hive` or `proxy` is provided
+
+- If `HIVE_CDN_ENDPOINT` and `HIVE_CDN_TOKEN` are provided, use them to fetch the supergraph from the Hive CDN
+- If not, check for a local supergraph file at `./supergraph.graphql`
+

--- a/packages/serve-cli/src/run.ts
+++ b/packages/serve-cli/src/run.ts
@@ -124,8 +124,13 @@ export async function run({
   if ('supergraph' in config) {
     unifiedGraphPath = config.supergraph;
   }
-  if (!('http' in config)) {
+
+  if (!('proxy' in config) && !('hive' in config)) {
     unifiedGraphPath = './supergraph.graphql';
+  }
+
+  if ('hive' in config || process.env.HIVE_CDN_ENDPOINT) {
+    unifiedGraphPath = 'Hive CDN';
   }
 
   let loadingMessage: string;

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -13,6 +13,7 @@ import {
 } from 'graphql-yoga';
 import { GraphiQLOptionsOrFactory } from 'graphql-yoga/typings/plugins/use-graphiql.js';
 import { createSupergraphSDLFetcher } from '@graphql-hive/client';
+import { process } from '@graphql-mesh/cross-helpers';
 import {
   handleFederationSupergraph,
   isDisposable,
@@ -42,7 +43,7 @@ import {
 } from './types.js';
 
 export function createServeRuntime<TContext extends Record<string, any> = Record<string, any>>(
-  config: MeshServeConfig<TContext>,
+  config: MeshServeConfig<TContext> = {},
 ) {
   let fetchAPI: Partial<FetchAPI> = config.fetchAPI;
   let logger: Logger;
@@ -62,7 +63,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
   const configContext: MeshServeConfigContext = {
     fetch: wrappedFetchFn,
     logger,
-    cwd: globalThis.process?.cwd(),
+    cwd: 'cwd' in config ? config.cwd : process.cwd?.(),
     cache: 'cache' in config ? config.cache : undefined,
     pubsub: 'pubsub' in config ? config.pubsub : undefined,
   };
@@ -105,18 +106,60 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     schemaInvalidator = () => executorPlugin.invalidateUnifiedGraph();
   } else {
     let unifiedGraphFetcher: UnifiedGraphManagerOptions<unknown>['getUnifiedGraph'];
+
     if ('supergraph' in config) {
       unifiedGraphFetcher = () => handleUnifiedGraphConfig(config.supergraph, configContext);
-    } else if ('hive' in config) {
-      const fetcher = createSupergraphSDLFetcher(config.hive);
+    } else if (('hive' in config && config.hive.endpoint) || process.env.HIVE_CDN_ENDPOINT) {
+      const cdnEndpoint = 'hive' in config ? config.hive.endpoint : process.env.HIVE_CDN_ENDPOINT;
+      const cdnKey = 'hive' in config ? config.hive.key : process.env.HIVE_CDN_KEY;
+      if (!cdnKey) {
+        throw new Error(
+          'You must provide HIVE_CDN_KEY environment variables or `key` in the hive config',
+        );
+      }
+      const fetcher = createSupergraphSDLFetcher({
+        endpoint: cdnEndpoint,
+        key: cdnKey,
+      });
       unifiedGraphFetcher = () => fetcher().then(({ supergraphSdl }) => supergraphSdl);
+    } else {
+      // Falls back to `./supergraph.graphql` by default
+      unifiedGraphFetcher = () => {
+        try {
+          const res$ = handleUnifiedGraphConfig('./supergraph.graphql', configContext);
+          if ('catch' in res$ && typeof res$.catch === 'function') {
+            return res$.catch(e => {
+              if (e.code === 'ENOENT') {
+                throw new Error(
+                  'You must provide a supergraph schema in the `supergraph` config or `HIVE_CDN_ENDPOINT` environment variable or `./supergraph.graphql` file',
+                );
+              }
+              throw e;
+            });
+          }
+          return res$;
+        } catch (e) {
+          if (e.code === 'ENOENT') {
+            throw new Error(
+              'You must provide a supergraph schema in the `supergraph` config or `HIVE_CDN_ENDPOINT` environment variable or `./supergraph.graphql` file',
+            );
+          }
+          throw e;
+        }
+      };
+    }
+
+    const hiveToken = 'hive' in config ? config.hive.token : process.env.HIVE_REGISTRY_TOKEN;
+    if (hiveToken) {
       registryPlugin = useMeshHive({
         enabled: true,
-        ...config.hive,
         ...configContext,
         logger: configContext.logger.child('Hive'),
+        ...('hive' in config ? config.hive : {}),
+        token: hiveToken,
       });
     }
+
     const unifiedGraphManager = new UnifiedGraphManager({
       getUnifiedGraph: unifiedGraphFetcher,
       handleUnifiedGraph: handleFederationSupergraph,

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -123,6 +123,8 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
       });
       unifiedGraphFetcher = () => fetcher().then(({ supergraphSdl }) => supergraphSdl);
     } else {
+      const errorMessage =
+        'You must provide a supergraph schema in the `supergraph` config or point to a supergraph file with `--supergraph` parameter or `HIVE_CDN_ENDPOINT` environment variable or `./supergraph.graphql` file';
       // Falls back to `./supergraph.graphql` by default
       unifiedGraphFetcher = () => {
         try {
@@ -130,9 +132,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
           if ('catch' in res$ && typeof res$.catch === 'function') {
             return res$.catch(e => {
               if (e.code === 'ENOENT') {
-                throw new Error(
-                  'You must provide a supergraph schema in the `supergraph` config or `HIVE_CDN_ENDPOINT` environment variable or `./supergraph.graphql` file',
-                );
+                throw new Error(errorMessage);
               }
               throw e;
             });
@@ -140,9 +140,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
           return res$;
         } catch (e) {
           if (e.code === 'ENOENT') {
-            throw new Error(
-              'You must provide a supergraph schema in the `supergraph` config or `HIVE_CDN_ENDPOINT` environment variable or `./supergraph.graphql` file',
-            );
+            throw new Error(errorMessage);
           }
           throw e;
         }

--- a/packages/serve-runtime/src/types.ts
+++ b/packages/serve-runtime/src/types.ts
@@ -7,7 +7,7 @@ import type {
   YogaServerOptions,
 } from 'graphql-yoga';
 import type { Plugin as EnvelopPlugin } from '@envelop/core';
-import { createSupergraphSDLFetcher } from '@graphql-hive/client';
+import type { createSupergraphSDLFetcher } from '@graphql-hive/client';
 import type { Transport, TransportsOption, UnifiedGraphPlugin } from '@graphql-mesh/fusion-runtime';
 import type {
   KeyValueCache,
@@ -80,7 +80,30 @@ interface MeshServeConfigWithHive<TContext> extends MeshServeConfigForSupergraph
   /**
    * Integration options with GraphQL Hive.
    */
-  hive: YamlConfig.HivePlugin & Parameters<typeof createSupergraphSDLFetcher>[0];
+  hive: YamlConfig.HivePlugin & HiveCDNOptions;
+}
+
+type HiveCDNFetcherOptions = Parameters<typeof createSupergraphSDLFetcher>[0];
+
+interface HiveCDNOptions extends Partial<HiveCDNFetcherOptions> {
+  /**
+   * The endpoint of the CDN you obtained from GraphQL Hive.
+   *
+   * You can provide an environment variable (HIVE_CDN_ENDPOINT) to set this value.
+   *
+   * @example https://cdn.graphql-hive.com/artifacts/v1/AAA-AAA-AAA/supergraph
+   *
+   * @default process.env.HIVE_CDN_ENDPOINT
+   */
+  endpoint?: string;
+  /**
+   * The key you obtained from GraphQL Hive for the CDN.
+   *
+   * You can provide an environment variable (HIVE_CDN_KEY) to set this value.
+   *
+   * @default process.env.HIVE_CDN_KEY
+   */
+  key?: string;
 }
 
 interface MeshServeConfigForSupergraph<TContext> extends MeshServeConfigWithoutSource<TContext> {
@@ -98,6 +121,10 @@ interface MeshServeConfigForSupergraph<TContext> extends MeshServeConfigWithoutS
    * Implement custom executors for transports.
    */
   transports?: TransportsOption;
+  /**
+   * Current working directory.
+   */
+  cwd?: string;
 }
 
 export interface MeshServeConfigWithProxy<TContext> extends MeshServeConfigWithoutSource<TContext> {

--- a/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
+++ b/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Serve Runtime Defaults falls back to "./supergraph.graphql" by default: default-supergraph 1`] = `
+"type Query {
+  foo: String
+}"
+`;
+
+exports[`Serve Runtime Hive CDN respects env vars: hive-cdn 1`] = `
+"type Query {
+  foo: String
+}"
+`;

--- a/packages/serve-runtime/tests/serve-runtime.spec.ts
+++ b/packages/serve-runtime/tests/serve-runtime.spec.ts
@@ -1,4 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import { createServer } from 'http';
+import { AddressInfo } from 'net';
+import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
+import {
+  buildClientSchema,
+  ExecutionResult,
+  getIntrospectionQuery,
+  IntrospectionQuery,
+  printSchema,
+} from 'graphql';
 import { createSchema, createYoga } from 'graphql-yoga';
 import { composeSubgraphs, getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { buildHTTPExecutor } from '@graphql-tools/executor-http';
@@ -6,65 +16,65 @@ import { Response } from '@whatwg-node/server';
 import { createServeRuntime } from '../src/createServeRuntime.js';
 
 describe('Serve Runtime', () => {
-  describe('Health and Readiness checks', () => {
-    const upstreamSchema = createSchema({
-      typeDefs: `
+  const upstreamSchema = createSchema({
+    typeDefs: `
           type Query {
             foo: String
           }
         `,
-      resolvers: {
-        Query: {
-          foo: () => 'bar',
+    resolvers: {
+      Query: {
+        foo: () => 'bar',
+      },
+    },
+  });
+  const upstreamAPI = createYoga({
+    schema: upstreamSchema,
+    logging: false,
+  });
+  let upstreamIsUp = true;
+  const serveRuntimes = {
+    proxyAPI: createServeRuntime({
+      proxy: {
+        endpoint: 'http://localhost:4000/graphql',
+        fetch(info, init, ...args) {
+          if (!upstreamIsUp) {
+            return Response.error();
+          }
+          return upstreamAPI.fetch(info, init, ...args);
         },
       },
-    });
-    const upstreamAPI = createYoga({
-      schema: upstreamSchema,
-      logging: false,
-    });
-    let upstreamIsUp = true;
-    const serveRuntimes = {
-      proxyAPI: createServeRuntime({
-        proxy: {
-          endpoint: 'http://localhost:4000/graphql',
-          fetch(info, init, ...args) {
-            if (!upstreamIsUp) {
-              return Response.error();
-            }
-            return upstreamAPI.fetch(info, init, ...args);
+    }),
+    supergraphAPI: createServeRuntime({
+      supergraph: () => {
+        if (!upstreamIsUp) {
+          throw new Error('Upstream is down');
+        }
+        return getUnifiedGraphGracefully([
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
           },
-        },
-      }),
-      supergraphAPI: createServeRuntime({
-        supergraph: () => {
-          if (!upstreamIsUp) {
-            throw new Error('Upstream is down');
-          }
-          return getUnifiedGraphGracefully([
-            {
-              name: 'upstream',
-              schema: upstreamSchema,
-            },
-          ]);
-        },
-        transports() {
-          return {
-            getSubgraphExecutor() {
-              return buildHTTPExecutor({
-                endpoint: 'http://localhost:4000/graphql',
-                fetch(info, init, ...args) {
-                  if (!upstreamIsUp) {
-                    return Response.error();
-                  }
-                  return upstreamAPI.fetch(info, init, ...args);
-                },
-              });
-            },
-          };
-        },
-      }),
-    };
+        ]);
+      },
+      transports() {
+        return {
+          getSubgraphExecutor() {
+            return buildHTTPExecutor({
+              endpoint: 'http://localhost:4000/graphql',
+              fetch(info, init, ...args) {
+                if (!upstreamIsUp) {
+                  return Response.error();
+                }
+                return upstreamAPI.fetch(info, init, ...args);
+              },
+            });
+          },
+        };
+      },
+    }),
+  };
+  describe('Endpoints', () => {
     beforeEach(() => {
       upstreamIsUp = true;
     });
@@ -104,6 +114,72 @@ describe('Serve Runtime', () => {
           });
         });
       });
+    });
+  });
+  describe('Hive CDN', () => {
+    afterEach(() => {
+      delete process.env.HIVE_CDN_ENDPOINT;
+      delete process.env.HIVE_CDN_KEY;
+    });
+    it('respects env vars', async () => {
+      await using disposableStack = new AsyncDisposableStack();
+      const cdnServer = createServer((req, res) => {
+        const supergraph = getUnifiedGraphGracefully([
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
+          },
+        ]);
+        res.end(supergraph);
+      });
+      await new Promise<void>(resolve => {
+        cdnServer.listen(0, resolve);
+      });
+      disposableStack.defer(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            cdnServer.close(err => (err ? reject(err) : resolve()));
+          }),
+      );
+      process.env.HIVE_CDN_ENDPOINT = `http://localhost:${(cdnServer.address() as AddressInfo).port}`;
+      process.env.HIVE_CDN_KEY = 'key';
+      const serveRuntime = createServeRuntime();
+      disposableStack.use(serveRuntime);
+      const res = await serveRuntime.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: getIntrospectionQuery(),
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const resJson: ExecutionResult<IntrospectionQuery> = await res.json();
+      const clientSchema = buildClientSchema(resJson.data);
+      expect(printSchema(clientSchema)).toMatchSnapshot('hive-cdn');
+    });
+  });
+  describe('Defaults', () => {
+    it('falls back to "./supergraph.graphql" by default', async () => {
+      const serveRuntime = createServeRuntime({
+        cwd: __dirname,
+      });
+      const res = await serveRuntime.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: getIntrospectionQuery(),
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const resJson: ExecutionResult<IntrospectionQuery> = await res.json();
+      const clientSchema = buildClientSchema(resJson.data);
+      expect(printSchema(clientSchema)).toMatchSnapshot('default-supergraph');
     });
   });
 });

--- a/packages/serve-runtime/tests/supergraph.graphql
+++ b/packages/serve-runtime/tests/supergraph.graphql
@@ -1,0 +1,65 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+scalar join__FieldSet
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+enum join__Graph {
+  UPSTREAM @join__graph(name: "upstream", url: "")
+}
+
+type Query @join__type(graph: UPSTREAM) {
+  foo: String
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4541,26 +4541,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-codegen/visitor-plugin-common@npm:5.2.0":
-  version: 5.2.0
-  resolution: "@graphql-codegen/visitor-plugin-common@npm:5.2.0"
-  dependencies:
-    "@graphql-codegen/plugin-helpers": "npm:^5.0.4"
-    "@graphql-tools/optimize": "npm:^2.0.0"
-    "@graphql-tools/relay-operation-optimizer": "npm:^7.0.0"
-    "@graphql-tools/utils": "npm:^10.0.0"
-    auto-bind: "npm:~4.0.0"
-    change-case-all: "npm:1.0.15"
-    dependency-graph: "npm:^0.11.0"
-    graphql-tag: "npm:^2.11.0"
-    parse-filepath: "npm:^1.0.2"
-    tslib: "npm:~2.6.0"
-  peerDependencies:
-    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/86ca3f7dd68e308b014040534dff7393122974c32e14d8453ff9cf52449b168aac49fcf65c42b5788b9571528b1b948c593f16d48d0513fea9da44c2c841e9be
-  languageName: node
-  linkType: hard
-
 "@graphql-codegen/visitor-plugin-common@npm:5.3.0":
   version: 5.3.0
   resolution: "@graphql-codegen/visitor-plugin-common@npm:5.3.0"


### PR DESCRIPTION
Change the default behavior of Serve Runtime;

If no `supergraph` or `hive` or `proxy` is provided

- If `HIVE_CDN_ENDPOINT` and `HIVE_CDN_TOKEN` are provided, use them to fetch the supergraph from the Hive CDN
- If not, check for a local supergraph file at `./supergraph.graphql`

