### PR TITLE
Replace `disposablestack` with `core-js-pure`

### DIFF
--- a/.changeset/ten-cougars-drum.md
+++ b/.changeset/ten-cougars-drum.md
@@ -1,0 +1,8 @@
+---
+'@graphql-mesh/supergraph': patch
+'@graphql-mesh/fusion-runtime': patch
+'@graphql-mesh/serve-runtime': patch
+'@graphql-mesh/utils': patch
+---
+
+Replaced `disposablestack` with much smaller `core-js` implementation

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -18,7 +18,7 @@ declare module '@newrelic/test-utilities' {
   export const TestAgent: any;
 }
 
-declare module 'disposablestack/AsyncDisposableStack' {
+declare module 'core-js-pure/actual/async-disposable-stack' {
   declare var AsyncDisposableStackCtor: typeof AsyncDisposableStack;
   export = AsyncDisposableStackCtor;
 }

--- a/packages/fusion/runtime/package.json
+++ b/packages/fusion/runtime/package.json
@@ -63,7 +63,7 @@
     "@graphql-tools/utils": "^10.2.3",
     "@graphql-tools/wrap": "^10.0.5",
     "change-case": "^4.1.2",
-    "disposablestack": "^1.1.6",
+    "core-js-pure": "^3.37.1",
     "graphql-yoga": "^5.6.0",
     "tslib": "^2.4.0"
   },

--- a/packages/fusion/runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion/runtime/src/unifiedGraphManager.ts
@@ -1,4 +1,4 @@
-import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
 import type { DocumentNode, GraphQLSchema } from 'graphql';
 import { buildASTSchema, buildSchema, isSchema } from 'graphql';
 import { getInContextSDK } from '@graphql-mesh/runtime';

--- a/packages/fusion/runtime/src/unifiedGraphManager.ts
+++ b/packages/fusion/runtime/src/unifiedGraphManager.ts
@@ -1,4 +1,4 @@
-import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack/index.js';
 import type { DocumentNode, GraphQLSchema } from 'graphql';
 import { buildASTSchema, buildSchema, isSchema } from 'graphql';
 import { getInContextSDK } from '@graphql-mesh/runtime';

--- a/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
+++ b/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack/index.js';
 import type { ServerOptions } from 'graphql-ws/lib/server';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import type { YogaServerInstance } from 'graphql-yoga';

--- a/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
+++ b/packages/legacy/handlers/supergraph/tests/supergraph.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
 import type { ServerOptions } from 'graphql-ws/lib/server';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import type { YogaServerInstance } from 'graphql-yoga';

--- a/packages/legacy/utils/package.json
+++ b/packages/legacy/utils/package.json
@@ -42,7 +42,7 @@
     "@graphql-mesh/string-interpolation": "^0.5.4",
     "@graphql-tools/delegate": "^10.0.14",
     "@whatwg-node/fetch": "^0.9.13",
-    "disposablestack": "^1.1.6",
+    "core-js-pure": "^3.37.1",
     "dset": "^3.1.2",
     "jiti": "^1.21.6",
     "js-yaml": "^4.1.0",

--- a/packages/legacy/utils/src/registerTerminateHandler.ts
+++ b/packages/legacy/utils/src/registerTerminateHandler.ts
@@ -1,4 +1,4 @@
-import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
 
 const terminateEvents = ['SIGINT', 'SIGTERM'] as const;
 

--- a/packages/legacy/utils/src/registerTerminateHandler.ts
+++ b/packages/legacy/utils/src/registerTerminateHandler.ts
@@ -1,4 +1,4 @@
-import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack/index.js';
 
 const terminateEvents = ['SIGINT', 'SIGTERM'] as const;
 

--- a/packages/serve-runtime/package.json
+++ b/packages/serve-runtime/package.json
@@ -53,7 +53,7 @@
     "@graphql-tools/stitch": "^9.2.10",
     "@graphql-tools/utils": "^10.2.3",
     "@whatwg-node/server": "^0.9.34",
-    "disposablestack": "^1.1.6",
+    "core-js-pure": "^3.37.1",
     "graphql-yoga": "^5.6.0"
   },
   "devDependencies": {

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import type { IncomingMessage } from 'node:http';
-import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack/index.js';
 import type { GraphQLSchema } from 'graphql';
 import { parse } from 'graphql';
 import {

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import type { IncomingMessage } from 'node:http';
-import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
+import AsyncDisposableStack from 'core-js-pure/actual/async-disposable-stack';
 import type { GraphQLSchema } from 'graphql';
 import { parse } from 'graphql';
 import {

--- a/packages/serve-runtime/tests/hive.spec.ts
+++ b/packages/serve-runtime/tests/hive.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { createServer } from 'http';
 import type { AddressInfo } from 'net';
-import AsyncDisposableStack from 'disposablestack/AsyncDisposableStack';
 import {
   buildClientSchema,
   getIntrospectionQuery,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4944,7 +4944,7 @@ __metadata:
     "@graphql-tools/utils": "npm:^10.2.3"
     "@graphql-tools/wrap": "npm:^10.0.5"
     change-case: "npm:^4.1.2"
-    disposablestack: "npm:^1.1.6"
+    core-js-pure: "npm:^3.37.1"
     graphql-yoga: "npm:^5.6.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
@@ -5525,7 +5525,7 @@ __metadata:
     "@graphql-tools/stitch": "npm:^9.2.10"
     "@graphql-tools/utils": "npm:^10.2.3"
     "@whatwg-node/server": "npm:^0.9.34"
-    disposablestack: "npm:^1.1.6"
+    core-js-pure: "npm:^3.37.1"
     graphql-sse: "npm:^2.5.3"
     graphql-yoga: "npm:^5.6.0"
     html-minifier-terser: "npm:7.2.0"
@@ -6077,7 +6077,7 @@ __metadata:
     "@types/lodash.topath": "npm:4.5.9"
     "@types/object-hash": "npm:3.0.6"
     "@whatwg-node/fetch": "npm:^0.9.13"
-    disposablestack: "npm:^1.1.6"
+    core-js-pure: "npm:^3.37.1"
     dset: "npm:^3.1.2"
     jiti: "npm:^1.21.6"
     js-yaml: "npm:^4.1.0"
@@ -14961,7 +14961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-pure@npm:^3.23.3":
+"core-js-pure@npm:^3.23.3, core-js-pure@npm:^3.37.1":
   version: 3.37.1
   resolution: "core-js-pure@npm:3.37.1"
   checksum: 10c0/38200d08862b4ef2207af72a7525f7b9ac750f5e1d84ef27a3e314aefa69518179a9b732f51ebe35c3b38606d9fa4f686fcf6eff067615cc293a3b1c84041e74
@@ -16269,7 +16269,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.1, define-data-property@npm:^1.1.4":
+"define-data-property@npm:^1.0.1, define-data-property@npm:^1.1.4":
   version: 1.1.4
   resolution: "define-data-property@npm:1.1.4"
   dependencies:
@@ -16515,25 +16515,6 @@ __metadata:
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
-  languageName: node
-  linkType: hard
-
-"disposablestack@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "disposablestack@npm:1.1.6"
-  dependencies:
-    call-bind: "npm:^1.0.7"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.23.3"
-    es-errors: "npm:^1.3.0"
-    es-set-tostringtag: "npm:^2.0.3"
-    get-intrinsic: "npm:^1.2.4"
-    globalthis: "npm:^1.0.4"
-    has-symbols: "npm:^1.0.3"
-    hasown: "npm:^2.0.2"
-    internal-slot: "npm:^1.0.7"
-    suppressed-error: "npm:^1.0.3"
-  checksum: 10c0/ea7e165148f076f3c9e7f40aa8f8deb7d33cd9d09c3938c593a899bdbc43fd1cd746182c0cefb0c54be6ec375a5634e68907408f93a2916bb50c6861f978ae62
   languageName: node
   linkType: hard
 
@@ -17087,7 +17068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-errors@npm:^1.1.0, es-errors@npm:^1.2.1, es-errors@npm:^1.3.0":
+"es-errors@npm:^1.2.1, es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
@@ -19655,7 +19636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globalthis@npm:^1.0.3, globalthis@npm:^1.0.4":
+"globalthis@npm:^1.0.3":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
   dependencies:
@@ -20259,7 +20240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.1, has-property-descriptors@npm:^1.0.2":
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.2":
   version: 1.0.2
   resolution: "has-property-descriptors@npm:1.0.2"
   dependencies:
@@ -33167,22 +33148,6 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
-  languageName: node
-  linkType: hard
-
-"suppressed-error@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "suppressed-error@npm:1.0.3"
-  dependencies:
-    define-data-property: "npm:^1.1.1"
-    define-properties: "npm:^1.2.1"
-    es-abstract: "npm:^1.22.3"
-    es-errors: "npm:^1.1.0"
-    function-bind: "npm:^1.1.2"
-    globalthis: "npm:^1.0.3"
-    has-property-descriptors: "npm:^1.0.1"
-    set-function-name: "npm:^2.0.1"
-  checksum: 10c0/e16592004cabda11bc257d437264d657ed2fabf20b6bea0f2b1978fcb6e0c20b09e398c92773c337e21ef856bb247e320e907c734ccd1cae96395823e6d84aef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR replaces the `disposablestack` with `core-js-pure` to improve install sizes and performance.

Installing the entire `core-js-pure` library is only 1.1MB (1 dependency) while `disposablestack` that is supposed to install only its namesake actually pulls in ~3.5MB (66 dependencies!!) worth of ponyfills for no valid reason!

These ponyfills also slow down performance (slightly) since they don't use the native implementations of the things they replace.

More details can be found in #7234

Fixes #7234

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We have been replacing all `disposablestack/AsyncDisposableStack` imports with `core-js-pure/actual/async-disposable-stack` in our services' builds and have encountered no issues.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I still have no idea why my tests are failing locally, saying that `__dirname` and `jest` are undefined 😕 