### PR TITLE
[v1] Add `schemaHeaders` to introspection queries

### DIFF
--- a/.changeset/loud-teachers-hide.md
+++ b/.changeset/loud-teachers-hide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/compose-cli': patch
+---
+
+`loadGraphQLHTTPSubgraph`: Added `schemaHeaders` to introspection requests

--- a/packages/compose-cli/src/loadGraphQLHTTPSubgraph.ts
+++ b/packages/compose-cli/src/loadGraphQLHTTPSubgraph.ts
@@ -164,6 +164,7 @@ export function loadGraphQLHTTPSubgraph(
             method: method || (useGETForQueries ? 'GET' : 'POST'),
             headers: {
               'Content-Type': 'application/json',
+              ...schemaHeaders,
             },
             body: JSON.stringify({
               query: getIntrospectionQuery(),
@@ -198,6 +199,7 @@ export function loadGraphQLHTTPSubgraph(
             method: method || (useGETForQueries ? 'GET' : 'POST'),
             headers: {
               'Content-Type': 'application/json',
+              ...schemaHeaders,
             },
             body: JSON.stringify({
               query: federationIntrospectionQuery,

--- a/packages/compose-cli/src/types.ts
+++ b/packages/compose-cli/src/types.ts
@@ -1,6 +1,6 @@
 import type { DocumentNode, GraphQLSchema } from 'graphql';
 import type { ComposeSubgraphsOptions } from '@graphql-mesh/fusion-composition';
-import type { Logger } from '@graphql-mesh/types';
+import type { Logger, MeshFetch } from '@graphql-mesh/types';
 import type { fetch as defaultFetch } from '@whatwg-node/fetch';
 
 export interface MeshComposeCLIConfig extends ComposeSubgraphsOptions {
@@ -13,7 +13,7 @@ export interface MeshComposeCLIConfig extends ComposeSubgraphsOptions {
   transforms?: MeshComposeCLITransformConfig[];
   additionalTypeDefs?: string | DocumentNode | (string | DocumentNode)[];
   subgraph?: string;
-  fetch?: typeof defaultFetch;
+  fetch?: MeshFetch;
   cwd?: string;
 }
 
@@ -30,7 +30,7 @@ export type MeshComposeCLISourceHandlerDef = (ctx: LoaderContext) => {
 export type MeshComposeCLITransformConfig = (input: GraphQLSchema, ...args: any[]) => GraphQLSchema;
 
 export interface LoaderContext {
-  fetch: typeof defaultFetch;
+  fetch: MeshFetch;
   cwd: string;
   logger: Logger;
 }

--- a/packages/compose-cli/tests/loadGraphQLHTTPSubgraph.test.ts
+++ b/packages/compose-cli/tests/loadGraphQLHTTPSubgraph.test.ts
@@ -1,0 +1,53 @@
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  introspectionFromSchema,
+  printSchema,
+} from 'graphql';
+import type { MeshFetch } from '@graphql-mesh/types';
+import { DefaultLogger } from '@graphql-mesh/utils';
+import { loadGraphQLHTTPSubgraph } from '../src/loadGraphQLHTTPSubgraph';
+
+describe('loadGraphQLHTTPSubgraph', () => {
+  it('respects schemaHeaders in introspection query', async () => {
+    const fetchFn = jest.fn<Promise<Response>, Parameters<MeshFetch>>(() =>
+      Promise.resolve(
+        Response.json({
+          data: introspectionFromSchema(
+            new GraphQLSchema({
+              query: new GraphQLObjectType({
+                name: 'Query',
+                fields: {
+                  foo: {
+                    type: GraphQLString,
+                  },
+                },
+              }),
+            }),
+          ),
+        }),
+      ),
+    );
+    const loader = loadGraphQLHTTPSubgraph('TEST', {
+      endpoint: 'http://test.com',
+      schemaHeaders: {
+        'x-token': 'reallysafe',
+      },
+    });
+    const { schema$ } = loader({ fetch: fetchFn, cwd: __dirname, logger: new DefaultLogger() });
+    const schema = await schema$;
+    expect(printSchema(schema)).toContain(
+      /* GraphQL */ `
+type Query {
+  foo: String
+}
+`.trim(),
+    );
+    expect(fetchFn.mock.calls[0][1]).toMatchObject({
+      headers: {
+        'x-token': 'reallysafe',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds the headers specified in `schemaHeaders` to introspection queries as well as the current schema fetch requests.

Fixes #7233

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Not sure which one this would qualify as

## How Has This Been Tested?

- [x] Being used with a patch in our deployment

**Test Environment**:

- OS: Amazon Linux
- `@graphql-mesh/runtime-serve`: latest
- NodeJS: 20

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docs are already correct)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

I can't run the tests on either of my machines due to half the tests failing because of `jest` and `__dirname` being undefined