### PR TITLE
feat(serve-cli): configure `maxHeaderSize`

### DIFF
--- a/.changeset/olive-waves-reflect.md
+++ b/.changeset/olive-waves-reflect.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/serve-cli': patch
+---
+
+Ability to configure max header size if you get 431 with headers payload longer than 16kb which is
+default value for Node.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,7 +63,7 @@
       }
     },
     {
-      "files": ["e2e/**/*"],
+      "files": ["e2e/**/*", "packages/serve-cli/**/*"],
       "rules": {
         "import/no-nodejs-modules": "off"
       }

--- a/packages/serve-cli/src/nodeHttp.ts
+++ b/packages/serve-cli/src/nodeHttp.ts
@@ -1,11 +1,7 @@
-// eslint-disable-next-line import/no-nodejs-modules
-import { promises as fsPromises } from 'fs';
-// eslint-disable-next-line import/no-nodejs-modules
-import { createServer as createHTTPServer } from 'http';
-// eslint-disable-next-line import/no-nodejs-modules
-import { createServer as createHTTPSServer } from 'https';
-// eslint-disable-next-line import/no-nodejs-modules
-import type { SecureContextOptions } from 'tls';
+import { promises as fsPromises } from 'node:fs';
+import { createServer as createHTTPServer } from 'node:http';
+import { createServer as createHTTPSServer } from 'node:https';
+import type { SecureContextOptions } from 'node:tls';
 import type { RecognizedString } from 'uWebSockets.js';
 import type { ServerOptions } from './types.js';
 
@@ -26,6 +22,7 @@ export async function startNodeHttpServer({
   host,
   port,
   sslCredentials,
+  maxHeaderSize,
 }: ServerOptions): Promise<AsyncDisposable> {
   if (sslCredentials) {
     const sslOptionsForNodeHttp: SecureContextOptions = {};
@@ -77,7 +74,12 @@ export async function startNodeHttpServer({
       });
     });
   }
-  const server = createHTTPServer(handler);
+  const server = createHTTPServer(
+    {
+      maxHeaderSize,
+    },
+    handler,
+  );
   log.info(`Starting server on ${protocol}://${host}:${port}`);
   return new Promise((resolve, reject) => {
     server.once('error', reject);

--- a/packages/serve-cli/src/run.ts
+++ b/packages/serve-cli/src/run.ts
@@ -1,14 +1,10 @@
 import 'json-bigint-patch'; // JSON.parse/stringify with bigints support
 import 'dotenv/config'; // inject dotenv options to process.env
 
-// eslint-disable-next-line import/no-nodejs-modules
-import cluster from 'cluster';
-// eslint-disable-next-line import/no-nodejs-modules
-import { availableParallelism, release } from 'os';
-// eslint-disable-next-line import/no-nodejs-modules
-import { dirname, isAbsolute, resolve } from 'path';
+import cluster from 'node:cluster';
+import { availableParallelism, release } from 'node:os';
+import { dirname, isAbsolute, resolve } from 'node:path';
 import createJITI from 'jiti';
-// import { tsImport } from 'tsx/dist/esm/api/index.mjs';
 import { Command, InvalidArgumentError, Option } from '@commander-js/extra-typings';
 import type { UnifiedGraphConfig } from '@graphql-mesh/serve-runtime';
 import { createServeRuntime } from '@graphql-mesh/serve-runtime';
@@ -253,6 +249,7 @@ export async function run({
     host,
     port,
     sslCredentials: config.sslCredentials,
+    maxHeaderSize: config.maxHeaderSize || 16_384,
   });
   terminateStack.use(server);
 }

--- a/packages/serve-cli/src/types.ts
+++ b/packages/serve-cli/src/types.ts
@@ -22,6 +22,12 @@ export type MeshServeCLIConfig = MeshServeConfig<MeshServeCLIContext> & {
    */
   sslCredentials?: AppOptions;
   /**
+   * The size of the HTTP headers to allow
+   *
+   * @default 16384
+   */
+  maxHeaderSize?: number;
+  /**
    * Path to the browser that will be used by `mesh serve` to open a playground window in development mode
    * This feature can be disabled by passing `false`
    */
@@ -41,5 +47,6 @@ export interface ServerOptions {
   protocol: 'http' | 'https';
   host: string;
   port: number;
+  maxHeaderSize: number;
   sslCredentials?: MeshServeCLIConfig['sslCredentials'];
 }

--- a/packages/serve-cli/src/uWebSockets.ts
+++ b/packages/serve-cli/src/uWebSockets.ts
@@ -7,7 +7,9 @@ export async function startuWebSocketsServer({
   host,
   port,
   sslCredentials,
+  maxHeaderSize,
 }: ServerOptions): Promise<Disposable> {
+  process.env.UWS_HTTP_MAX_HEADERS_SIZE = maxHeaderSize.toString();
   return import('uWebSockets.js').then(uWS => {
     const app = sslCredentials ? uWS.SSLApp(sslCredentials) : uWS.App();
     app.any('/*', handler);

--- a/website/src/pages/v1/compose/source-handlers/index.mdx
+++ b/website/src/pages/v1/compose/source-handlers/index.mdx
@@ -43,16 +43,6 @@ in this doc.
 
 </Callout>
 
-<Callout emoji="⚠️" type="warning">
-  Using (very) long headers?
-
-Under the hood, Mesh is using `uWebSockets` to serve the GraphQL API. `uWebSockets` has a length
-limit, and responds with 431 code if the header is too long. In case you are using long headers, you
-may need to set `UWS_HTTP_MAX_HEADERS_SIZE` environment variable with a higher value. For example,
-you can set it to 16384 (16KB).
-
-</Callout>
-
 ### Setting configurations
 
 There are two headers-designated configuration fields under each handler - `schemaHeaders` and

--- a/website/src/pages/v1/serve/references/config.mdx
+++ b/website/src/pages/v1/serve/references/config.mdx
@@ -285,6 +285,19 @@ export const serveConfig = defineConfig({
 })
 ```
 
+#### `maxHeaderSize`
+
+This is the option to configure the maximum header size of the server. By default, it is 16KB. If
+longer headers are sent, the server will respond with a 431 status code.
+
+```ts filename="mesh.config.ts"
+import { defineConfig } from '@graphql-mesh/serve-cli'
+
+export const serveConfig = defineConfig({
+  maxHeaderSize: 32 * 1024 // 32KB
+})
+```
+
 #### `plugins`
 
 This is the option to extend your Mesh Gateway with plugins. GraphQL Mesh uses


### PR DESCRIPTION
Ability to configure max header size if you get 431 with headers payload longer than 16kb.
By default, it is 16KB. If longer headers are sent, the server will respond with a 431 status code.

```ts filename="mesh.config.ts"
import { defineConfig } from '@graphql-mesh/serve-cli'

export const serveConfig = defineConfig({
  maxHeaderSize: 32 * 1024 // 32KB
})
```