### PR TITLE
legacy/http: add tests for Content Encoding plugin

### DIFF
--- a/packages/legacy/runtime/src/types.ts
+++ b/packages/legacy/runtime/src/types.ts
@@ -1,5 +1,4 @@
 import type { DocumentNode, ExecutionResult } from 'graphql';
-import type { Plugin } from '@envelop/core';
 import type {
   GraphQLOperation,
   KeyValueCache,
@@ -7,6 +6,7 @@ import type {
   MeshFetch,
   MeshHandler,
   MeshMerger,
+  MeshPlugin,
   MeshPubSub,
   MeshTransform,
   YamlConfig,
@@ -25,7 +25,7 @@ export type GetMeshOptions = {
   pubsub?: MeshPubSub;
   merger: MeshMerger;
   logger?: Logger;
-  additionalEnvelopPlugins?: Plugin[];
+  additionalEnvelopPlugins?: MeshPlugin<any>[];
   documents?: Source[];
   fetchFn?: MeshFetch;
 };

--- a/packages/loaders/soap/test/soap.test.ts
+++ b/packages/loaders/soap/test/soap.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-nodejs-modules */
 import { promises } from 'fs';
+import { globalAgent } from 'https';
 import { join } from 'path';
 import { parse } from 'graphql';
 import type { Logger, MeshFetch } from '@graphql-mesh/types';
@@ -18,6 +19,9 @@ describe('SOAP Loader', () => {
     log: jest.fn(),
     child: () => mockLogger,
   };
+  afterEach(() => {
+    globalAgent.destroy();
+  });
   it('should generate the schema correctly', async () => {
     const soapLoader = new SOAPLoader({
       subgraphName: 'Test',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12070,7 +12070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@whatwg-node/node-fetch@npm:^0.5.16":
+"@whatwg-node/node-fetch@npm:^0.5.16, @whatwg-node/node-fetch@npm:^0.5.7":
   version: 0.5.16
   resolution: "@whatwg-node/node-fetch@npm:0.5.16"
   dependencies:
@@ -12080,19 +12080,6 @@ __metadata:
     fast-querystring: "npm:^1.1.1"
     tslib: "npm:^2.6.3"
   checksum: 10c0/75880677e74eba063239b38ccdaa43acbd6625ca91c018b5b28278a56bc2938319e2cf467e76c24ab4d9040ff3052bb61b865fafae48534fd31d5695214ba457
-  languageName: node
-  linkType: hard
-
-"@whatwg-node/node-fetch@npm:^0.5.7":
-  version: 0.5.12
-  resolution: "@whatwg-node/node-fetch@npm:0.5.12"
-  dependencies:
-    "@kamilkisiela/fast-url-parser": "npm:^1.1.4"
-    "@whatwg-node/events": "npm:^0.1.0"
-    busboy: "npm:^1.6.0"
-    fast-querystring: "npm:^1.1.1"
-    tslib: "npm:^2.6.3"
-  checksum: 10c0/009827a06ac9e068a0347864ec657061d6be9155e4496a47098e9da661f2e615ef669a682e5e1c6d2f7a199358ca5c84871534a6ecb9629c17b9b779097f5378
   languageName: node
   linkType: hard
 
@@ -33436,7 +33423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:3.4.7":
+"tailwindcss@npm:3.4.7, tailwindcss@npm:^3.0.2, tailwindcss@npm:^3.4.3":
   version: 3.4.7
   resolution: "tailwindcss@npm:3.4.7"
   dependencies:
@@ -33466,39 +33453,6 @@ __metadata:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
   checksum: 10c0/dd74c29ae0ec314d46300a1163b106b84d3ca58d71e4e16c2c8ad9ee3d7ba6cfeab4a97176c0e9bfeebc5e9cd9636531648a3f3874ede376751a572d230dd979
-  languageName: node
-  linkType: hard
-
-"tailwindcss@npm:^3.0.2, tailwindcss@npm:^3.4.3":
-  version: 3.4.6
-  resolution: "tailwindcss@npm:3.4.6"
-  dependencies:
-    "@alloc/quick-lru": "npm:^5.2.0"
-    arg: "npm:^5.0.2"
-    chokidar: "npm:^3.5.3"
-    didyoumean: "npm:^1.2.2"
-    dlv: "npm:^1.1.3"
-    fast-glob: "npm:^3.3.0"
-    glob-parent: "npm:^6.0.2"
-    is-glob: "npm:^4.0.3"
-    jiti: "npm:^1.21.0"
-    lilconfig: "npm:^2.1.0"
-    micromatch: "npm:^4.0.5"
-    normalize-path: "npm:^3.0.0"
-    object-hash: "npm:^3.0.0"
-    picocolors: "npm:^1.0.0"
-    postcss: "npm:^8.4.23"
-    postcss-import: "npm:^15.1.0"
-    postcss-js: "npm:^4.0.1"
-    postcss-load-config: "npm:^4.0.1"
-    postcss-nested: "npm:^6.0.1"
-    postcss-selector-parser: "npm:^6.0.11"
-    resolve: "npm:^1.22.2"
-    sucrase: "npm:^3.32.0"
-  bin:
-    tailwind: lib/cli.js
-    tailwindcss: lib/cli.js
-  checksum: 10c0/8d82b697ecf41d8cd100ab3369e3cbcb30e350afc5b595a000b201ba666628a68543154297f96c5b2a3f2614f37bb981af4766556ebaae832079fa9a436e8563
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Compatibility tests for `useContentEncoding` plugin and legacy Mesh HTTP runtime