### PR TITLE
[v1] close subscriptions on disposal and schema change with different codes

### DIFF
--- a/.changeset/small-planets-push.md
+++ b/.changeset/small-planets-push.md
@@ -1,0 +1,35 @@
+---
+'@graphql-mesh/serve-runtime': patch
+---
+
+Close subscriptions on disposal and schema change with different codes.
+
+When the server gets disposed (on shutdown), all active subscriptions will complete emitting the following execution error:
+
+```json
+{
+  "errors": [
+    {
+      "extensions": {
+        "code": "SHUTTING_DOWN",
+      },
+      "message": "subscription has been closed because the server is shutting down",
+    },
+  ],
+}
+```
+
+However, when the server detects a schema change, all active subscriptions will complete emitting the following execution error:
+
+```json
+{
+  "errors": [
+    {
+      "extensions": {
+        "code": "SUBSCRIPTION_SCHEMA_RELOAD",
+      },
+      "message": "subscription has been closed due to a schema reload",
+    },
+  ],
+}
+```

--- a/packages/fusion/runtime/tests/polling.test.ts
+++ b/packages/fusion/runtime/tests/polling.test.ts
@@ -1,7 +1,6 @@
-import { buildSchema, GraphQLSchema, parse } from 'graphql';
+import { GraphQLSchema, parse } from 'graphql';
 import { createSchema } from 'graphql-yoga';
-import { composeSubgraphs, getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
-import { createServeRuntime } from '@graphql-mesh/serve-runtime';
+import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { createDefaultExecutor, type DisposableExecutor } from '@graphql-mesh/transport-common';
 import { normalizedExecutor } from '@graphql-tools/executor';
 import { isAsyncIterable } from '@graphql-tools/utils';
@@ -100,42 +99,5 @@ describe('Polling', () => {
     await manager[Symbol.asyncDispose]();
     // Check if transport executor is disposed on global shutdown
     expect(disposeFn).toHaveBeenCalledTimes(3);
-  });
-
-  it('should invoke onSchemaChange hooks when schema changes', done => {
-    let onSchemaChangeCalls = 0;
-    const serve = createServeRuntime({
-      polling: 500,
-      supergraph() {
-        if (onSchemaChangeCalls > 0) {
-          // change schema after onSchemaChange was invoked
-          return /* GraphQL */ `
-            type Query {
-              hello: Int!
-            }
-          `;
-        }
-
-        return /* GraphQL */ `
-          type Query {
-            world: String!
-          }
-        `;
-      },
-      plugins: () => [
-        {
-          onSchemaChange() {
-            if (onSchemaChangeCalls > 0) {
-              // schema changed for the second time
-              done();
-            }
-            onSchemaChangeCalls++;
-          },
-        },
-      ],
-    });
-
-    // trigger mesh
-    serve.fetch('http://mesh/graphql?query={__typename}');
   });
 });

--- a/packages/serve-runtime/package.json
+++ b/packages/serve-runtime/package.json
@@ -57,6 +57,7 @@
     "graphql-yoga": "^5.6.0"
   },
   "devDependencies": {
+    "graphql-sse": "^2.5.3",
     "html-minifier-terser": "7.2.0"
   },
   "publishConfig": {

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -257,7 +257,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     check: readinessChecker,
   });
 
-  function handleSubscriptionTerminationOnUnifiedGraphChange(
+  function handleSubscriptionTerminationOnUnifiedGraphDispose(
     result: AsyncIterableIteratorOrValue<ExecutionResult>,
     setResult: (result: AsyncIterableIteratorOrValue<ExecutionResult>) => void,
   ) {
@@ -270,9 +270,9 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
         });
         onUnifiedGraphDispose(() => {
           stop(
-            createGraphQLError('subscription has been closed due to a schema reload', {
+            createGraphQLError('subscription has been closed because the server is shutting down', {
               extensions: {
-                code: 'SUBSCRIPTION_SCHEMA_RELOAD',
+                code: 'SHUTTING_DOWN',
               },
             }),
           );
@@ -310,14 +310,14 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
     onExecute() {
       return {
         onExecuteDone({ result, setResult }) {
-          handleSubscriptionTerminationOnUnifiedGraphChange(result, setResult);
+          handleSubscriptionTerminationOnUnifiedGraphDispose(result, setResult);
         },
       };
     },
     onSubscribe() {
       return {
         onSubscribeResult({ result, setResult }) {
-          handleSubscriptionTerminationOnUnifiedGraphChange(result, setResult);
+          handleSubscriptionTerminationOnUnifiedGraphDispose(result, setResult);
         },
       };
     },

--- a/packages/serve-runtime/src/useCompleteSubscriptionsOnSchemaChange.ts
+++ b/packages/serve-runtime/src/useCompleteSubscriptionsOnSchemaChange.ts
@@ -28,7 +28,9 @@ export function useCompleteSubscriptionsOnSchemaChange(): MeshServePlugin {
                   }
                   activeSubs.push(complete);
 
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   stop.then(() => {
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
                     result.return?.();
                     activeSubs.splice(activeSubs.indexOf(complete), 1);
                   });

--- a/packages/serve-runtime/src/useCompleteSubscriptionsOnSchemaChange.ts
+++ b/packages/serve-runtime/src/useCompleteSubscriptionsOnSchemaChange.ts
@@ -1,0 +1,43 @@
+import { createGraphQLError, isAsyncIterable, Repeater } from 'graphql-yoga';
+import type { MeshServePlugin } from './types';
+
+export function useCompleteSubscriptionsOnSchemaChange(): MeshServePlugin {
+  const activeSubs: (() => void)[] = [];
+  return {
+    onSchemaChange() {
+      while (activeSubs.length) {
+        activeSubs.pop()?.();
+      }
+    },
+    onSubscribe() {
+      return {
+        onSubscribeResult({ result, setResult }) {
+          if (isAsyncIterable(result)) {
+            setResult(
+              Repeater.race([
+                result,
+                new Repeater((_push, stop) => {
+                  function complete() {
+                    stop(
+                      createGraphQLError('subscription has been closed due to a schema reload', {
+                        extensions: {
+                          code: 'SUBSCRIPTION_SCHEMA_RELOAD',
+                        },
+                      }),
+                    );
+                  }
+                  activeSubs.push(complete);
+
+                  stop.then(() => {
+                    result.return?.();
+                    activeSubs.splice(activeSubs.indexOf(complete), 1);
+                  });
+                }),
+              ]),
+            );
+          }
+        },
+      };
+    },
+  };
+}

--- a/packages/serve-runtime/src/useCompleteSubscriptionsOnUnifiedGraphDispose.ts
+++ b/packages/serve-runtime/src/useCompleteSubscriptionsOnUnifiedGraphDispose.ts
@@ -13,6 +13,7 @@ export function useCompleteSubscriptionsOnUnifiedGraphDispose(
               Repeater.race([
                 result,
                 new Repeater((_push, stop) => {
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
                   stop.then(() => result.return?.());
                   onDispose(() => {
                     stop(

--- a/packages/serve-runtime/src/useCompleteSubscriptionsOnUnifiedGraphDispose.ts
+++ b/packages/serve-runtime/src/useCompleteSubscriptionsOnUnifiedGraphDispose.ts
@@ -1,0 +1,37 @@
+import { createGraphQLError, isAsyncIterable, Repeater } from 'graphql-yoga';
+import type { MeshServePlugin } from './types';
+
+export function useCompleteSubscriptionsOnUnifiedGraphDispose(
+  onDispose: (cb: () => void) => void,
+): MeshServePlugin {
+  return {
+    onSubscribe() {
+      return {
+        onSubscribeResult({ result, setResult }) {
+          if (isAsyncIterable(result)) {
+            setResult(
+              Repeater.race([
+                result,
+                new Repeater((_push, stop) => {
+                  stop.then(() => result.return?.());
+                  onDispose(() => {
+                    stop(
+                      createGraphQLError(
+                        'subscription has been closed because the server is shutting down',
+                        {
+                          extensions: {
+                            code: 'SHUTTING_DOWN',
+                          },
+                        },
+                      ),
+                    );
+                  });
+                }),
+              ]),
+            );
+          }
+        },
+      };
+    },
+  };
+}

--- a/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
+++ b/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
@@ -12,7 +12,6 @@ exports[`Serve Runtime Hive CDN respects env vars: hive-cdn 1`] = `
 }
 
 type Subscription {
-  pull: String
   neverEmits: String
 }"
 `;

--- a/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
+++ b/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
@@ -9,9 +9,5 @@ exports[`Serve Runtime Defaults falls back to "./supergraph.graphql" by default:
 exports[`Serve Runtime Hive CDN respects env vars: hive-cdn 1`] = `
 "type Query {
   foo: String
-}
-
-type Subscription {
-  neverEmits: String
 }"
 `;

--- a/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
+++ b/packages/serve-runtime/tests/__snapshots__/serve-runtime.spec.ts.snap
@@ -13,5 +13,6 @@ exports[`Serve Runtime Hive CDN respects env vars: hive-cdn 1`] = `
 
 type Subscription {
   pull: String
+  neverEmits: String
 }"
 `;

--- a/packages/serve-runtime/tests/serve-runtime.spec.ts
+++ b/packages/serve-runtime/tests/serve-runtime.spec.ts
@@ -329,19 +329,6 @@ describe('Serve Runtime', () => {
   });
   it('terminates subscriptions gracefully on schema update', async () => {
     upstreamIsUp = true;
-    const res = await serveRuntimes.supergraphAPI.fetch('http://localhost:4000/graphql', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        query: /* GraphQL */ `
-          subscription {
-            pull
-          }
-        `,
-      }),
-    });
 
     const sse = createSSEClient({
       url: 'http://mesh/graphql',

--- a/packages/serve-runtime/tests/serve-runtime.spec.ts
+++ b/packages/serve-runtime/tests/serve-runtime.spec.ts
@@ -12,17 +12,12 @@ import {
   type ExecutionResult,
   type IntrospectionQuery,
 } from 'graphql';
-import { createClient as createSSEClient } from 'graphql-sse';
-import { createSchema, createYoga, Repeater } from 'graphql-yoga';
+import { createSchema, createYoga } from 'graphql-yoga';
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import type { MeshServePlugin } from '@graphql-mesh/serve-runtime';
 import { buildHTTPExecutor } from '@graphql-tools/executor-http';
-import type { MaybePromise } from '@graphql-tools/utils';
 import { Response } from '@whatwg-node/server';
 import { createServeRuntime } from '../src/createServeRuntime.js';
-
-const leftovers: (() => MaybePromise<void>)[] = [];
-afterAll(() => Promise.all(leftovers.map(l => l())));
 
 describe('Serve Runtime', () => {
   jest.useFakeTimers();
@@ -67,24 +62,10 @@ describe('Serve Runtime', () => {
           type Query {
             foo: String
           }
-
-          type Subscription {
-            neverEmits: String
-          }
         `,
       resolvers: {
         Query: {
           foo: () => 'bar',
-        },
-        Subscription: {
-          neverEmits: {
-            subscribe: () =>
-              new Repeater(() => {
-                return new Promise<void>(resolve => {
-                  leftovers.push(() => resolve());
-                });
-              }),
-          },
         },
       },
     });

--- a/packages/serve-runtime/tests/subscriptions.test.ts
+++ b/packages/serve-runtime/tests/subscriptions.test.ts
@@ -1,0 +1,166 @@
+import { createClient as createSSEClient } from 'graphql-sse';
+import { createSchema, createYoga, Repeater } from 'graphql-yoga';
+import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
+import { buildHTTPExecutor } from '@graphql-tools/executor-http';
+import { type MaybePromise } from '@graphql-tools/utils';
+import { createServeRuntime } from '../src/createServeRuntime';
+
+const leftovers: (() => MaybePromise<void>)[] = [];
+afterAll(() => Promise.all(leftovers.map(l => l())));
+
+describe('Subscriptions', () => {
+  const upstreamSchema = createSchema({
+    typeDefs: /* GraphQL */ `
+      """
+      Fetched on ${new Date().toISOString()}
+      """
+      type Query {
+        foo: String
+      }
+
+      type Subscription {
+        neverEmits: String
+      }
+    `,
+    resolvers: {
+      Query: {
+        foo: () => 'bar',
+      },
+      Subscription: {
+        neverEmits: {
+          subscribe: () =>
+            new Repeater((_push, stop) => {
+              leftovers.push(stop);
+            }),
+        },
+      },
+    },
+  });
+  const upstream = createYoga({ schema: upstreamSchema });
+
+  it('should terminate subscriptions gracefully on shutdown', async () => {
+    await using serve = createServeRuntime({
+      logging: false,
+      supergraph() {
+        return getUnifiedGraphGracefully([
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
+          },
+        ]);
+      },
+      transports() {
+        return {
+          getSubgraphExecutor() {
+            return buildHTTPExecutor({
+              endpoint: 'http://upstream/graphql',
+              fetch: upstream.fetch,
+            });
+          },
+        };
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+      on: {
+        connected() {
+          serve[Symbol.asyncDispose]();
+        },
+      },
+    });
+
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          neverEmits
+        }
+      `,
+    });
+
+    const msgs: unknown[] = [];
+    for await (const msg of sub) {
+      msgs.push(msg);
+    }
+
+    expect(msgs[msgs.length - 1]).toMatchInlineSnapshot(`
+{
+  "errors": [
+    {
+      "extensions": {
+        "code": "SHUTTING_DOWN",
+      },
+      "message": "subscription has been closed because the server is shutting down",
+    },
+  ],
+}
+`);
+  });
+
+  it('should terminate subscriptions gracefully on schema update', async () => {
+    let changeSchema = false;
+
+    await using serve = createServeRuntime({
+      logging: false,
+      polling: 500,
+      supergraph() {
+        if (changeSchema) {
+          return /* GraphQL */ `
+            type Query {
+              hello: Int!
+            }
+          `;
+        }
+        changeSchema = true;
+        return getUnifiedGraphGracefully([
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
+          },
+        ]);
+      },
+      transports() {
+        return {
+          getSubgraphExecutor() {
+            return buildHTTPExecutor({
+              endpoint: 'http://upstream/graphql',
+              fetch: upstream.fetch,
+            });
+          },
+        };
+      },
+    });
+
+    const sse = createSSEClient({
+      url: 'http://mesh/graphql',
+      fetchFn: serve.fetch,
+    });
+
+    const sub = sse.iterate({
+      query: /* GraphQL */ `
+        subscription {
+          neverEmits
+        }
+      `,
+    });
+
+    const msgs: unknown[] = [];
+    for await (const msg of sub) {
+      msgs.push(msg);
+    }
+
+    expect(msgs[msgs.length - 1]).toMatchInlineSnapshot(`
+      {
+        "errors": [
+          {
+            "extensions": {
+              "code": "SUBSCRIPTION_SCHEMA_RELOAD",
+            },
+            "message": "subscription has been closed due to a schema reload",
+          },
+        ],
+      }
+      `);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5466,6 +5466,7 @@ __metadata:
     "@graphql-tools/utils": "npm:^10.2.3"
     "@whatwg-node/server": "npm:^0.9.34"
     disposablestack: "npm:^1.1.6"
+    graphql-sse: "npm:^2.5.3"
     graphql-yoga: "npm:^5.6.0"
     html-minifier-terser: "npm:7.2.0"
   peerDependencies:
@@ -19700,6 +19701,15 @@ __metadata:
     graphql-relay: ^0.4.2 || ^0.5.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0
     sequelize: ">=3.0.0"
   checksum: 10c0/a4d2ba73c332ddf63439f84ca04496d5bd927ef28e1e85834857661c94450b13463015b303d03ad720fd53e62d44fcb3a95c3995b8c3d0ef389c18345244a188
+  languageName: node
+  linkType: hard
+
+"graphql-sse@npm:^2.5.3":
+  version: 2.5.3
+  resolution: "graphql-sse@npm:2.5.3"
+  peerDependencies:
+    graphql: ">=0.11 <=16"
+  checksum: 10c0/b556564aaddd8dfcc4e7fd25da37cfe95dbf5e100fca287b1b15ab6874a772fda96088b66e7d02739076fb769d60279c17afe54d5ab196eeca67972247c6c73e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Close subscriptions on disposal and schema change with different codes.

When the server gets disposed (on shutdown), all active subscriptions will complete emitting the following execution error:

```json
{
  "errors": [
    {
      "extensions": {
        "code": "SHUTTING_DOWN",
      },
      "message": "subscription has been closed because the server is shutting down",
    },
  ],
}
```

However, when the server detects a schema change, all active subscriptions will complete emitting the following execution error:

```json
{
  "errors": [
    {
      "extensions": {
        "code": "SUBSCRIPTION_SCHEMA_RELOAD",
      },
      "message": "subscription has been closed due to a schema reload",
    },
  ],
}
```