### PR TITLE
[v1] fix(runtime): cleanup transport executors per schema change

### DIFF
--- a/.changeset/nice-kangaroos-laugh.md
+++ b/.changeset/nice-kangaroos-laugh.md
@@ -1,5 +1,6 @@
 ---
 '@graphql-mesh/fusion-runtime': patch
+'@graphql-mesh/serve-runtime': patch
 ---
 
 Cleanup created transport executors per schema change

--- a/.changeset/nice-kangaroos-laugh.md
+++ b/.changeset/nice-kangaroos-laugh.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Cleanup created transport executors per schema change
+Previously they were cleaned up only on server close, which could lead to memory leaks in case of schema changes.

--- a/packages/fusion/runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion/runtime/src/unifiedGraphManager.ts
@@ -83,6 +83,7 @@ export class UnifiedGraphManager<TContext> {
       this.inContextSDK = undefined;
       this.initialUnifiedGraph$ = undefined;
       this.pausePolling();
+      return this._transportExecutorStack?.disposeAsync();
     });
   }
 

--- a/packages/fusion/runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion/runtime/src/unifiedGraphManager.ts
@@ -70,7 +70,7 @@ export class UnifiedGraphManager<TContext> {
   private onSubgraphExecuteHooks: OnSubgraphExecuteHook[];
   private currentTimeout: NodeJS.Timeout | undefined;
   private inContextSDK;
-  private initialUnifiedGraph$: MaybePromise<void>;
+  private initialUnifiedGraph$: MaybePromise<true>;
   private disposableStack = new AsyncDisposableStack();
   private _transportEntryMap: Record<string, TransportEntry>;
   private _transportExecutorStack: AsyncDisposableStack;
@@ -108,7 +108,7 @@ export class UnifiedGraphManager<TContext> {
   }
 
   private ensureUnifiedGraph() {
-    if (!this.initialUnifiedGraph$ && !this.unifiedGraph) {
+    if (!this.initialUnifiedGraph$) {
       this.initialUnifiedGraph$ = this.getAndSetUnifiedGraph();
     }
     return this.initialUnifiedGraph$;
@@ -133,9 +133,9 @@ export class UnifiedGraphManager<TContext> {
         if (this.lastLoadedUnifiedGraph != null) {
           this.opts.transportBaseContext?.logger?.debug('Unified Graph changed, updating...');
         }
-        let cleanupJob$: Promise<void>;
+        let cleanupJob$: Promise<true>;
         if (this._transportExecutorStack) {
-          cleanupJob$ = this._transportExecutorStack.disposeAsync();
+          cleanupJob$ = this._transportExecutorStack.disposeAsync().then(() => true);
         }
         this._transportExecutorStack = new AsyncDisposableStack();
         this.lastLoadedUnifiedGraph ||= loadedUnifiedGraph;
@@ -180,7 +180,7 @@ export class UnifiedGraphManager<TContext> {
         }
         this.continuePolling();
         this._transportEntryMap = transportEntryMap;
-        return cleanupJob$;
+        return cleanupJob$ || true;
       },
     );
   }

--- a/packages/fusion/runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion/runtime/src/unifiedGraphManager.ts
@@ -87,6 +87,10 @@ export class UnifiedGraphManager<TContext> {
     });
   }
 
+  public onUnifiedGraphDispose(fn: () => MaybePromise<void>) {
+    this._transportExecutorStack?.defer(fn);
+  }
+
   private pausePolling() {
     if (this.currentTimeout) {
       clearTimeout(this.currentTimeout);
@@ -104,7 +108,7 @@ export class UnifiedGraphManager<TContext> {
   }
 
   private ensureUnifiedGraph() {
-    if (!this.initialUnifiedGraph$) {
+    if (!this.initialUnifiedGraph$ && !this.unifiedGraph) {
       this.initialUnifiedGraph$ = this.getAndSetUnifiedGraph();
     }
     return this.initialUnifiedGraph$;

--- a/packages/fusion/runtime/src/utils.ts
+++ b/packages/fusion/runtime/src/utils.ts
@@ -67,7 +67,7 @@ export function createTransportGetter(transports: TransportsOption): TransportGe
 export function getTransportExecutor(
   transportGetter: TransportGetter,
   transportContext: TransportExecutorFactoryOpts,
-  disposableStack: AsyncDisposableStack,
+  transportExecutorStack: AsyncDisposableStack,
 ): MaybePromise<Executor> {
   const transportKind = transportContext.transportEntry?.kind || '';
   const subgraphName = transportContext.subgraphName || '';
@@ -75,7 +75,7 @@ export function getTransportExecutor(
   return mapMaybePromise(transportGetter(transportKind), transport =>
     mapMaybePromise(transport.getSubgraphExecutor(transportContext), executor => {
       if (isDisposable(executor)) {
-        disposableStack.use(executor);
+        transportExecutorStack.use(executor);
       }
       return executor;
     }),
@@ -91,7 +91,7 @@ export function getOnSubgraphExecute({
   transportBaseContext,
   transportEntryMap,
   getSubgraphSchema,
-  disposableStack,
+  transportExecutorStack,
   transports = createDefaultTransportsOption(transportBaseContext?.logger),
 }: {
   onSubgraphExecuteHooks: OnSubgraphExecuteHook[];
@@ -99,7 +99,7 @@ export function getOnSubgraphExecute({
   transportBaseContext?: TransportBaseContext;
   transportEntryMap?: Record<string, TransportEntry>;
   getSubgraphSchema(subgraphName: string): GraphQLSchema;
-  disposableStack: AsyncDisposableStack;
+  transportExecutorStack: AsyncDisposableStack;
 }) {
   const subgraphExecutorMap = new Map<string, Executor>();
   const transportGetter = createTransportGetter(transports);
@@ -135,7 +135,7 @@ export function getOnSubgraphExecute({
                   },
                   subgraphName,
                 },
-            disposableStack,
+            transportExecutorStack,
           ),
           executor_ => {
             // Wraps the transport executor with hooks

--- a/packages/fusion/runtime/tests/polling.test.ts
+++ b/packages/fusion/runtime/tests/polling.test.ts
@@ -38,7 +38,7 @@ describe('Polling', () => {
       ]);
     };
     const disposeFn = jest.fn();
-    await using manager = new UnifiedGraphManager({
+    const manager = new UnifiedGraphManager({
       getUnifiedGraph: unifiedGraphFetcher,
       polling: pollingInterval,
       transports() {
@@ -95,5 +95,9 @@ describe('Polling', () => {
 
     // Check if transport executor is disposed per schema change
     expect(disposeFn).toHaveBeenCalledTimes(2);
+
+    await manager[Symbol.asyncDispose]();
+    // Check if transport executor is disposed on global shutdown
+    expect(disposeFn).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/fusion/runtime/tests/polling.test.ts
+++ b/packages/fusion/runtime/tests/polling.test.ts
@@ -1,43 +1,99 @@
-import { buildSchema } from 'graphql';
+import { buildSchema, GraphQLSchema, parse } from 'graphql';
+import { createSchema } from 'graphql-yoga';
 import { composeSubgraphs, getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
+import { createDefaultExecutor, type DisposableExecutor } from '@graphql-mesh/transport-common';
+import { normalizedExecutor } from '@graphql-tools/executor';
+import { isAsyncIterable } from '@graphql-tools/utils';
 import { UnifiedGraphManager } from '../src/unifiedGraphManager';
 
 describe('Polling', () => {
   it('polls the schema in a certain interval', async () => {
     jest.useFakeTimers();
     const pollingInterval = 35_000;
-    const unifiedGraphFetcher = () =>
-      getUnifiedGraphGracefully([
-        {
-          name: 'Test',
-          schema: buildSchema(/* GraphQL */ `
+    let schema: GraphQLSchema;
+    const unifiedGraphFetcher = () => {
+      const time = new Date().toISOString();
+      schema = createSchema({
+        typeDefs: /* GraphQL */ `
           """
-          Fetched on ${new Date().toISOString()}
+          Fetched on ${time}
           """
           type Query {
-            test: String
+            time: String
           }
-        `),
+        `,
+        resolvers: {
+          Query: {
+            time() {
+              return time;
+            },
+          },
+        },
+      });
+      return getUnifiedGraphGracefully([
+        {
+          name: 'Test',
+          schema,
         },
       ]);
+    };
+    const disposeFn = jest.fn();
     await using manager = new UnifiedGraphManager({
       getUnifiedGraph: unifiedGraphFetcher,
       polling: pollingInterval,
+      transports() {
+        return {
+          getSubgraphExecutor() {
+            const executor: DisposableExecutor = createDefaultExecutor(schema);
+            executor[Symbol.asyncDispose] = disposeFn;
+            return executor;
+          },
+        };
+      },
     });
-    async function getFetchedTime() {
+    async function getFetchedTimeOnComment() {
       const schema = await manager.getUnifiedGraph();
       const queryType = schema.getQueryType();
       const lastFetchedDateStr = queryType.description.match(/Fetched on (.*)/)[1];
       const lastFetchedDate = new Date(lastFetchedDateStr);
       return lastFetchedDate;
     }
-    const firstDate = await getFetchedTime();
+    async function getFetchedTimeFromResolvers() {
+      const schema = await manager.getUnifiedGraph();
+      const result = await normalizedExecutor({
+        schema,
+        document: parse(/* GraphQL */ `
+          query {
+            time
+          }
+        `),
+      });
+      if (isAsyncIterable(result)) {
+        throw new Error('Unexpected async iterable');
+      }
+      return new Date(result.data.time);
+    }
+    async function compareTimes() {
+      const timeFromComment = await getFetchedTimeOnComment();
+      const timeFromResolvers = await getFetchedTimeFromResolvers();
+      expect(timeFromComment).toEqual(timeFromResolvers);
+    }
+    await compareTimes();
+    const firstDate = await getFetchedTimeOnComment();
     jest.advanceTimersByTime(pollingInterval);
-    const secondDate = await getFetchedTime();
-    expect(secondDate.getTime() - firstDate.getTime()).toBeGreaterThanOrEqual(pollingInterval);
+    await compareTimes();
+    const secondDate = await getFetchedTimeOnComment();
+    const diffBetweenFirstAndSecond = secondDate.getTime() - firstDate.getTime();
+    expect(diffBetweenFirstAndSecond).toBeGreaterThanOrEqual(pollingInterval);
     jest.advanceTimersByTime(pollingInterval);
-    const thirdDate = await getFetchedTime();
-    expect(thirdDate.getTime() - secondDate.getTime()).toBeGreaterThanOrEqual(pollingInterval);
-    expect(thirdDate.getTime() - firstDate.getTime()).toBeGreaterThanOrEqual(pollingInterval * 2);
+    await compareTimes();
+    const thirdDate = await getFetchedTimeOnComment();
+    const diffBetweenSecondAndThird = thirdDate.getTime() - secondDate.getTime();
+    expect(diffBetweenSecondAndThird).toBeGreaterThanOrEqual(pollingInterval);
+    const diffBetweenFirstAndThird = thirdDate.getTime() - firstDate.getTime();
+    expect(diffBetweenFirstAndThird).toBeGreaterThanOrEqual(pollingInterval * 2);
+
+    // Check if transport executor is disposed per schema change
+    expect(disposeFn).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/serve-runtime/src/getProxyExecutor.ts
+++ b/packages/serve-runtime/src/getProxyExecutor.ts
@@ -38,7 +38,7 @@ export function getProxyExecutor<TContext>({
     }),
     transportBaseContext: configContext,
     getSubgraphSchema: getSchema,
-    disposableStack,
+    transportExecutorStack: disposableStack,
   });
   return function proxyExecutor(executionRequest) {
     return onSubgraphExecute(subgraphName, executionRequest);

--- a/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
+++ b/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
@@ -9,5 +9,9 @@ exports[`Serve Runtime Defaults falls back to "./supergraph.graphql" by default:
 exports[`Serve Runtime Hive CDN respects env vars: hive-cdn 1`] = `
 "type Query {
   foo: String
+}
+
+type Subscription {
+  pull: String
 }"
 `;


### PR DESCRIPTION
Cleanup created transport executors per schema change
Previously they were cleaned up only on server close, which could lead to memory leaks in case of schema changes.

This PR also terminates downstream subscriptions in case of a supergraph update.