### PR TITLE
[v1] docs(deployment): SvelteKit integration

### DIFF
--- a/website/src/pages/docs/getting-started/deploy-mesh-gateway.mdx
+++ b/website/src/pages/docs/getting-started/deploy-mesh-gateway.mdx
@@ -326,19 +326,6 @@ app.use(async ctx => {
 })
 ```
 
-### Mesh and SvelteKit
-
-Similarly to regular and Vercel deployment, we will need to add the `mesh build` command in the
-build step.
-
-```ts filename="index.ts"
-import { createBuiltMeshHTTPHandler } from './.mesh'
-
-const meshHttp = createBuiltMeshHTTPHandler()
-
-export { meshHttp as get, meshHttp as post }
-```
-
 ## Mesh and Docker
 
 A GraphQL Mesh Gateway should be treated like any Node.js project while keeping in mind that a

--- a/website/src/pages/v1/serve/deployment/node-frameworks/_meta.ts
+++ b/website/src/pages/v1/serve/deployment/node-frameworks/_meta.ts
@@ -7,4 +7,5 @@ export default {
   nestjs: 'NestJS',
   uwebsockets: 'µWebSockets.js',
   nextjs: 'Next.js',
+  sveltekit: 'SvelteKit',
 };

--- a/website/src/pages/v1/serve/deployment/node-frameworks/sveltekit.mdx
+++ b/website/src/pages/v1/serve/deployment/node-frameworks/sveltekit.mdx
@@ -1,0 +1,41 @@
+---
+description:
+  SvelteKit is a framework for rapidly developing robust, performant web applications using Svelte.
+---
+
+import { Callout } from '@theguild/components'
+
+# Integration with SvelteKit
+
+[SvelteKit](https://kit.svelte.dev/) is a framework for rapidly developing robust, performant web
+applications using [Svelte](https://svelte.dev/). You can easily integrate Mesh Serve into your
+SvelteKit powered application.
+
+## Example
+
+SvelteKit is typically used together with [Vite](https://vitejs.dev/) with the project structure
+[looking like this](https://kit.svelte.dev/docs/project-structure). We also assume that you have
+composed a `supergraph.graphql` with [Mesh Compose](/v1/compose).
+
+In this example, we want to integrate Mesh Serve into Vite's routes, we'll therefore use the
+runtime.
+
+```sh npm2yarn
+npm i @graphql-mesh/serve-runtime
+```
+
+Keeping the [aforementioned project layout](https://kit.svelte.dev/docs/project-structure) in mind,
+create a new server route in `my-project/src/routes/graphql/+server.ts` to expose the GraphQL server
+at `/graphql` and implement using the Mesh Serve runtime like this:
+
+```ts filename="my-project/src/routes/graphql/+server.ts"
+import { createServeRuntime } from '@graphql-mesh/serve-runtime'
+
+const serve = createServeRuntime({
+  supergraph: 'supergraph.graphql', // working directory is root of the project
+  graphqlEndpoint: '/graphql', // matches the server route path
+  fetchAPI: { Response } // use the native `Response`
+})
+
+export { serve as GET, serve as POST }
+```

--- a/website/src/pages/v1/serve/deployment/node-frameworks/sveltekit.mdx
+++ b/website/src/pages/v1/serve/deployment/node-frameworks/sveltekit.mdx
@@ -3,8 +3,6 @@ description:
   SvelteKit is a framework for rapidly developing robust, performant web applications using Svelte.
 ---
 
-import { Callout } from '@theguild/components'
-
 # Integration with SvelteKit
 
 [SvelteKit](https://kit.svelte.dev/) is a framework for rapidly developing robust, performant web


### PR DESCRIPTION
Closes #7130

Note that v0 SvelteKit example straight up does not work. I spent a chunk of time debugging and decided it wasnt worth the time. [So I just removed the SK example in v0](https://github.com/ardatan/graphql-mesh/pull/7263/commits/48c1c072980173602ab686a650cd8a9e7c465a1e) and expect users to use v1.