### PR TITLE
fix(omnigraph): make `@transport` repeatable

### DIFF
--- a/.changeset/spicy-games-yawn.md
+++ b/.changeset/spicy-games-yawn.md
@@ -1,0 +1,6 @@
+---
+'@omnigraph/json-schema': patch
+'@omnigraph/mysql': patch
+---
+
+Make `@transport` directive repeatable so a merged schema can have multiple `@transport` definitions

--- a/examples/hello-world-esm/tests/__snapshots__/hello-world.test.ts.snap
+++ b/examples/hello-world-esm/tests/__snapshots__/hello-world.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Hello World should generate correct schema 1`] = `
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   greeting: String @httpOperation(subgraph: "Hello World", path: "/", httpMethod: GET)

--- a/examples/hello-world/tests/__snapshots__/hello-world.test.ts.snap
+++ b/examples/hello-world/tests/__snapshots__/hello-world.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Hello World should generate correct schema 1`] = `
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   greeting: String @httpOperation(subgraph: "Hello World", path: "/", httpMethod: GET)

--- a/examples/json-schema-covid/tests/__snapshots__/json-schema-covid.test.ts.snap
+++ b/examples/json-schema-covid/tests/__snapshots__/json-schema-covid.test.ts.snap
@@ -10,7 +10,7 @@ directive @resolveTo(additionalArgs: ResolveToSourceArgs, filterBy: String, keyF
 
 directive @responseMetadata(subgraph: String) on FIELD_DEFINITION
 
-directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) on SCHEMA
+directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) repeatable on SCHEMA
 
 """Desc Api Population"""
 type ApiPopulation {

--- a/examples/json-schema-example/tests/__snapshots__/json-schema-example.test.ts.snap
+++ b/examples/json-schema-example/tests/__snapshots__/json-schema-example.test.ts.snap
@@ -12,7 +12,7 @@ directive @example(subgraph: String, value: ObjMap) repeatable on FIELD_DEFINITI
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HttpMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   me: User @httpOperation(subgraph: "FakeAPI", path: "/me", httpMethod: GET)

--- a/examples/json-schema-fhir/tests/__snapshots__/fhir.test.ts.snap
+++ b/examples/json-schema-fhir/tests/__snapshots__/fhir.test.ts.snap
@@ -15,7 +15,7 @@ directive @regexp(subgraph: String, pattern: String) on SCALAR
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 directive @resolveTo(requiredSelectionSet: String, sourceName: String!, sourceTypeName: String!, sourceFieldName: String!, sourceSelectionSet: String, sourceArgs: ResolveToSourceArgs, keyField: String, keysArg: String, pubsubTopic: String, filterBy: String, additionalArgs: ResolveToSourceArgs, result: String, resultType: String) on FIELD_DEFINITION
 

--- a/examples/json-schema-subscriptions/tests/__snapshots__/json-schema-subscriptions.test.ts.snap
+++ b/examples/json-schema-subscriptions/tests/__snapshots__/json-schema-subscriptions.test.ts.snap
@@ -13,7 +13,7 @@ directive @httpOperation(subgraph: String, path: String, operationSpecificHeader
 
 directive @pubsubOperation(subgraph: String, pubsubTopic: String) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 directive @live on QUERY
 

--- a/examples/mysql-employees/tests/__snapshots__/mysql-employees.test.ts.snap
+++ b/examples/mysql-employees/tests/__snapshots__/mysql-employees.test.ts.snap
@@ -6,7 +6,7 @@ exports[`MySQL Employees should generate correct schema: schema 1`] = `
   mutation: Mutation
 }
 
-directive @transport(subgraph: String, kind: String, location: String) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
 
 directive @mysqlSelect(table: String, columnMap: [[String]]) on FIELD_DEFINITION
 

--- a/examples/openapi-javascript-wiki/tests/__snapshots__/javascript-wiki.test.ts.snap
+++ b/examples/openapi-javascript-wiki/tests/__snapshots__/javascript-wiki.test.ts.snap
@@ -16,7 +16,7 @@ directive @resolveRootField(subgraph: String, field: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """

--- a/examples/openapi-location-weather/tests/__snapshots__/location-weather.test.ts.snap
+++ b/examples/openapi-location-weather/tests/__snapshots__/location-weather.test.ts.snap
@@ -7,7 +7,7 @@ directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiField
 
 directive @resolveTo(additionalArgs: ResolveToSourceArgs, filterBy: String, keyField: String, keysArg: String, pubsubTopic: String, requiredSelectionSet: String, result: String, resultType: String, sourceArgs: ResolveToSourceArgs, sourceFieldName: String!, sourceName: String!, sourceSelectionSet: String, sourceTypeName: String!) on FIELD_DEFINITION
 
-directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) on SCHEMA
+directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) repeatable on SCHEMA
 
 type AQCurrent {
   """Cloud cover as a percentage (%)"""

--- a/examples/programmatic-batching/tests/__snapshots__/programmatic-batching.spec.ts.snap
+++ b/examples/programmatic-batching/tests/__snapshots__/programmatic-batching.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`Batching Example should generate correct schema 1`] = `
 
 directive @httpOperation(httpMethod: HTTPMethod, isBinary: Boolean, jsonApiFields: Boolean, operationSpecificHeaders: [[String]], path: String, queryParamArgMap: ObjMap, queryStringOptions: ObjMap, queryStringOptionsByParam: ObjMap, requestBaseBody: ObjMap, subgraph: String) on FIELD_DEFINITION
 
-directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) on SCHEMA
+directive @transport(headers: [[String]], kind: String, location: String, queryParams: [[String]], queryStringOptions: ObjMap, subgraph: String) repeatable on SCHEMA
 
 enum HTTPMethod {
   CONNECT

--- a/packages/legacy/runtime/test/getMesh.test.ts
+++ b/packages/legacy/runtime/test/getMesh.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { parse } from 'graphql';
+import { buildSchema, OperationTypeNode, parse, validateSchema } from 'graphql';
 import LocalforageCache from '@graphql-mesh/cache-localforage';
 import GraphQLHandler from '@graphql-mesh/graphql';
+import JsonSchemaHandler from '@graphql-mesh/json-schema';
+import BareMerger from '@graphql-mesh/merger-bare';
 import StitchingMerger from '@graphql-mesh/merger-stitching';
 import { InMemoryStoreStorageAdapter, MeshStore } from '@graphql-mesh/store';
 import { Logger } from '@graphql-mesh/types';
@@ -399,5 +401,73 @@ describe('getMesh', () => {
         wave1: String
       }"
     `);
+  });
+
+  it('generates valid schema from multiple JSON Schema sources with bare merger', async () => {
+    const mesh = await getMesh({
+      cache,
+      pubsub,
+      logger,
+      sources: [
+        {
+          name: 'Foo',
+          handler: new JsonSchemaHandler({
+            baseDir,
+            cache,
+            pubsub,
+            logger,
+            store,
+            importFn: defaultImportFn,
+            name: 'Foo',
+            config: {
+              operations: [
+                {
+                  type: 'Query',
+                  field: 'foo',
+                  path: '/foo',
+                  responseSample: {
+                    bar: 'baz',
+                  },
+                },
+              ],
+            },
+          }),
+        },
+        {
+          name: 'Bar',
+          handler: new JsonSchemaHandler({
+            baseDir,
+            cache,
+            pubsub,
+            logger,
+            store,
+            importFn: defaultImportFn,
+            name: 'Bar',
+            config: {
+              operations: [
+                {
+                  type: 'Query',
+                  field: 'bar',
+                  path: '/bar',
+                  responseSample: {
+                    baz: 'qux',
+                  },
+                },
+              ],
+            },
+          }),
+        },
+      ],
+      merger: new BareMerger({
+        cache,
+        pubsub,
+        logger,
+        store,
+      }),
+    });
+    const printedSchema = printSchemaWithDirectives(mesh.schema);
+    const parsedSchema = buildSchema(printedSchema);
+    const validatedErrors = validateSchema(parsedSchema);
+    expect(validatedErrors).toHaveLength(0);
   });
 });

--- a/packages/loaders/json-schema/src/directives.ts
+++ b/packages/loaders/json-schema/src/directives.ts
@@ -296,4 +296,5 @@ export const TransportDirective = new GraphQLDirective({
     },
   },
   locations: [DirectiveLocation.SCHEMA],
+  isRepeatable: true,
 });

--- a/packages/loaders/json-schema/test/__snapshots__/query-params.test.ts.snap
+++ b/packages/loaders/json-schema/test/__snapshots__/query-params.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Query Params queryParamsSample with invalid param names: queryParamsSam
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   test(foo_bar: String): JSON @httpOperation(subgraph: "test", path: "/test", httpMethod: GET, queryParamArgMap: "{\\"foo:bar\\":\\"foo_bar\\"}")

--- a/packages/loaders/mysql/src/directives.ts
+++ b/packages/loaders/mysql/src/directives.ts
@@ -83,4 +83,5 @@ export const TransportDirective = new GraphQLDirective({
       type: GraphQLString,
     },
   },
+  isRepeatable: true,
 });

--- a/packages/loaders/openapi/tests/__snapshots__/additionalProperties.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/additionalProperties.test.ts.snap
@@ -9,7 +9,7 @@ directive @dictionary(subgraph: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   test: test_200_response @httpOperation(subgraph: "additionalPropertiesTest", path: "/test", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET)

--- a/packages/loaders/openapi/tests/__snapshots__/allof-properties.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/allof-properties.test.ts.snap
@@ -12,7 +12,7 @@ directive @length(subgraph: String, min: Int, max: Int) on SCALAR
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Admin implements User {
   """The name"""

--- a/packages/loaders/openapi/tests/__snapshots__/basket.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/basket.test.ts.snap
@@ -14,7 +14,7 @@ directive @typescript(subgraph: String, type: String) on SCALAR | ENUM
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   customers_by_customerId(

--- a/packages/loaders/openapi/tests/__snapshots__/calendly.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/calendly.test.ts.snap
@@ -22,7 +22,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Returns a list of Invitees for an event."""

--- a/packages/loaders/openapi/tests/__snapshots__/cloudfunction.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/cloudfunction.test.ts.snap
@@ -8,7 +8,7 @@ exports[`OpenAPI Loader: Cloudfunction should generate correct schema: cloudfunc
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   dummy: String

--- a/packages/loaders/openapi/tests/__snapshots__/cloudfunction_expanded.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/cloudfunction_expanded.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Cloudfunction should generate correct schema: cloudfunction-schema 1`] 
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   dummy: String

--- a/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/discriminator.test.ts.snap
@@ -9,7 +9,7 @@ directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on IN
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   pets_by_id(id: String!): Pet @httpOperation(subgraph: "test", path: "/pets/{args.id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET)

--- a/packages/loaders/openapi/tests/__snapshots__/docusign.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/docusign.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Docusign should generate correct schema: docusign-schema 1`] = `
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """

--- a/packages/loaders/openapi/tests/__snapshots__/escaped-values.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/escaped-values.test.ts.snap
@@ -9,7 +9,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   test: test_200_response @httpOperation(subgraph: "escaped_values", path: "/test", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET)

--- a/packages/loaders/openapi/tests/__snapshots__/example_api.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api.test.ts.snap
@@ -16,7 +16,7 @@ directive @linkResolver(subgraph: String, linkResolverMap: ObjMap) on FIELD_DEFI
 
 directive @link(defaultRootType: String, defaultField: String) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Return a list of users."""

--- a/packages/loaders/openapi/tests/__snapshots__/example_api2.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api2.test.ts.snap
@@ -7,7 +7,7 @@ exports[`OpenAPI loader: Naming convention should generate the schema correctly 
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Return a user."""

--- a/packages/loaders/openapi/tests/__snapshots__/example_api4.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api4.test.ts.snap
@@ -9,7 +9,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Basic oneOf test"""

--- a/packages/loaders/openapi/tests/__snapshots__/example_api5.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api5.test.ts.snap
@@ -9,7 +9,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 directive @linkResolver(subgraph: String, linkResolverMap: ObjMap) on FIELD_DEFINITION
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api6.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api6.test.ts.snap
@@ -8,7 +8,7 @@ exports[`example_api6 should generate the schema correctly 1`] = `
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 directive @linkResolver(subgraph: String, linkResolverMap: ObjMap) on FIELD_DEFINITION
 

--- a/packages/loaders/openapi/tests/__snapshots__/example_api8.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api8.test.ts.snap
@@ -7,7 +7,7 @@ exports[`OpenAPI loader: Empty upstream 404 response should generate the schema 
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Return a user."""

--- a/packages/loaders/openapi/tests/__snapshots__/example_api_combined.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/example_api_combined.test.ts.snap
@@ -9,7 +9,7 @@ directive @enum(subgraph: String, value: String) on ENUM_VALUE
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Returns information about all employee cars"""

--- a/packages/loaders/openapi/tests/__snapshots__/government_social_work.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/government_social_work.test.ts.snap
@@ -12,7 +12,7 @@ directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Gets all \`Assessment\` types"""

--- a/packages/loaders/openapi/tests/__snapshots__/looker.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/looker.test.ts.snap
@@ -18,7 +18,7 @@ directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """

--- a/packages/loaders/openapi/tests/__snapshots__/mime-type-with-version.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/mime-type-with-version.test.ts.snap
@@ -20,7 +20,7 @@ directive @typescript(subgraph: String, type: String) on SCALAR | ENUM
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Get info about the current user"""

--- a/packages/loaders/openapi/tests/__snapshots__/multiple-responses-swagger.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/multiple-responses-swagger.test.ts.snap
@@ -12,7 +12,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Optional extended description in Markdown."""

--- a/packages/loaders/openapi/tests/__snapshots__/nested-one-of.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/nested-one-of.test.ts.snap
@@ -12,7 +12,7 @@ directive @flatten(subgraph: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Retrieve the Rule with the specified objectID."""

--- a/packages/loaders/openapi/tests/__snapshots__/nested_objects.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/nested_objects.test.ts.snap
@@ -9,7 +9,7 @@ directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Search for documents in a collection that match the search criteria."""

--- a/packages/loaders/openapi/tests/__snapshots__/non_string_links.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/non_string_links.test.ts.snap
@@ -9,7 +9,7 @@ directive @httpOperation(subgraph: String, path: String, operationSpecificHeader
 
 directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 directive @linkResolver(subgraph: String, linkResolverMap: ObjMap) on FIELD_DEFINITION
 

--- a/packages/loaders/openapi/tests/__snapshots__/oneof-without-descriminator.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/oneof-without-descriminator.test.ts.snap
@@ -16,7 +16,7 @@ directive @resolveRoot(subgraph: String) on FIELD_DEFINITION
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   dummy: String

--- a/packages/loaders/openapi/tests/__snapshots__/pet.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/pet.test.ts.snap
@@ -9,7 +9,7 @@ directive @discriminator(subgraph: String, field: String, mapping: ObjMap) on IN
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Dog implements Pet {
   dog_exclusive: String

--- a/packages/loaders/openapi/tests/__snapshots__/required-allof.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/required-allof.test.ts.snap
@@ -11,7 +11,7 @@ directive @length(subgraph: String, min: Int, max: Int) on SCALAR
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Admin implements User {
   """The Name."""

--- a/packages/loaders/openapi/tests/__snapshots__/spotify.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/spotify.test.ts.snap
@@ -20,7 +20,7 @@ directive @statusCodeTypeName(subgraph: String, typeName: String, statusCode: ID
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """

--- a/packages/loaders/raml/tests/__snapshots__/query-params.test.ts.snap
+++ b/packages/loaders/raml/tests/__snapshots__/query-params.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Query Parameters generates correct schema 1`] = `
 
 directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
 
-directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) on SCHEMA
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
 
 type Query {
   """Get a list of products"""


### PR DESCRIPTION
When using bare merging which is basically regular schema merging compared to stitching, `@transport` directive can exist on `schema` multiple times.
And this makes the merged schema invalid so `@transport` needs to be `repeatable`.