### PR TITLE
feat(serve-cli): isolate bundle modules in the docker image and read-only bundle files

### DIFF
--- a/packages/serve-cli/Dockerfile
+++ b/packages/serve-cli/Dockerfile
@@ -1,14 +1,15 @@
+# syntax=docker/dockerfile:1.7-labs
+
 # IMPORTANT: make sure bundle is ready with `yarn bundle`
 
 # we build with Node 21 because node-libcurl has published prebuilt releases (building from source fails when using Node 22)
-FROM node:21 AS build
+FROM node:21 AS install
 
-WORKDIR /build
+WORKDIR /install
 
-COPY bundle/package.json package.json
-RUN npm i
-
-COPY bundle .
+RUN npm i \
+  uNetworking/uWebSockets.js#semver:^20 \
+  node-libcurl
 
 #
 
@@ -24,9 +25,13 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /serve
 
-COPY --from=build /build .
+COPY --chown=root --from=install /install/node_modules /node_modules
+COPY --chown=root --exclude=dist bundle /
+COPY --chown=root bundle/dist .
 
-RUN chown -R node .
+# node user can create files and install modules, but not modify the bundle (existing contents)
+RUN chown node . && \
+  echo "{}" > package.json && chown node package.json
 
 USER node
-ENTRYPOINT ["dumb-init", "node", "--enable-source-maps", "."]
+ENTRYPOINT ["dumb-init", "node", "--enable-source-maps", "bin.mjs"]

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -125,48 +125,76 @@ need to create a new Dockerfile basing the image off `ghcr.io/ardatan/mesh-serve
 For example, adding [Rate Limiting](/v1/serve/features/security/rate-limiting) to the container
 would look like this:
 
+### Install plugin
+
+If you want to only add a plugin (or some other dependencies), you can simply extend the image and
+install the modules with `npm i`:
+
 ```dockerfile filename="Dockerfile"
 FROM ghcr.io/ardatan/mesh-serve
 
 RUN npm i @graphql-mesh/plugin-rate-limit
 ```
 
-Build your image:
+### Develop additional resolvers
 
-```sh
-docker build -t mesh-serve-w-rate-limit .
+However, you may have additional resolvers and have a more sophisticated setup with some
+dependencies and source code, copying over your project's files is the way to go.
+
+Say you have the following files:
+
+```json filename="package.json"
+{
+  "name": "my-time",
+  "dependencies": {
+    "moment": "^2"
+  },
+  "devDependencies": {
+    "@graphql-mesh/serve-cli": "latest"
+  }
+}
 ```
 
-Configure to use the rate limiting plugin:
+```js filename="my-time.ts"
+import moment from 'moment'
+
+export const additionalResolvers = {
+  Query: {
+    formattedToday() {
+      return moment().format('DD.MM.YYYY')
+    }
+  }
+}
+```
 
 ```ts filename="mesh.config.ts"
-import useRateLimit from '@graphql-mesh/plugin-rate-limit'
 import { defineConfig } from '@graphql-mesh/serve-cli'
+import { additionalResolvers } from './my-time'
 
-export const serveConfig = defineConfig({
-  plugins: pluginCtx => [
-    useRateLimit({
-      ...pluginCtx,
-      rules: [
-        {
-          type: 'Query',
-          field: 'foo',
-          max: 5, // requests limit for a time period
-          ttl: 5000, // time period
-          // You can use any value from the context
-          identifier: '{context.headers.authorization}'
-        }
-      ]
-    })
-  ]
-})
+export const serveConfig = defineConfig({ additionalResolvers })
 ```
 
-And then simply start the new image with the config file mounted:
+Your Dockerfile should then look something like this:
+
+```dockerfile filename="Dockerfile"
+FROM ghcr.io/ardatan/mesh-serve
+
+# we dont install dev deps because we need them for types only
+COPY package.json .
+RUN npm i --omit=dev
+
+COPY my-time.ts .
+COPY mesh.config.ts .
+```
+
+Then build your image:
 
 ```sh
-docker run \
-  -p 4000:4000 \
-  -v "$(pwd)/mesh.config.ts:/serve/mesh.config.ts" \
-  mesh-serve-w-rate-limit
+docker build -t mesh-serve-w-add-res .
+```
+
+And finally start it (the config file is in the image and doesn't need to be mounted):
+
+```sh
+docker run -p 4000:4000 mesh-serve-w-add-res
 ```

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -136,32 +136,59 @@ FROM ghcr.io/ardatan/mesh-serve
 RUN npm i @graphql-mesh/plugin-rate-limit
 ```
 
-### Develop additional resolvers
+### Develop plugin
 
-However, you may have additional resolvers and have a more sophisticated setup with some
-dependencies and source code, copying over your project's files is the way to go.
+However, you may be developing a plugin and have a setup with some dependencies and source code,
+copying over your project's files is the way to go.
 
-Say you have the following files:
+In the following example, we're developing a `useTiming` plugin that will add a human readable
+execution duration to the GraphQL result `extensions` property.
 
 ```json filename="package.json"
 {
-  "name": "my-time",
+  "name": "my-timing",
   "dependencies": {
     "moment": "^2"
   },
   "devDependencies": {
-    "@graphql-mesh/serve-cli": "latest"
+    "@graphql-mesh/serve-cli": "latest",
+    "@graphql-mesh/serve-runtime": "latest"
   }
 }
 ```
 
-```js filename="my-time.ts"
+```ts filename="my-timing.ts"
 import moment from 'moment'
+import type { MeshServePlugin } from '@graphql-mesh/serve-runtime'
 
-export const additionalResolvers = {
-  Query: {
-    formattedToday() {
-      return moment().format('DD.MM.YYYY')
+export function useTiming(): MeshServePlugin {
+  return {
+    onExecute() {
+      const start = Date.now()
+      return {
+        onExecuteDone({ result, setResult }) {
+          const duration = moment.duration(Date.now() - start)
+          if (isAsyncIterable(result)) {
+            setResult(
+              mapAsyncIterator(result, result => ({
+                ...result,
+                extensions: {
+                  ...result?.extensions,
+                  duration: duration.humanize()
+                }
+              }))
+            )
+            return
+          }
+          setResult({
+            ...result,
+            extensions: {
+              ...result?.extensions,
+              duration: duration.humanize()
+            }
+          })
+        }
+      }
     }
   }
 }
@@ -169,9 +196,11 @@ export const additionalResolvers = {
 
 ```ts filename="mesh.config.ts"
 import { defineConfig } from '@graphql-mesh/serve-cli'
-import { additionalResolvers } from './my-time'
+import { useTiming } from './my-timing'
 
-export const serveConfig = defineConfig({ additionalResolvers })
+export const serveConfig = defineConfig({
+  plugins: () => [useTiming()]
+})
 ```
 
 Your Dockerfile should then look something like this:
@@ -179,7 +208,9 @@ Your Dockerfile should then look something like this:
 ```dockerfile filename="Dockerfile"
 FROM ghcr.io/ardatan/mesh-serve
 
-# we dont install dev deps because we need them for types only
+# we dont install dev deps because:
+#   1. we need them for type checking only
+#   2. Mesh Serve is already available in the docker image
 COPY package.json .
 RUN npm i --omit=dev
 
@@ -198,3 +229,16 @@ And finally start it (the config file is in the image and doesn't need to be mou
 ```sh
 docker run -p 4000:4000 mesh-serve-w-add-res
 ```
+
+<Callout>
+  For faster development, you can mount the source code as volumes so that you don't have to rebuild
+  the image on each run.
+
+```sh
+docker run -p 4000:4000 \
+  -v "$(pwd)/mesh.config.ts":/serve/mesh.config.ts \
+  -v "$(pwd)/my-timing.ts":/serve/my-timing.ts \
+  mesh-serve-w-add-res
+```
+
+</Callout>

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -280,3 +280,69 @@ docker run -p 4000:4000 \
 ```
 
 </Callout>
+
+### Additional Resolvers
+
+Instead maybe you need to define additional resolvers that depend on other dependencies. Similarily
+to the [Develop Plugin](#develop-plugin) approach, you can just copy the project code over and build
+another image.
+
+Say you have the following files:
+
+```json filename="package.json"
+{
+  "name": "my-time",
+  "dependencies": {
+    "moment": "^2"
+  },
+  "devDependencies": {
+    "@graphql-mesh/serve-cli": "latest"
+  }
+}
+```
+
+```js filename="my-time.ts"
+import moment from 'moment'
+
+export const additionalResolvers = {
+  Query: {
+    formattedToday() {
+      return moment().format('DD.MM.YYYY')
+    }
+  }
+}
+```
+
+```ts filename="mesh.config.ts"
+import { defineConfig } from '@graphql-mesh/serve-cli'
+import { additionalResolvers } from './my-time'
+
+export const serveConfig = defineConfig({ additionalResolvers })
+```
+
+Your Dockerfile should then look something like this:
+
+```dockerfile filename="Dockerfile"
+FROM ghcr.io/ardatan/mesh-serve
+
+# we dont install dev deps because:
+#   1. we need them for type checking only
+#   2. Mesh Serve is already available in the docker image
+COPY package.json .
+RUN npm i --omit=dev
+
+COPY my-time.ts .
+COPY mesh.config.ts .
+```
+
+Then build your image:
+
+```sh
+docker build -t mesh-serve-w-add-res .
+```
+
+And finally start it (the config file is in the image and doesn't need to be mounted):
+
+```sh
+docker run -p 4000:4000 mesh-serve-w-add-res
+```

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -259,13 +259,13 @@ COPY mesh.config.ts .
 Then build your image:
 
 ```sh
-docker build -t mesh-serve-w-add-res .
+docker build -t mesh-serve-w-my-timing .
 ```
 
 And finally start it (the config file is in the image and doesn't need to be mounted):
 
 ```sh
-docker run -p 4000:4000 mesh-serve-w-add-res
+docker run -p 4000:4000 mesh-serve-w-my-timing
 ```
 
 <Callout>
@@ -276,7 +276,7 @@ docker run -p 4000:4000 mesh-serve-w-add-res
 docker run -p 4000:4000 \
   -v "$(pwd)/mesh.config.ts":/serve/mesh.config.ts \
   -v "$(pwd)/my-timing.ts":/serve/my-timing.ts \
-  mesh-serve-w-add-res
+  mesh-serve-w-my-timing
 ```
 
 </Callout>

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -119,21 +119,59 @@ docker compose up
 
 ## Extend Docker Image
 
-For cases where you want to add additional functionality, or plugins to the base image - you just
-need to create a new Dockerfile basing the image off `ghcr.io/ardatan/mesh-serve`.
+### Install plugin
+
+You may want to add additional functionality, or plugins to the base image - you just need to create
+a new Dockerfile basing the image off `ghcr.io/ardatan/mesh-serve`.
+
+If need only a handful of plugins (or some other dependencies), you can simply extend the image and
+install the modules with `npm i`:
 
 For example, adding [Rate Limiting](/v1/serve/features/security/rate-limiting) to the container
 would look like this:
-
-### Install plugin
-
-If you want to only add a plugin (or some other dependencies), you can simply extend the image and
-install the modules with `npm i`:
 
 ```dockerfile filename="Dockerfile"
 FROM ghcr.io/ardatan/mesh-serve
 
 RUN npm i @graphql-mesh/plugin-rate-limit
+```
+
+```sh
+docker build -t mesh-serve-w-rate-limit .
+```
+
+Configure to use the rate limiting plugin:
+
+```ts filename="mesh.config.ts"
+import useRateLimit from '@graphql-mesh/plugin-rate-limit'
+import { defineConfig } from '@graphql-mesh/serve-cli'
+
+export const serveConfig = defineConfig({
+  plugins: pluginCtx => [
+    useRateLimit({
+      ...pluginCtx,
+      rules: [
+        {
+          type: 'Query',
+          field: 'foo',
+          max: 5, // requests limit for a time period
+          ttl: 5000, // time period
+          // You can use any value from the context
+          identifier: '{context.headers.authorization}'
+        }
+      ]
+    })
+  ]
+})
+```
+
+And then simply start the new image with the config file mounted:
+
+```sh
+docker run \
+  -p 4000:4000 \
+  -v "$(pwd)/mesh.config.ts:/serve/mesh.config.ts" \
+  mesh-serve-w-rate-limit
 ```
 
 ### Develop plugin

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -249,7 +249,7 @@ FROM ghcr.io/ardatan/mesh-serve
 # we dont install dev deps because:
 #   1. we need them for type checking only
 #   2. Mesh Serve is already available in the docker image
-COPY package.json .
+COPY package*.json .
 RUN npm i --omit=dev
 
 COPY my-time.ts .
@@ -328,7 +328,7 @@ FROM ghcr.io/ardatan/mesh-serve
 # we dont install dev deps because:
 #   1. we need them for type checking only
 #   2. Mesh Serve is already available in the docker image
-COPY package.json .
+COPY package*.json .
 RUN npm i --omit=dev
 
 COPY my-time.ts .

--- a/website/src/pages/v1/serve/deployment/docker.mdx
+++ b/website/src/pages/v1/serve/deployment/docker.mdx
@@ -61,7 +61,7 @@ docker run \
 
 For a full list of CLI arguments, please refer to the [Config Reference](./references/config).
 
-### Changing port in container
+### Changing Port in Container
 
 The default port where Mesh Serve listens is `4000`; however, maybe the container is running inside
 a network (like when using [Networking in Compose](https://docs.docker.com/compose/networking/)) and
@@ -119,7 +119,7 @@ docker compose up
 
 ## Extend Docker Image
 
-### Install plugin
+### Install Plugin
 
 You may want to add additional functionality, or plugins to the base image - you just need to create
 a new Dockerfile basing the image off `ghcr.io/ardatan/mesh-serve`.
@@ -174,7 +174,7 @@ docker run \
   mesh-serve-w-rate-limit
 ```
 
-### Develop plugin
+### Develop Plugin
 
 However, you may be developing a plugin and have a setup with some dependencies and source code,
 copying over your project's files is the way to go.


### PR DESCRIPTION
By moving the bundled `node_modules` outside the workdir of mesh-serve (in the root `/node_module`) we allow for easier extending of the image where copying an external `package.json` (wont overwrite an existing one in the image). We also make sure that no package manager manipulates the bundle (running `npm i` will remove the bundle modules from workdir's `node_modules`).

### TODO
- [x] Documentation