### PR TITLE
feat(serve-runtime): `skipValidation` option to skip validation while proxying

### DIFF
--- a/.changeset/blue-bottles-beam.md
+++ b/.changeset/blue-bottles-beam.md
@@ -1,0 +1,18 @@
+---
+'@graphql-mesh/serve-runtime': patch
+---
+
+Disable validation of the operations on the gateway while using Mesh Server as a proxy
+
+```ts filename="mesh.config.ts"
+import { defineConfig as defineServeConfig } from '@graphql-mesh/serve-cli'
+
+export default defineServeConfig({
+  proxy: {
+    endpoint: 'https://my-service.com/graphql',
+  },
+  skipValidation: true
+})
+```
+
+This will disable the validation of the operations, and send the operations directly to the upstream service.

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -100,6 +100,11 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     executorPlugin.onSchemaChange = function onSchemaChange(payload) {
       unifiedGraph = payload.schema;
     };
+    if (config.skipValidation) {
+      executorPlugin.onValidate = function ({ setResult }) {
+        setResult([]);
+      };
+    }
     unifiedGraphPlugin = executorPlugin;
     readinessChecker = () => {
       const res$ = proxyExecutor({

--- a/packages/serve-runtime/src/types.ts
+++ b/packages/serve-runtime/src/types.ts
@@ -137,6 +137,16 @@ export interface MeshServeConfigWithProxy<TContext> extends MeshServeConfigWitho
     | Transport<'http'>
     | Promise<Transport<'http'>>
     | (() => Transport<'http'> | Promise<Transport<'http'>>);
+
+  /**
+   * Disable GraphQL validation on the gateway
+   *
+   * By default, the gateway will validate the query against the schema before sending it to the executor.
+   * This is recommended to be enabled, but can be disabled for performance reasons.
+   *
+   * @default false
+   */
+  skipValidation?: boolean;
 }
 
 interface MeshServeConfigWithoutSource<TContext extends Record<string, any>> {

--- a/packages/serve-runtime/tests/useForwardHeaders.spec.ts
+++ b/packages/serve-runtime/tests/useForwardHeaders.spec.ts
@@ -34,6 +34,7 @@ describe('useForwardHeaders', () => {
         fetch: upstream.fetch as any,
       },
       plugins: () => [useForwardHeaders(['x-my-header', 'x-my-other'])],
+      logging: false,
     });
     const response = await serveRuntime.fetch('http://localhost:4000/graphql', {
       method: 'POST',
@@ -74,6 +75,7 @@ describe('useForwardHeaders', () => {
   });
   it("forwards specified headers but doesn't override the provided headers", async () => {
     const serveRuntime = createServeRuntime({
+      logging: false,
       proxy: {
         endpoint: 'https://example.com/graphql',
         headers: {


### PR DESCRIPTION
Disable validation of the operations on the gateway while using Mesh Server as a proxy

```ts filename="mesh.config.ts"
import { defineConfig as defineServeConfig } from '@graphql-mesh/serve-cli'

export default defineServeConfig({
  proxy: {
    endpoint: 'https://my-service.com/graphql',
  },
  skipValidation: true
})
```

This will disable the validation of the operations, and send the operations directly to the upstream service.
