### PR TITLE
Lazy-initialize type._valueLookup in grpc handler

### DIFF
--- a/.changeset/moody-coins-hug.md
+++ b/.changeset/moody-coins-hug.md
@@ -2,4 +2,4 @@
 '@graphql-mesh/grpc': patch
 ---
 
-#7174
+Support graphql-js@16.9.0

--- a/.changeset/moody-coins-hug.md
+++ b/.changeset/moody-coins-hug.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/grpc': patch
+---
+
+#7174

--- a/packages/legacy/handlers/grpc/src/index.ts
+++ b/packages/legacy/handlers/grpc/src/index.ts
@@ -466,6 +466,13 @@ export default class GrpcHandler implements MeshHandler {
               if (enumSerializedValue) {
                 const serializedValue = JSON.parse(enumSerializedValue);
                 value.value = serializedValue;
+                let valueLookup = (type as any)._valueLookup;
+                if (!valueLookup) {
+                  valueLookup = new Map(
+                    type.getValues().map(enumValue => [enumValue.value, enumValue]),
+                  );
+                  (type as any)._valueLookup = valueLookup;
+                }
                 (type as any)._valueLookup.set(serializedValue, value);
               }
             }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes #7174 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

https://stackblitz.com/edit/github-acjw4e-rs3wnu?file=.meshrc.yml

## How Has This Been Tested?

`mesh start` failed locally then passed with a patch identical to this fix. Issue was 

**Test Environment**:

- OS: MacOS
- `@graphql-mesh/grpc`: 0.100.0
- NodeJS: 16 and 20

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Creating a test was difficult because the error only occurs when loading built files, not when loading the original proto. That's why the existing tests pass. I didn't find a test to emulate in #7140
