### PR TITLE
feat(serve-cli): Add CLI arguments for polling and error masking and documentation improvements

### DIFF
--- a/.changeset/sharp-experts-run.md
+++ b/.changeset/sharp-experts-run.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/serve-cli': minor
+---
+
+Add CLI arguments for polling and error masking

--- a/.changeset/sharp-experts-run.md
+++ b/.changeset/sharp-experts-run.md
@@ -3,3 +3,14 @@
 ---
 
 Add CLI arguments for polling and error masking
+
+The usage of arguments is as follows:
+
+```
+Usage: mesh-serve [options]
+
+Options:
+  --polling <intervalInMs>  schema polling interval in milliseconds
+  --masked-errors           mask unexpected errors in responses (default: true)
+  --no-masked-errors        don't mask unexpected errors in responses
+```

--- a/packages/serve-cli/src/run.ts
+++ b/packages/serve-cli/src/run.ts
@@ -70,7 +70,16 @@ let program = new Command()
         return port;
       }),
   )
-  .option('--supergraph <path>', 'path to the supergraph schema');
+  .option('--supergraph <path>', 'path to the supergraph schema')
+  .option('--polling <intervalInMs>', 'schema polling interval in milliseconds', v => {
+    const port = parseInt(v);
+    if (isNaN(port)) {
+      throw new InvalidArgumentError('not a number.');
+    }
+    return port;
+  })
+  .option('--masked-errors', 'mask unexpected errors in responses', true)
+  .option('--no-masked-errors', "don't mask unexpected errors in responses", false);
 
 export interface RunOptions extends ReturnType<typeof program.opts> {
   /** @default new DefaultLogger() */

--- a/website/src/pages/v1/serve/references/cli.mdx
+++ b/website/src/pages/v1/serve/references/cli.mdx
@@ -14,20 +14,38 @@ import { Callout } from '@theguild/components'
 An overview of all the CLI arguments and environment variables for the `mesh-serve` CLI.
 [Get started with the CLI](/v1/serve/introduction).
 
-### Arguments
+### Usage
 
-<Callout>All of those can be passed in the configuration file as well</Callout>
+You can get help with using the CLI by appending the `--help` argument:
 
-- `--supergraph`: Path to the supergraph file in Federation Supergraph format
-- `--port` or `-p`: Port to serve the supergraph (default: 4000)
-- `--host` or `-h`: Host to serve the supergraph (default: localhost)
-- `--fork`: Count of workers to spawn. defaults to `os.availableParallelism()` when NODE_ENV is
-  "production", otherwise only one (the main) worker
+```sh
+mesh-serve --help
+```
 
-**If you want to serve a single subgraph, you can use the parameter below and _NOT_ the one above:**
+which will print out the following:
 
-- `--subgraph`: Path to the subgraph file in Federation Subgraph format (conflicts with
-  `--supergraph`)
+{/* IMPORTANT: please dont forget to update the following when arguments change. simply run `node --import tsx packages/serve-cli/src/bin.ts --help` and copy over the text */}
+
+```
+Usage: mesh-serve [options]
+
+serve GraphQL federated architecture for any API service(s)
+
+Options:
+  --fork [count]            count of workers to spawn. defaults to `os.availableParallelism()` when NODE_ENV is "production", otherwise only one (the main)
+                            worker (default: 1, env: FORK)
+  -c, --config-path <path>  path to the configuration file. defaults to the following files respectively in the current working directory: mesh.config.ts,
+                            mesh.config.mts, mesh.config.cts, mesh.config.js, mesh.config.mjs, mesh.config.cjs (env: CONFIG_PATH)
+  -h, --host <hostname>     host to use for serving (default: "0.0.0.0")
+  -p, --port <number>       port to use for serving (default: 4000, env: PORT)
+  --supergraph <path>       path to the supergraph schema
+  --polling <intervalInMs>  schema polling interval in milliseconds
+  --masked-errors           mask unexpected errors in responses (default: true)
+  --no-masked-errors        don't mask unexpected errors in responses
+  --help                    display help for command
+```
+
+<Callout>All arguments can also be configured in the config file.</Callout>
 
 ### Environment Variables
 


### PR DESCRIPTION
Also updated the docs to simply copy over the CLI usage printout.

```
Usage: mesh-serve [options]

Options:
  --polling <intervalInMs>  schema polling interval in milliseconds
  --masked-errors           mask unexpected errors in responses (default: true)
  --no-masked-errors        don't mask unexpected errors in responses
```