### PR TITLE
Failing test for discriminator with multiple response codes

### DIFF
--- a/packages/loaders/openapi/tests/fixtures/pet.yml
+++ b/packages/loaders/openapi/tests/fixtures/pet.yml
@@ -15,10 +15,17 @@ paths:
             type: string
       responses:
         200:
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pet'
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
 
 components:
   schemas:
@@ -50,6 +57,15 @@ components:
           properties:
             dog_exclusive:
               type: string
+    ApiError:
+      required:
+        - code
+        - description
+      type: object
+      properties:
+        code:
+          type: string
+      additionalProperties: false
   requestBodies:
     Pet:
       required: true


### PR DESCRIPTION
## Description

This creates a failing test for issue described in #7379 regarding a bug with discriminated unions when there's multiple response codes. It does not fix the issue.

## Type of change

Please delete options that are not relevant.

- [x] Failing test for a bug fix
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?

`yarn jest packages/loaders/openapi/tests/pet.test.ts`

It returns this error

```
    Should be provided ObjectType but received InterfaceTypeComposer({ _gqcInterfaces: [], _gqcFallbackResolveType: null, schemaComposer: SchemaComposer, _gqType: GraphQLInterfaceType({ name: "Pet", description: undefined, resolveType: undefined, extensions: { default: undefined }, astNode: Object({ kind: "InterfaceTypeDefinition", name: Object({ kind: "Name", value: "Pet" }), description: undefined, directives: undefined, fields: undefined }), extensionASTNodes: [], _fields: [function bound defineFieldMap], _interfaces: [function bound defineInterfaces] }), _gqcFields: Object({ name: Object({ type: ThunkComposer({ _thunk: [function ], _typeFromThunk: NonNullComposer({ ofType: ScalarTypeComposer({ schemaComposer: SchemaComposer, _gqType: GraphQLScalarType({ name: "String", description: "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.", specifiedByURL: undefined, serialize: [function serialize], parseValue: [function parseValue], parseLiteral: [function parseLiteral], extensions: {  }, astNode: Object({ kind: "ScalarTypeDefinition", name: Object({ kind: "Name", value: "String" }), description: Object({ kind: "StringValue", value: "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text." }), directives: undefined }), extensionASTNodes: [] }), _gqcSerialize: [function serialize], _gqcIsModified: false, _gqcParseValue: [function parseValue], _gqcParseLiteral: [function parseLiteral] }) }) }), args: Object({  }), directives: [], extensions: Object({ nullable: undefined }), description: undefined, deprecationReason: undefined }), petType: Object({ type: ThunkComposer({ _thunk: [function ] }), args: Object({  }), directives: [], extensions: Object({ nullable: undefined }), description: undefined, deprecationReason: undefined }) }), _gqcIsModified: true, _gqcExtensions: Object({ default: undefined }), _gqcDirectives: [Object({ name: "discriminator", args: Object({ subgraph: "Pet", field: "petType", mapping: Object({ Dog: "Dog", Cat: "Cat" }) }) })] })

      119 |           });
      120 |         }
    > 121 |         (subSchemaAndTypeComposers.output as UnionTypeComposer).addType(outputTypeComposer);
          |                                                                 ^
      122 |       } else {
      123 |         for (const possibleType of outputTypeComposer.getTypes()) {
      124 |           (subSchemaAndTypeComposers.output as UnionTypeComposer).addType(possibleType);

      at UnionTypeComposer._convertObjectType (node_modules/graphql-compose/src/UnionTypeComposer.ts:604:11)
      at UnionTypeComposer.addType (node_modules/graphql-compose/src/UnionTypeComposer.ts:259:21)
      at addType (packages/loaders/json-schema/src/getUnionTypeComposers.ts:121:65)
      at leave (packages/loaders/json-schema/src/getComposerFromJSONSchema.ts:921:37)
      at leave (packages/json-machete/src/visitJSONSchema.ts:93:33)
      at visitJSONSchema (packages/json-machete/src/visitJSONSchema.ts:73:50)
      at visitJSONSchema (packages/json-machete/src/visitJSONSchema.ts:73:50)
      at getGraphQLSchemaFromDereferencedJSONSchema (packages/loaders/json-schema/src/getGraphQLSchemaFromDereferencedJSONSchema.ts:26:25)
      at loadGraphQLSchemaFromJSONSchemas (packages/loaders/json-schema/src/loadGraphQLSchemaFromJSONSchemas.ts:42:25)
      at Object.<anonymous> (packages/loaders/openapi/tests/pet.test.ts:28:14)
```

**Test Environment**:

- OS: MacOS
- `"@graphql-mesh/openapi": "^0.100.12"`:
- NodeJS: `v18.19.0`

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
