### PR TITLE
feat(serve/legacy/http): allow extra params in body

### DIFF
--- a/.changeset/@graphql-mesh_fusion-runtime-7183-dependencies.md
+++ b/.changeset/@graphql-mesh_fusion-runtime-7183-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/fusion-runtime": patch
+---
+dependencies updates:
+  - Updated dependency [`graphql-yoga@^5.6.0` ↗︎](https://www.npmjs.com/package/graphql-yoga/v/5.6.0) (from `^5.3.0`, in `dependencies`)

--- a/.changeset/@graphql-mesh_http-7183-dependencies.md
+++ b/.changeset/@graphql-mesh_http-7183-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/http": patch
+---
+dependencies updates:
+  - Updated dependency [`graphql-yoga@^5.6.0` ↗︎](https://www.npmjs.com/package/graphql-yoga/v/5.6.0) (from `^5.3.0`, in `dependencies`)

--- a/.changeset/@graphql-mesh_plugin-response-cache-7183-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-response-cache-7183-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/plugin-response-cache": patch
+---
+dependencies updates:
+  - Updated dependency [`graphql-yoga@^5.6.0` ↗︎](https://www.npmjs.com/package/graphql-yoga/v/5.6.0) (from `^5.1.1`, in `dependencies`)

--- a/.changeset/@graphql-mesh_serve-runtime-7183-dependencies.md
+++ b/.changeset/@graphql-mesh_serve-runtime-7183-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/serve-runtime": patch
+---
+dependencies updates:
+  - Updated dependency [`graphql-yoga@^5.6.0` ↗︎](https://www.npmjs.com/package/graphql-yoga/v/5.6.0) (from `^5.3.0`, in `dependencies`)

--- a/.changeset/flat-actors-heal.md
+++ b/.changeset/flat-actors-heal.md
@@ -1,0 +1,30 @@
+---
+'@graphql-mesh/types': patch
+'@graphql-mesh/http': patch
+---
+
+By default, Mesh does not allow extra parameters in the request body other than `query`, `operationName`, `extensions`, and `variables`, then throws 400 HTTP Error.
+This change adds a new option called `extraParamNames` to allow extra parameters in the request body.
+
+```yaml
+serve:
+  extraParamNames:
+    - extraParam1
+    - extraParam2
+```
+
+```ts
+const res = await fetch('/graphql', {
+    method: 'POST',
+    headers: {
+        'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+        query: 'query { __typename }',
+        extraParam1: 'value1',
+        extraParam2: 'value2',
+    }),
+});
+
+console.assert(res.status === 200);
+```

--- a/e2e/auto-type-merging/package.json
+++ b/e2e/auto-type-merging/package.json
@@ -6,6 +6,6 @@
     "@graphql-mesh/serve-cli": "workspace:*",
     "@omnigraph/openapi": "workspace:*",
     "graphql": "^16.8.1",
-    "graphql-yoga": "^5.3.0"
+    "graphql-yoga": "^5.6.0"
   }
 }

--- a/e2e/type-merging-batching/package.json
+++ b/e2e/type-merging-batching/package.json
@@ -6,6 +6,6 @@
     "@graphql-mesh/fusion-runtime": "workspace:*",
     "@graphql-mesh/serve-cli": "workspace:*",
     "graphql": "^16.8.1",
-    "graphql-yoga": "^5.3.0"
+    "graphql-yoga": "^5.6.0"
   }
 }

--- a/examples/graphql-file-upload-example/package.json
+++ b/examples/graphql-file-upload-example/package.json
@@ -13,7 +13,7 @@
     "@graphql-mesh/graphql": "0.98.10",
     "concurrently": "8.2.2",
     "graphql": "16.9.0",
-    "graphql-yoga": "^5.3.0",
+    "graphql-yoga": "^5.6.0",
     "sharp": "0.33.4"
   },
   "devDependencies": {

--- a/examples/v1-next/hive-example/my-graphql/package.json
+++ b/examples/v1-next/hive-example/my-graphql/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@graphql-hive/cli": "0.38.4",
     "graphql": "16.9.0",
-    "graphql-yoga": "5.4.0",
+    "graphql-yoga": "5.6.0",
     "tsx": "4.15.8"
   }
 }

--- a/packages/fusion/runtime/package.json
+++ b/packages/fusion/runtime/package.json
@@ -64,7 +64,7 @@
     "@graphql-tools/wrap": "^10.0.5",
     "change-case": "^4.1.2",
     "disposablestack": "^1.1.6",
-    "graphql-yoga": "^5.3.0",
+    "graphql-yoga": "^5.6.0",
     "tslib": "^2.4.0"
   },
   "publishConfig": {

--- a/packages/legacy/cli/src/commands/serve/yaml-config.graphql
+++ b/packages/legacy/cli/src/commands/serve/yaml-config.graphql
@@ -70,6 +70,17 @@ type ServeConfig @md {
   Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)
   """
   healthCheckEndpoint: String
+
+  """
+  By default, GraphQL Mesh does not allow parameters in the request body except `query`, `variables`, `extensions`, and `operationName`.
+
+  This option allows you to specify additional parameters that are allowed in the request body.
+
+  @default []
+
+  @example ['doc_id', 'id']
+  """
+  extraParamNames: [String]
 }
 
 union Port = Int | String

--- a/packages/legacy/http/package.json
+++ b/packages/legacy/http/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@whatwg-node/server": "^0.9.34",
-    "graphql-yoga": "^5.3.0"
+    "graphql-yoga": "^5.6.0"
   },
   "devDependencies": {
     "@types/lodash.get": "4.4.9",

--- a/packages/legacy/http/src/graphqlHandler.ts
+++ b/packages/legacy/http/src/graphqlHandler.ts
@@ -10,6 +10,7 @@ export const graphqlHandler = ({
   corsConfig,
   batchingLimit,
   healthCheckEndpoint = '/healthcheck',
+  extraParamNames,
 }: {
   getBuiltMesh: () => Promise<MeshInstance>;
   playgroundTitle: string;
@@ -18,6 +19,7 @@ export const graphqlHandler = ({
   corsConfig: CORSOptions;
   batchingLimit?: number;
   healthCheckEndpoint?: string;
+  extraParamNames?: string[];
 }) => {
   const getYogaForMesh = memoize1(function getYogaForMesh(mesh: MeshInstance) {
     return createYoga({
@@ -32,6 +34,7 @@ export const graphqlHandler = ({
           },
         }),
       ],
+      extraParamNames,
       logging: mesh.logger,
       maskedErrors: false,
       graphiql: playgroundEnabled && {

--- a/packages/legacy/http/src/index.ts
+++ b/packages/legacy/http/src/index.ts
@@ -31,6 +31,7 @@ export function createMeshHTTPHandler<TServerContext>({
     healthCheckEndpoint = '/healthcheck',
     // TODO
     // trustProxy = 'loopback',
+    extraParamNames,
   } = rawServeConfig;
 
   getBuiltMesh()
@@ -50,6 +51,7 @@ export function createMeshHTTPHandler<TServerContext>({
       graphqlEndpoint: graphqlPath,
       corsConfig,
       batchingLimit,
+      extraParamNames,
     }),
     {
       plugins: [

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -173,6 +173,14 @@
         "healthCheckEndpoint": {
           "type": "string",
           "description": "Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)"
+        },
+        "extraParamNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "additionalItems": false,
+          "description": "By default, GraphQL Mesh does not allow parameters in the request body except `query`, `variables`, `extensions`, and `operationName`.\n\nThis option allows you to specify additional parameters that are allowed in the request body.\n\n@default []\n\n@example ['doc_id', 'id']"
         }
       }
     },

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -125,6 +125,16 @@ export interface ServeConfig {
    * Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)
    */
   healthCheckEndpoint?: string;
+  /**
+   * By default, GraphQL Mesh does not allow parameters in the request body except `query`, `variables`, `extensions`, and `operationName`.
+   *
+   * This option allows you to specify additional parameters that are allowed in the request body.
+   *
+   * @default []
+   *
+   * @example ['doc_id', 'id']
+   */
+  extraParamNames?: string[];
 }
 /**
  * Configuration for CORS

--- a/packages/loaders/openapi/package.json
+++ b/packages/loaders/openapi/package.json
@@ -50,7 +50,7 @@
     "@graphql-tools/utils": "10.2.2",
     "@whatwg-node/fetch": "0.9.18",
     "fets": "0.8.1",
-    "graphql-yoga": "5.4.0",
+    "graphql-yoga": "5.6.0",
     "json-bigint-patch": "0.0.8"
   },
   "publishConfig": {

--- a/packages/plugins/newrelic/package.json
+++ b/packages/plugins/newrelic/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@newrelic/test-utilities": "6.5.5",
     "@types/newrelic": "9.14.4",
-    "graphql-yoga": "5.4.0",
+    "graphql-yoga": "5.6.0",
     "newrelic": "10.6.2"
   },
   "publishConfig": {

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -43,7 +43,7 @@
     "@envelop/response-cache": "^6.1.1",
     "@graphql-mesh/string-interpolation": "0.5.4",
     "@graphql-yoga/plugin-response-cache": "^3.1.1",
-    "graphql-yoga": "^5.1.1"
+    "graphql-yoga": "^5.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/serve-runtime/package.json
+++ b/packages/serve-runtime/package.json
@@ -51,7 +51,7 @@
     "@graphql-tools/utils": "^10.2.1",
     "@whatwg-node/server": "^0.9.34",
     "disposablestack": "^1.1.6",
-    "graphql-yoga": "^5.3.0"
+    "graphql-yoga": "^5.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/website/src/generated-markdown/ServeConfig.generated.md
+++ b/website/src/generated-markdown/ServeConfig.generated.md
@@ -30,3 +30,10 @@ This feature can be disabled by passing `false` One of:
 [Learn more](https://expressjs.com/en/guide/behind-proxies.html)
 * `batchingLimit` (type: `Int`) - Enable and define a limit for [Request Batching](https://github.com/graphql/graphql-over-http/blob/main/rfcs/Batching.md)
 * `healthCheckEndpoint` (type: `String`) - Endpoint for [Health Check](https://the-guild.dev/graphql/yoga-server/docs/features/health-check)
+* `extraParamNames` (type: `Array of String`) - By default, GraphQL Mesh does not allow parameters in the request body except `query`, `variables`, `extensions`, and `operationName`.
+
+This option allows you to specify additional parameters that are allowed in the request body.
+
+@default []
+
+@example ['doc_id', 'id']

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,7 +3578,7 @@ __metadata:
     "@graphql-mesh/serve-cli": "workspace:*"
     "@omnigraph/openapi": "workspace:*"
     graphql: "npm:^16.8.1"
-    graphql-yoga: "npm:^5.3.0"
+    graphql-yoga: "npm:^5.6.0"
   languageName: unknown
   linkType: soft
 
@@ -3786,7 +3786,7 @@ __metadata:
     "@graphql-mesh/fusion-runtime": "workspace:*"
     "@graphql-mesh/serve-cli": "workspace:*"
     graphql: "npm:^16.8.1"
-    graphql-yoga: "npm:^5.3.0"
+    graphql-yoga: "npm:^5.6.0"
   languageName: unknown
   linkType: soft
 
@@ -4259,7 +4259,7 @@ __metadata:
   dependencies:
     "@graphql-hive/cli": "npm:0.38.4"
     graphql: "npm:16.9.0"
-    graphql-yoga: "npm:5.4.0"
+    graphql-yoga: "npm:5.6.0"
     tsx: "npm:4.15.8"
   languageName: unknown
   linkType: soft
@@ -4922,7 +4922,7 @@ __metadata:
     "@graphql-tools/wrap": "npm:^10.0.5"
     change-case: "npm:^4.1.2"
     disposablestack: "npm:^1.1.6"
-    graphql-yoga: "npm:^5.3.0"
+    graphql-yoga: "npm:^5.6.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -4987,7 +4987,7 @@ __metadata:
     "@types/ws": "npm:8.5.10"
     "@types/yargs": "npm:17.0.32"
     "@whatwg-node/server": "npm:^0.9.34"
-    graphql-yoga: "npm:^5.3.0"
+    graphql-yoga: "npm:^5.6.0"
   peerDependencies:
     "@graphql-mesh/cross-helpers": ^0.4.3
     "@graphql-mesh/runtime": ^0.99.11
@@ -5263,7 +5263,7 @@ __metadata:
     "@graphql-mesh/string-interpolation": "npm:^0.5.4"
     "@newrelic/test-utilities": "npm:6.5.5"
     "@types/newrelic": "npm:9.14.4"
-    graphql-yoga: "npm:5.4.0"
+    graphql-yoga: "npm:5.6.0"
     newrelic: "npm:10.6.2"
   peerDependencies:
     "@graphql-mesh/cross-helpers": ^0.4.3
@@ -5342,7 +5342,7 @@ __metadata:
     "@envelop/response-cache": "npm:^6.1.1"
     "@graphql-mesh/string-interpolation": "npm:0.5.4"
     "@graphql-yoga/plugin-response-cache": "npm:^3.1.1"
-    graphql-yoga: "npm:^5.1.1"
+    graphql-yoga: "npm:^5.6.0"
   peerDependencies:
     "@graphql-mesh/cross-helpers": ^0.4.3
     "@graphql-mesh/types": ^0.98.9
@@ -5496,7 +5496,7 @@ __metadata:
     "@graphql-tools/utils": "npm:^10.2.1"
     "@whatwg-node/server": "npm:^0.9.34"
     disposablestack: "npm:^1.1.6"
-    graphql-yoga: "npm:^5.3.0"
+    graphql-yoga: "npm:^5.6.0"
   peerDependencies:
     graphql: "*"
   languageName: unknown
@@ -8503,7 +8503,7 @@ __metadata:
     "@whatwg-node/fetch": "npm:0.9.18"
     change-case: "npm:^4.1.2"
     fets: "npm:0.8.1"
-    graphql-yoga: "npm:5.4.0"
+    graphql-yoga: "npm:5.6.0"
     json-bigint-patch: "npm:0.0.8"
     json-machete: "npm:^0.97.3"
     openapi-types: "npm:^12.1.0"
@@ -19556,7 +19556,7 @@ __metadata:
     "@graphql-mesh/graphql": "npm:0.98.10"
     concurrently: "npm:8.2.2"
     graphql: "npm:16.9.0"
-    graphql-yoga: "npm:^5.3.0"
+    graphql-yoga: "npm:^5.6.0"
     jest: "npm:29.7.0"
     sharp: "npm:0.33.4"
     ts-jest: "npm:29.1.5"
@@ -19747,9 +19747,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-yoga@npm:5.4.0, graphql-yoga@npm:^5.1.1, graphql-yoga@npm:^5.3.0":
-  version: 5.4.0
-  resolution: "graphql-yoga@npm:5.4.0"
+"graphql-yoga@npm:5.6.0, graphql-yoga@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "graphql-yoga@npm:5.6.0"
   dependencies:
     "@envelop/core": "npm:^5.0.0"
     "@graphql-tools/executor": "npm:^1.2.5"
@@ -19764,7 +19764,7 @@ __metadata:
     tslib: "npm:^2.5.2"
   peerDependencies:
     graphql: ^15.2.0 || ^16.0.0
-  checksum: 10c0/472b445c6ad5c84b16e326f9d7181dbf4b7288398bcf27a33f05c09b2a21200fa143a6b8b446514cdbb5117d1af0a20ffaa86bcc256cdcd407be8e3643305e2b
+  checksum: 10c0/bcacd9ed6a29721bdd142d0e9199e142ba20b4057fb5aea960ddbd760075d295d92230eb7fffe671217d4fb6dcd13249f5d28795dfe787716b6a4979b80062d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By default, Mesh does not allow extra parameters in the request body other than `query`, `operationName`, `extensions`, and `variables`, then throws 400 HTTP Error.
This change adds a new option called `extraParamNames` to allow extra parameters in the request body.

```yaml
serve:
  extraParamNames:
    - extraParam1
    - extraParam2
```

```ts
const res = await fetch('/graphql', {
    method: 'POST',
    headers: {
        'Content-Type': 'application/json',
    },
    body: JSON.stringify({
        query: 'query { __typename }',
        extraParam1: 'value1',
        extraParam2: 'value2',
    }),
});

console.assert(res.status === 200);
```