### PR TITLE
fix(legacy/utils,legacy/cli): no jiti in utils, but use it as default JS importer in cli

### DIFF
--- a/.changeset/@graphql-mesh_cli-7360-dependencies.md
+++ b/.changeset/@graphql-mesh_cli-7360-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+dependencies updates:
+  - Added dependency [`jiti@^1.21.6` ↗︎](https://www.npmjs.com/package/jiti/v/1.21.6) (to `dependencies`)

--- a/.changeset/@graphql-mesh_utils-7360-dependencies.md
+++ b/.changeset/@graphql-mesh_utils-7360-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/utils": patch
+---
+dependencies updates:
+  - Removed dependency [`jiti@^1.21.6` ↗︎](https://www.npmjs.com/package/jiti/v/1.21.6) (from `dependencies`)

--- a/.changeset/two-geese-relate.md
+++ b/.changeset/two-geese-relate.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+No jiti, keep the utils JS env agnostic

--- a/.changeset/young-tips-bake.md
+++ b/.changeset/young-tips-bake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': patch
+---
+
+Use jiti as default JS importer

--- a/packages/legacy/cli/package.json
+++ b/packages/legacy/cli/package.json
@@ -61,6 +61,7 @@
     "dotenv": "^16.0.3",
     "graphql-import-node": "^0.0.5",
     "graphql-ws": "^5.12.1",
+    "jiti": "^1.21.6",
     "json-bigint-patch": "^0.0.8",
     "json5": "^2.2.3",
     "mkdirp": "^3.0.0",

--- a/packages/legacy/cli/src/config.ts
+++ b/packages/legacy/cli/src/config.ts
@@ -6,7 +6,7 @@ import { path, process } from '@graphql-mesh/cross-helpers';
 import type { YamlConfig } from '@graphql-mesh/types';
 import { jsonSchema } from '@graphql-mesh/types';
 import { DefaultLogger, loadYaml } from '@graphql-mesh/utils';
-import { defaultImportFn } from './defaultImportFn';
+import { defaultImportFn } from './defaultImportFn.js';
 
 export function validateConfig(
   config: any,

--- a/packages/legacy/cli/src/config.ts
+++ b/packages/legacy/cli/src/config.ts
@@ -5,7 +5,8 @@ import { processConfig } from '@graphql-mesh/config';
 import { path, process } from '@graphql-mesh/cross-helpers';
 import type { YamlConfig } from '@graphql-mesh/types';
 import { jsonSchema } from '@graphql-mesh/types';
-import { defaultImportFn, DefaultLogger, loadYaml } from '@graphql-mesh/utils';
+import { DefaultLogger, loadYaml } from '@graphql-mesh/utils';
+import { defaultImportFn } from './defaultImportFn';
 
 export function validateConfig(
   config: any,

--- a/packages/legacy/cli/src/defaultImportFn.ts
+++ b/packages/legacy/cli/src/defaultImportFn.ts
@@ -1,10 +1,17 @@
-import createJITI from 'jiti';
+import createJITI, { type JITI } from 'jiti';
 import type { ImportFn } from '@graphql-mesh/types';
 
-const jiti = createJITI(__filename);
+let jiti: JITI;
+function getOrCreateImportFn(): ImportFn {
+  if (!jiti) {
+    // we instantiate on demand because sometimes jiti is not used
+    jiti = createJITI(__filename);
+  }
+  return id => jiti.import(id, {}) as Promise<any>;
+}
 
 export const defaultImportFn: ImportFn = async id => {
-  let module: any = await jiti.import(id, {});
+  let module: any = await getOrCreateImportFn()(id);
   if (module.default != null) {
     module = module.default;
   }

--- a/packages/legacy/cli/src/defaultImportFn.ts
+++ b/packages/legacy/cli/src/defaultImportFn.ts
@@ -1,0 +1,8 @@
+import createJITI from 'jiti';
+import type { ImportFn } from '@graphql-mesh/types';
+
+const jiti = createJITI(__filename);
+
+export const defaultImportFn: ImportFn = module => {
+  return jiti.import(module, {}) as Promise<any>;
+};

--- a/packages/legacy/cli/src/defaultImportFn.ts
+++ b/packages/legacy/cli/src/defaultImportFn.ts
@@ -3,6 +3,20 @@ import type { ImportFn } from '@graphql-mesh/types';
 
 const jiti = createJITI(__filename);
 
-export const defaultImportFn: ImportFn = module => {
-  return jiti.import(module, {}) as Promise<any>;
+export const defaultImportFn: ImportFn = async id => {
+  let module: any = await jiti.import(id, {});
+  if (module.default != null) {
+    module = module.default;
+  }
+  if (typeof module === 'object' && module != null) {
+    const prototypeOfObject = Object.getPrototypeOf(module);
+    if (prototypeOfObject == null || prototypeOfObject === Object.prototype) {
+      const normalizedVal: Record<string, any> = {};
+      for (const key in module) {
+        normalizedVal[key] = module[key];
+      }
+      return normalizedVal;
+    }
+  }
+  return module;
 };

--- a/packages/legacy/cli/src/index.ts
+++ b/packages/legacy/cli/src/index.ts
@@ -7,7 +7,6 @@ import { getMesh } from '@graphql-mesh/runtime';
 import { FsStoreStorageAdapter, MeshStore } from '@graphql-mesh/store';
 import type { Logger, YamlConfig } from '@graphql-mesh/types';
 import {
-  defaultImportFn,
   DefaultLogger,
   pathExists,
   registerTerminateHandler,
@@ -18,6 +17,7 @@ import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { serveMesh } from './commands/serve/serve.js';
 import { generateTsArtifacts } from './commands/ts-artifacts.js';
 import { findAndParseConfig } from './config.js';
+import { defaultImportFn } from './defaultImportFn';
 import { handleFatalError } from './handleFatalError.js';
 
 export { generateTsArtifacts, serveMesh, findAndParseConfig, handleFatalError };

--- a/packages/legacy/cli/src/index.ts
+++ b/packages/legacy/cli/src/index.ts
@@ -17,7 +17,7 @@ import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { serveMesh } from './commands/serve/serve.js';
 import { generateTsArtifacts } from './commands/ts-artifacts.js';
 import { findAndParseConfig } from './config.js';
-import { defaultImportFn } from './defaultImportFn';
+import { defaultImportFn } from './defaultImportFn.js';
 import { handleFatalError } from './handleFatalError.js';
 
 export { generateTsArtifacts, serveMesh, findAndParseConfig, handleFatalError };

--- a/packages/legacy/utils/package.json
+++ b/packages/legacy/utils/package.json
@@ -44,7 +44,6 @@
     "@whatwg-node/fetch": "^0.9.13",
     "disposablestack": "^1.1.6",
     "dset": "^3.1.2",
-    "jiti": "^1.21.6",
     "js-yaml": "^4.1.0",
     "lodash.get": "^4.4.2",
     "lodash.topath": "^4.5.2",

--- a/packages/legacy/utils/src/defaultImportFn.ts
+++ b/packages/legacy/utils/src/defaultImportFn.ts
@@ -1,17 +1,20 @@
-import createJITI, { type JITI } from 'jiti';
-import type { ImportFn } from '@graphql-mesh/types';
-
-let jiti: JITI;
-function getOrCreateImportFn(): ImportFn {
-  if (!jiti) {
-    // we instantiate on demand because sometimes jiti is not used
-    jiti = createJITI(__filename);
-  }
-  return module => jiti.import(module, {}) as Promise<any>;
-}
+import { path as pathModule } from '@graphql-mesh/cross-helpers';
 
 async function defaultImportFn(path: string): Promise<any> {
-  let module: any = await getOrCreateImportFn()(path);
+  let module = await import(/* @vite-ignore */ path)
+    .catch(e => {
+      if (e.code === 'ERR_REQUIRE_ESM') {
+        // eslint-disable-next-line no-new-func
+        return new Function(`return import(${JSON.stringify(path)})`)();
+      }
+      throw e;
+    })
+    .catch(e => {
+      if (pathModule.isAbsolute(path) && !path.endsWith('.js') && !path.endsWith('.ts')) {
+        return defaultImportFn(`${path}.ts`);
+      }
+      throw e;
+    });
   if (module.default != null) {
     module = module.default;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,6 +4864,7 @@ __metadata:
     dotenv: "npm:^16.0.3"
     graphql-import-node: "npm:^0.0.5"
     graphql-ws: "npm:^5.12.1"
+    jiti: "npm:^1.21.6"
     json-bigint-patch: "npm:^0.0.8"
     json5: "npm:^2.2.3"
     mkdirp: "npm:^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6165,7 +6165,6 @@ __metadata:
     "@whatwg-node/fetch": "npm:^0.9.13"
     disposablestack: "npm:^1.1.6"
     dset: "npm:^3.1.2"
-    jiti: "npm:^1.21.6"
     js-yaml: "npm:^4.1.0"
     lodash.get: "npm:^4.4.2"
     lodash.topath: "npm:^4.5.2"


### PR DESCRIPTION
Closes #7342

Utils need to be kept JS env agnostic.