### PR TITLE
[OData] Fix action bound to entity set

### DIFF
--- a/.changeset/mighty-suits-pay.md
+++ b/.changeset/mighty-suits-pay.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/odata': minor
+---
+
+support actions bound to entity sets

--- a/packages/legacy/handlers/odata/src/index.ts
+++ b/packages/legacy/handlers/odata/src/index.ts
@@ -1137,66 +1137,106 @@ export default class ODataHandler implements MeshHandler {
         });
       };
 
+      const boundActionEntityParameterDetails = (parameterObj: any) => {
+        const parameterName = parameterObj.attributes.Name;
+        const parameterTypeRef = parameterObj.attributes.Type;
+        const isRequired = parameterObj.attributes.Nullable === 'false';
+        const parameterTypeName = getTypeNameFromRef({
+          typeRef: parameterTypeRef,
+          isInput: true,
+          isRequired,
+        });
+        const boundEntityTypeName = getTypeNameFromRef({
+          typeRef: parameterTypeRef,
+          isInput: false,
+          isRequired: false,
+        })
+          .replace('[', '')
+          .replace(']', ''); // Todo temp workaround
+        return { boundEntityTypeName, argName: parameterName, argType: parameterTypeName };
+      };
+      const boundActionEntitySetDetails = (entitySetObj: any) => {
+        const entitySetTypeRef = entitySetObj.attributes.EntityType;
+        const boundEntityTypeName = getTypeNameFromRef({
+          typeRef: entitySetTypeRef,
+          isInput: false,
+          isRequired: false,
+        });
+
+        const entityOutputTC = getTCByTypeNames('I' + boundEntityTypeName, boundEntityTypeName) as
+          | InterfaceTypeComposer
+          | ObjectTypeComposer;
+        const { entityInfo } = entityOutputTC.getExtensions() as EntityTypeExtensions;
+        const argName = entityInfo.identifierFieldName;
+        const argType = entityOutputTC.getFieldTypeName(argName);
+        return { boundEntityTypeName, argName, argType };
+      };
       const handleBoundActionObj = (boundActionObj: any) => {
         const actionName = boundActionObj.attributes.Name;
         const actionRef = schemaNamespace + '.' + actionName;
+        const entitySetPath = boundActionObj.attributes.EntitySetPath;
+        // If entitySetPath is not specified, take first parameter as entity
+        const entityParameterObj = boundActionObj.Parameter?.find(
+          (parameterObj: any) => !entitySetPath || parameterObj.attributes.Name === entitySetPath,
+        );
+        // Try to find EntitySet matching entitySetPath:
+        const entitySetObj = schemaObj.EntityContainer?.flatMap(
+          entityContainerObj =>
+            entityContainerObj.EntitySet?.flatMap(entitySetObj =>
+              entitySetObj.attributes.Name === entitySetPath ? [entitySetObj] : [],
+            ) ?? [],
+        )?.[0];
+        const { boundEntityTypeName, argName, argType } = entitySetObj
+          ? boundActionEntitySetDetails(entitySetObj)
+          : entityParameterObj
+            ? boundActionEntityParameterDetails(entityParameterObj)
+            : (() => {
+                throw new Error(
+                  `EntitySet ${entitySetPath} not found in schema ${schemaNamespace}`,
+                );
+              })();
+
         const args: ObjectTypeComposerArgumentConfigMapDefinition<any> = {
           ...commonArgs,
+          [argName]: {
+            type: argType,
+          },
         };
-        let entitySetPath = boundActionObj.attributes.EntitySetPath;
-        let boundField: ObjectTypeComposerFieldConfigDefinition<any, any, any>;
-        let boundEntityTypeName: string;
+        // add remaining parameters to args:
         boundActionObj.Parameter?.forEach((parameterObj: any) => {
-          const parameterName = parameterObj.attributes.Name;
-          const parameterTypeRef = parameterObj.attributes.Type;
-          const isRequired = parameterObj.attributes.Nullable === 'false';
-          const parameterTypeName = getTypeNameFromRef({
-            typeRef: parameterTypeRef,
-            isInput: true,
-            isRequired,
-          });
-          // If entitySetPath is not available, take first parameter as entity
-          entitySetPath = entitySetPath || parameterName;
-          if (entitySetPath === parameterName) {
-            boundEntityTypeName = getTypeNameFromRef({
-              typeRef: parameterTypeRef,
-              isInput: false,
-              isRequired: false,
-            })
-              .replace('[', '')
-              .replace(']', ''); // Todo temp workaround
-            boundField = {
-              type: 'JSON',
-              args,
-              resolve: async (root, args, context, info) => {
-                const url = new URL(root['@odata.id']);
-                url.href = urljoin(url.href, '/' + actionRef);
-                const urlString = getUrlString(url);
-                const method = 'POST';
-                const request = new Request(urlString, {
-                  method,
-                  headers: headersFactory(
-                    {
-                      root,
-                      args,
-                      context,
-                      info,
-                      env: process.env,
-                    },
-                    method,
-                  ),
-                  body: JSON.stringify(args),
-                });
-                const response = await context[contextDataloaderName].load(request);
-                const responseText = await response.text();
-                return handleResponseText(responseText, urlString, info);
-              },
-            };
-          }
-          args[parameterName] = {
-            type: parameterTypeName,
+          const { argName, argType } = boundActionEntityParameterDetails(parameterObj);
+          args[argName] = {
+            type: argType,
           };
         });
+
+        const boundField: ObjectTypeComposerFieldConfigDefinition<any, any, any> = {
+          type: 'JSON',
+          args,
+          resolve: async (root, args, context, info) => {
+            const url = new URL(root['@odata.id']);
+            url.href = urljoin(url.href, '/' + actionRef);
+            const urlString = getUrlString(url);
+            const method = 'POST';
+            const request = new Request(urlString, {
+              method,
+              headers: headersFactory(
+                {
+                  root,
+                  args,
+                  context,
+                  info,
+                  env: process.env,
+                },
+                method,
+              ),
+              body: JSON.stringify(args),
+            });
+            const response = await context[contextDataloaderName].load(request);
+            const responseText = await response.text();
+            return handleResponseText(responseText, urlString, info);
+          },
+        };
         const boundEntityType = schemaComposer.getAnyTC(
           boundEntityTypeName,
         ) as InterfaceTypeComposer;

--- a/packages/legacy/handlers/odata/src/index.ts
+++ b/packages/legacy/handlers/odata/src/index.ts
@@ -1180,10 +1180,13 @@ export default class ODataHandler implements MeshHandler {
           (parameterObj: any) => !entitySetPath || parameterObj.attributes.Name === entitySetPath,
         );
         // Try to find EntitySet matching entitySetPath:
-        const entitySetObj = schemaObj.EntityContainer?.flatMap(
-          entityContainerObj =>
-            entityContainerObj.EntitySet?.flatMap(entitySetObj =>
-              entitySetObj.attributes.Name === entitySetPath ? [entitySetObj] : [],
+        const entitySetObj = schemas.flatMap(
+          schemaObj =>
+            schemaObj.EntityContainer?.flatMap(
+              entityContainerObj =>
+                entityContainerObj.EntitySet?.flatMap(entitySetObj =>
+                  entitySetObj.attributes.Name === entitySetPath ? [entitySetObj] : [],
+                ) ?? [],
             ) ?? [],
         )?.[0];
         const { boundEntityTypeName, argName, argType } = entitySetObj

--- a/packages/legacy/handlers/odata/test/__snapshots__/handler.spec.ts.snap
+++ b/packages/legacy/handlers/odata/test/__snapshots__/handler.spec.ts.snap
@@ -427,6 +427,81 @@ input AirportUpdateInput {
 }"
 `;
 
+exports[`odata should create correct GraphQL schema for actions bound to entity set 1`] = `
+"type Person {
+  UserName: String!
+  SendMessage(UserName: String!, Message: String!): JSON
+}
+
+"""
+The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+type Query {
+  People(queryOptions: QueryOptions): [Person]
+  PeopleByUserName(UserName: String!): Person
+  PeopleCount(queryOptions: QueryOptions): Int
+}
+
+input QueryOptions {
+  """
+  A data service URI with a $orderby System Query Option specifies an expression for determining what values are used to order the collection of Entries identified by the Resource Path section of the URI. This query option is only supported when the resource path identifies a Collection of Entries.
+  """
+  orderby: String
+
+  """
+  A data service URI with a $top System Query Option identifies a subset of the Entries in the Collection of Entries identified by the Resource Path section of the URI. This subset is formed by selecting only the first N items of the set, where N is an integer greater than or equal to zero specified by this query option. If a value less than zero is specified, the URI should be considered malformed.
+  """
+  top: Int
+
+  """
+  A data service URI with a $skip System Query Option identifies a subset of the Entries in the Collection of Entries identified by the Resource Path section of the URI. That subset is defined by seeking N Entries into the Collection and selecting only the remaining Entries (starting with Entry N+1). N is an integer greater than or equal to zero specified by this query option. If a value less than zero is specified, the URI should be considered malformed.
+  """
+  skip: Int
+
+  """
+  A URI with a $filter System Query Option identifies a subset of the Entries from the Collection of Entries identified by the Resource Path section of the URI. The subset is determined by selecting only the Entries that satisfy the predicate expression specified by the query option.
+  """
+  filter: String
+
+  """
+  A URI with a $inlinecount System Query Option specifies that the response to the request includes a count of the number of Entries in the Collection of Entries identified by the Resource Path section of the URI. The count must be calculated after applying any $filter System Query Options present in the URI. The set of valid values for the $inlinecount query option are shown in the table below. If a value other than one shown in Table 4 is specified the URI is considered malformed.
+  """
+  inlinecount: InlineCount
+  count: Boolean
+}
+
+enum InlineCount {
+  """
+  The OData MUST include a count of the number of entities in the collection identified by the URI (after applying any $filter System Query Options present on the URI)
+  """
+  allpages
+
+  """
+  The OData service MUST NOT include a count in the response. This is equivalence to a URI that does not include a $inlinecount query string parameter.
+  """
+  none
+}
+
+type Mutation {
+  People(queryOptions: QueryOptions): [Person]
+  PeopleByUserName(UserName: String!): Person
+  createPeople(input: PersonInput): Person
+  deletePeopleByUserName(UserName: String!): JSON
+  updatePeopleByUserName(UserName: String!, input: PersonUpdateInput): Person
+}
+
+input PersonInput {
+  UserName: String!
+}
+
+""""""
+input PersonUpdateInput {
+  UserName: String
+}"
+`;
+
 exports[`odata should create correct GraphQL schema for functions with entity set paths 1`] = `
 "type Person {
   UserName: String!

--- a/packages/legacy/handlers/odata/test/fixtures/alice.json
+++ b/packages/legacy/handlers/odata/test/fixtures/alice.json
@@ -1,0 +1,11 @@
+{
+  "@odata.context": "https://sample.service.com/$metadata#People/$entity",
+  "@odata.type": "#Sample.Service.Person",
+  "@odata.id": "https://sample.service.com/People/alice/",
+  "@odata.editLink": "https://sample.service.com/People/alice/",
+  "UserName": "alice",
+  "#Sample.Service.SendMessage": {
+    "title": "Sample.Service.SendMessage",
+    "target": "https://sample.service.com/People/alice/Sample.Service.SendMessage"
+  }
+}

--- a/packages/legacy/handlers/odata/test/fixtures/bound-action.xml
+++ b/packages/legacy/handlers/odata/test/fixtures/bound-action.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+	<DataServices>
+		<Schema Namespace="Sample.Service" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+			<EntityType Name="Person">
+				<Key>
+					<PropertyRef Name="UserName" />
+				</Key>
+				<Property Name="UserName" Type="Edm.String" Nullable="false" />
+			</EntityType>
+			<EntityContainer Name="Container">
+				<EntitySet Name="People" EntityType="Sample.Service.Person">
+				</EntitySet>
+			</EntityContainer>
+      <Action Name="SendMessage" EntitySetPath="People" IsBound="true">
+        <Parameter Name="UserName" Type="Edm.String" Nullable="false" />
+        <Parameter Name="Message" Type="Edm.String" Nullable="false" />
+      </Action>
+		</Schema>
+	</DataServices>
+</Edmx>

--- a/packages/legacy/handlers/odata/test/handler.spec.ts
+++ b/packages/legacy/handlers/odata/test/handler.spec.ts
@@ -22,6 +22,10 @@ const BasicMetadata = fs.readFileSync(
   path.resolve(__dirname, './fixtures/simple-metadata.xml'),
   'utf-8',
 );
+const BoundActionMetadata = fs.readFileSync(
+  path.resolve(__dirname, './fixtures/bound-action.xml'),
+  'utf-8',
+);
 
 const baseDir = __dirname;
 const importFn = (id: string) => require(id);
@@ -81,6 +85,29 @@ describe('odata', () => {
       fetchFn: mockFetch,
     });
     expect(printSchema(source.schema)).toMatchSnapshot();
+  });
+  it('should create correct GraphQL schema for actions bound to entity set', async () => {
+    addMock(
+      'http://sample.service.com/$metadata',
+      async () => new MockResponse(BoundActionMetadata),
+    );
+    const handler = new ODataHandler({
+      name: 'SampleService',
+      config: {
+        endpoint: 'http://sample.service.com',
+      },
+      pubsub,
+      cache,
+      store,
+      baseDir,
+      importFn,
+      logger,
+    });
+    const source = await handler.getMeshSource({
+      fetchFn: mockFetch,
+    });
+    expect(source.schema).toBeTruthy();
+    // expect(printSchema(source.schema)).toMatchSnapshot();
   });
   it('should declare arguments for fields created from bound functions', async () => {
     addMock(

--- a/packages/legacy/handlers/odata/test/handler.spec.ts
+++ b/packages/legacy/handlers/odata/test/handler.spec.ts
@@ -106,8 +106,7 @@ describe('odata', () => {
     const source = await handler.getMeshSource({
       fetchFn: mockFetch,
     });
-    expect(source.schema).toBeTruthy();
-    // expect(printSchema(source.schema)).toMatchSnapshot();
+    expect(printSchema(source.schema)).toMatchSnapshot();
   });
   it('should declare arguments for fields created from bound functions', async () => {
     addMock(


### PR DESCRIPTION
## Description

Previously OData handler failed on schemas where an action was bound to an entity set instead of one of the action's parameters. This is however [specified](https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_EntitySetPath) used in the wild in Abacus OData schema (see linked issue).

Fixes #6984

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) - it doesn't fail on specific schemas
- [x] New feature (non-breaking change which adds functionality) - actions bound to entity sets now work

## How Has This Been Tested?

`yarn test odata`

**Test Environment**:

- OS: MacOS
- `@graphql-mesh/odata`: master
- NodeJS: v20

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes (there were unrelated failures on master without my changes)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The change is not big, mostly refactoring of the `handleBoundAction` function. I would appreciate if someone familiar with OData could review my test expectations as well.