### PR TITLE
[v1] Invoke `onSchemaChange` plugin hook as soon as supergraph changes

### DIFF
--- a/.changeset/few-rats-compare.md
+++ b/.changeset/few-rats-compare.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/serve-runtime': patch
+---
+
+Invoke onSchemaChange plugin hook as soon as supergraph changes and schema setting optimizations

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -87,7 +87,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
   let unifiedGraph: GraphQLSchema;
   let schemaInvalidator: () => void;
   let onUnifiedGraphDispose: (callback: () => MaybePromise<void>) => void;
-  let getSchema: () => MaybePromise<GraphQLSchema>;
+  let getSchema: () => MaybePromise<GraphQLSchema> = () => unifiedGraph;
   let schemaChanged = (_schema: GraphQLSchema): void => {
     throw new Error('Schema changed too early');
   };
@@ -110,7 +110,6 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     executorPlugin.onSchemaChange = function onSchemaChange(payload) {
       unifiedGraph = payload.schema;
     };
-    getSchema = () => unifiedGraph;
     if (config.skipValidation) {
       executorPlugin.onValidate = function ({ setResult }) {
         setResult([]);

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -49,6 +49,7 @@ import type {
   MeshServeContext,
   MeshServePlugin,
 } from './types.js';
+import { useChangingSchema } from './useChangingSchema.js';
 
 export function createServeRuntime<TContext extends Record<string, any> = Record<string, any>>(
   config: MeshServeConfig<TContext> = {},
@@ -86,7 +87,10 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
   let unifiedGraph: GraphQLSchema;
   let schemaInvalidator: () => void;
   let onUnifiedGraphDispose: (callback: () => MaybePromise<void>) => void;
-  let schemaFetcher: () => MaybePromise<GraphQLSchema>;
+  let getSchema: () => MaybePromise<GraphQLSchema>;
+  let schemaChanged = (_schema: GraphQLSchema): void => {
+    throw new Error('Schema changed too early');
+  };
   let contextBuilder: <T>(context: T) => MaybePromise<T>;
   let readinessChecker: () => MaybePromise<boolean>;
   let registryPlugin: MeshPlugin<unknown> = {};
@@ -106,6 +110,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     executorPlugin.onSchemaChange = function onSchemaChange(payload) {
       unifiedGraph = payload.schema;
     };
+    getSchema = () => unifiedGraph;
     if (config.skipValidation) {
       executorPlugin.onValidate = function ({ setResult }) {
         setResult([]);
@@ -180,7 +185,12 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
 
     const unifiedGraphManager = new UnifiedGraphManager({
       getUnifiedGraph: unifiedGraphFetcher,
-      handleUnifiedGraph: handleFederationSupergraph,
+      handleUnifiedGraph: opts => {
+        // when handleUnifiedGraph is called, we're sure that the schema
+        // _really_ changed, we can therefore confidently notify about the schema change
+        schemaChanged(opts.unifiedGraph);
+        return handleFederationSupergraph(opts);
+      },
       transports: config.transports,
       polling: config.polling,
       additionalResolvers: config.additionalResolvers,
@@ -189,7 +199,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
       onSubgraphExecuteHooks,
     });
     onUnifiedGraphDispose = callback => unifiedGraphManager.onUnifiedGraphDispose(callback);
-    schemaFetcher = () => unifiedGraphManager.getUnifiedGraph();
+    getSchema = () => unifiedGraphManager.getUnifiedGraph();
     readinessChecker = () =>
       mapMaybePromise(unifiedGraphManager.getUnifiedGraph(), schema => !!schema);
     schemaInvalidator = () => unifiedGraphManager.invalidateUnifiedGraph();
@@ -374,8 +384,6 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
   }
 
   const yoga = createYoga<unknown, MeshServeContext>({
-    // @ts-expect-error PromiseLike is not compatible with Promise
-    schema: schemaFetcher,
     fetchAPI: config.fetchAPI,
     logging: logger,
     plugins: [
@@ -383,6 +391,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
       unifiedGraphPlugin,
       readinessCheckPlugin,
       registryPlugin,
+      useChangingSchema(getSchema, cb => (schemaChanged = cb)),
       ...(config.plugins?.(configContext) || []),
     ],
     // @ts-expect-error PromiseLike is not compatible with Promise

--- a/packages/serve-runtime/src/useChangingSchema.ts
+++ b/packages/serve-runtime/src/useChangingSchema.ts
@@ -1,4 +1,5 @@
 import type { GraphQLSchema } from 'graphql';
+import { mapMaybePromise } from '@graphql-mesh/utils';
 import type { MaybePromise } from '@graphql-tools/utils';
 import type { MeshServePlugin } from './types';
 
@@ -19,11 +20,12 @@ export function useChangingSchema(
     },
     onRequestParse({ request }) {
       return {
-        async onRequestParseDone() {
+        onRequestParseDone() {
           if (!currentSchema) {
             // only if the schema is not already set do we want to get it
-            const schema = await getSchema();
-            schemaByRequest.set(request, schema);
+            return mapMaybePromise(getSchema(), schema => {
+              schemaByRequest.set(request, schema);
+            }) as any; // TODO: PromiseLike in Mesh MaybePromise is not assignable to type Yoga's PromiseOrValue
           }
         },
       };

--- a/packages/serve-runtime/src/useChangingSchema.ts
+++ b/packages/serve-runtime/src/useChangingSchema.ts
@@ -23,7 +23,6 @@ export function useChangingSchema(
           if (!currentSchema) {
             // only if the schema is not already set do we want to get it
             const schema = await getSchema();
-            currentSchema = schema;
             schemaByRequest.set(request, schema);
           }
         },
@@ -31,10 +30,11 @@ export function useChangingSchema(
     },
     onEnveloped({ context, setSchema }) {
       const schema = context?.request && schemaByRequest.get(context.request);
-      if (schema && schema !== currentSchema) {
+      if (schema && currentSchema !== schema) {
         // the schema will be available in the request only if schemaChanged was never invoked
         // also avoid setting the schema multiple times by checking whether it was already set
         setSchema(schema);
+        currentSchema = schema;
       }
     },
   };

--- a/packages/serve-runtime/src/useChangingSchema.ts
+++ b/packages/serve-runtime/src/useChangingSchema.ts
@@ -6,33 +6,32 @@ export function useChangingSchema(
   getSchema: () => MaybePromise<GraphQLSchema>,
   schemaChanged: (cb: (schema: GraphQLSchema) => void) => void,
 ): MeshServePlugin {
-  let schemaSet = false;
+  let currentSchema: GraphQLSchema | undefined;
   const schemaByRequest = new WeakMap<Request, GraphQLSchema>();
   return {
     onPluginInit({ setSchema }) {
       schemaChanged(schema => {
-        setSchema(schema);
-        schemaSet = true;
+        if (currentSchema !== schema) {
+          setSchema(schema);
+          currentSchema = schema;
+        }
       });
     },
     onRequestParse({ request }) {
       return {
         async onRequestParseDone() {
-          if (!schemaSet) {
+          if (!currentSchema) {
             // only if the schema is not already set do we want to get it
-            schemaByRequest.set(request, await getSchema());
+            const schema = await getSchema();
+            currentSchema = schema;
+            schemaByRequest.set(request, schema);
           }
         },
       };
     },
     onEnveloped({ context, setSchema }) {
-      if (context?.request == null) {
-        throw new Error(
-          'Request object is not available in the context. Make sure you use this plugin with GraphQL Mesh.',
-        );
-      }
-      const schema = schemaByRequest.get(context.request);
-      if (schema && !schemaSet) {
+      const schema = context?.request && schemaByRequest.get(context.request);
+      if (schema && schema !== currentSchema) {
         // the schema will be available in the request only if schemaChanged was never invoked
         // also avoid setting the schema multiple times by checking whether it was already set
         setSchema(schema);

--- a/packages/serve-runtime/src/useChangingSchema.ts
+++ b/packages/serve-runtime/src/useChangingSchema.ts
@@ -1,0 +1,42 @@
+import type { GraphQLSchema } from 'graphql';
+import type { MaybePromise } from '@graphql-tools/utils';
+import type { MeshServePlugin } from './types';
+
+export function useChangingSchema(
+  getSchema: () => MaybePromise<GraphQLSchema>,
+  schemaChanged: (cb: (schema: GraphQLSchema) => void) => void,
+): MeshServePlugin {
+  let schemaSet = false;
+  const schemaByRequest = new WeakMap<Request, GraphQLSchema>();
+  return {
+    onPluginInit({ setSchema }) {
+      schemaChanged(schema => {
+        setSchema(schema);
+        schemaSet = true;
+      });
+    },
+    onRequestParse({ request }) {
+      return {
+        async onRequestParseDone() {
+          if (!schemaSet) {
+            // only if the schema is not already set do we want to get it
+            schemaByRequest.set(request, await getSchema());
+          }
+        },
+      };
+    },
+    onEnveloped({ context, setSchema }) {
+      if (context?.request == null) {
+        throw new Error(
+          'Request object is not available in the context. Make sure you use this plugin with GraphQL Mesh.',
+        );
+      }
+      const schema = schemaByRequest.get(context.request);
+      if (schema && !schemaSet) {
+        // the schema will be available in the request only if schemaChanged was never invoked
+        // also avoid setting the schema multiple times by checking whether it was already set
+        setSchema(schema);
+      }
+    },
+  };
+}


### PR DESCRIPTION
The `useChangingSchema` has also optimizations over Yoga's default `useSchema`, including:
- no `schemaByRequest` weakmap
- no setting schema on each request
- no unnecessary `onSchemaChange` invokations