### PR TITLE
feat(serve-runtime): support Hive CDN as schema source for proxy mode

### DIFF
--- a/.changeset/mighty-flies-wink.md
+++ b/.changeset/mighty-flies-wink.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/serve-runtime': patch
+---
+
+Support Hive CDN in proxy mode
+If Hive CDN endpoint is provided, the runtime won't introspect the schema from the endpoint, and fetch it from Hive CDN.

--- a/.changeset/mighty-flies-wink.md
+++ b/.changeset/mighty-flies-wink.md
@@ -4,3 +4,21 @@
 
 Support Hive CDN in proxy mode
 If Hive CDN endpoint is provided, the runtime won't introspect the schema from the endpoint, and fetch it from Hive CDN.
+
+By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
+validation and schema aware features. But if Hive CDN endpoint and key have been provided in the
+configuration, Mesh Serve will fetch the schema from the Hive CDN.
+
+```ts filename="mesh.config.ts"
+import { defineConfig } from '@graphql-mesh/serve-cli'
+
+export const serveConfig = defineConfig({
+  proxy: {
+    endpoint: 'https://example.com/graphql'
+  },
+  hive: {
+    endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/0123-3434/sdl',
+    key: 'SOME_HIVE_KEY'
+  }
+})
+```

--- a/packages/serve-cli/src/run.ts
+++ b/packages/serve-cli/src/run.ts
@@ -67,7 +67,12 @@ let program = new Command()
         return port;
       }),
   )
-  .option('--supergraph <path>', 'path to the supergraph schema')
+  .addOption(
+    new Option('--supergraph <path>', 'path to the supergraph schema').conflicts([
+      'proxy',
+      'subgraph',
+    ]),
+  )
   .addOption(
     new Option('--polling <intervalInMs>', 'schema polling interval in milliseconds')
       .env('POLLING')
@@ -80,7 +85,20 @@ let program = new Command()
       }),
   )
   .option('--masked-errors', 'mask unexpected errors in responses')
-  .option('--subgraph <path>', 'path to the subgraph schema');
+  .addOption(
+    new Option('--subgraph <path>', 'path to the subgraph schema').conflicts([
+      'supergraph',
+      'proxy',
+    ]),
+  )
+  .addOption(
+    new Option('--proxy <endpoint>', 'proxy all requests to this endpoint')
+      .env('PROXY_ENDPOINT')
+      .argParser(e => ({
+        endpoint: new URL(e).toString(),
+      }))
+      .conflicts(['supergraph', 'subgraph']),
+  );
 
 export interface RunOptions extends ReturnType<typeof program.opts> {
   /** @default new DefaultLogger() */

--- a/packages/serve-runtime/package.json
+++ b/packages/serve-runtime/package.json
@@ -59,6 +59,7 @@
     "graphql-yoga": "^5.6.0"
   },
   "devDependencies": {
+    "@envelop/disable-introspection": "6.0.0",
     "graphql-sse": "^2.5.3",
     "html-minifier-terser": "7.2.0"
   },

--- a/packages/serve-runtime/src/createServeRuntime.ts
+++ b/packages/serve-runtime/src/createServeRuntime.ts
@@ -152,7 +152,6 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
       if (config.polling) {
         currentTimeout = setTimeout(schemaFetcher, config.polling);
       }
-      currentTimeout = setTimeout(schemaFetcher, config.polling);
     }
     function pausePolling() {
       if (currentTimeout) {
@@ -206,6 +205,10 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
             continuePolling();
             return true;
           },
+          err => {
+            configContext.logger.warn(`Failed to introspect schema`, err);
+            return true;
+          },
         );
       };
     }
@@ -213,7 +216,7 @@ export function createServeRuntime<TContext extends Record<string, any> = Record
       if (unifiedGraph != null) {
         return unifiedGraph;
       }
-      if (initialFetch$) {
+      if (initialFetch$ != null) {
         return mapMaybePromise(initialFetch$, () => unifiedGraph);
       }
       if (!initialFetch$) {

--- a/packages/serve-runtime/src/types.ts
+++ b/packages/serve-runtime/src/types.ts
@@ -84,7 +84,7 @@ interface MeshServeConfigWithHive<TContext> extends MeshServeConfigForSupergraph
   /**
    * Integration options with GraphQL Hive.
    */
-  hive: YamlConfig.HivePlugin & HiveCDNOptions;
+  hive: Partial<YamlConfig.HivePlugin> & HiveCDNOptions;
 }
 
 interface MeshServeConfigWithSubgraph<TContext>
@@ -188,6 +188,14 @@ export interface MeshServeConfigWithProxy<TContext>
    * HTTP executor to proxy all incoming requests to another HTTP endpoint.
    */
   proxy: HTTPExecutorOptions;
+  /**
+   * Integration options with GraphQL Hive.
+   */
+  hive?: Partial<YamlConfig.HivePlugin> & HiveCDNOptions;
+  /**
+   * Polling interval in milliseconds.
+   */
+  polling?: number;
   /**
    * Disable GraphQL validation on the gateway
    *

--- a/packages/serve-runtime/tests/hive.spec.ts
+++ b/packages/serve-runtime/tests/hive.spec.ts
@@ -4,12 +4,16 @@ import type { AddressInfo } from 'net';
 import {
   buildClientSchema,
   getIntrospectionQuery,
+  GraphQLSchema,
   printSchema,
   type ExecutionResult,
   type IntrospectionQuery,
 } from 'graphql';
-import { createSchema } from 'graphql-yoga';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { useDisableIntrospection } from '@envelop/disable-introspection';
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
+import { useCustomFetch } from '@graphql-mesh/serve-runtime';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import { createDisposableServer } from '../../testing/createDisposableServer.js';
 import { createServeRuntime } from '../src/createServeRuntime.js';
 
@@ -78,5 +82,60 @@ describe('Hive CDN', () => {
     expect(landingPage).toContain('Hive CDN');
     expect(landingPage).toContain('upstream');
     expect(landingPage).toContain('http://upstream/graphql');
+  });
+  it('uses Hive CDN instead of introspection for Proxy mode with env vars', async () => {
+    const upstreamSchema = createUpstreamSchema();
+    const upstreamServer = createYoga({
+      schema: upstreamSchema,
+      plugins: [useDisableIntrospection()],
+    });
+    process.env.PROXY_ENDPOINT = 'http://upstream/graphql';
+    process.env.HIVE_CDN_ENDPOINT = 'http://hive/upstream';
+    process.env.HIVE_CDN_KEY = 'key';
+    let schemaChangeSpy = jest.fn((schema: GraphQLSchema) => {});
+    await using serveRuntime = createServeRuntime({
+      plugins: () => [
+        useCustomFetch(function (url, opts) {
+          if (url === process.env.HIVE_CDN_ENDPOINT) {
+            if (opts.headers?.['X-Hive-CDN-Key'] !== process.env.HIVE_CDN_KEY) {
+              return new serveRuntime.fetchAPI.Response('Unauthorized', {
+                status: 401,
+              });
+            }
+            return new serveRuntime.fetchAPI.Response(printSchemaWithDirectives(upstreamSchema));
+          }
+          if (url === 'http://upstream/graphql') {
+            return upstreamServer.fetch(url, opts);
+          }
+          return serveRuntime.fetchAPI.Response.error();
+        }),
+        {
+          onSchemaChange({ schema }) {
+            schemaChangeSpy(schema);
+          },
+        },
+      ],
+    });
+    const res = await serveRuntime.fetch('http://localhost:4000/graphql', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: /* GraphQL */ `
+          query {
+            foo
+          }
+        `,
+      }),
+    });
+    const resJson: ExecutionResult = await res.json();
+    expect(resJson).toEqual({
+      data: {
+        foo: 'bar',
+      },
+    });
+    expect(schemaChangeSpy).toHaveBeenCalledTimes(1);
+    expect(printSchema(schemaChangeSpy.mock.calls[0][0])).toBe(printSchema(upstreamSchema));
   });
 });

--- a/website/src/pages/v1/serve/references/cli.mdx
+++ b/website/src/pages/v1/serve/references/cli.mdx
@@ -32,15 +32,17 @@ Usage: mesh-serve [options]
 serve GraphQL federated architecture for any API service(s)
 
 Options:
-  --fork [count]            count of workers to spawn. defaults to `os.availableParallelism()` when NODE_ENV is "production", otherwise only one (the main)
-                            worker (default: 1, env: FORK)
-  -c, --config-path <path>  path to the configuration file. defaults to the following files respectively in the current working directory: mesh.config.ts,
-                            mesh.config.mts, mesh.config.cts, mesh.config.js, mesh.config.mjs, mesh.config.cjs (env: CONFIG_PATH)
-  -h, --host <hostname>     host to use for serving (default: "0.0.0.0")
+  --fork [count]            count of workers to spawn. defaults to `os.availableParallelism()` when NODE_ENV is "production", otherwise only one (the main) worker (default: 1, env:
+                            FORK)
+  -c, --config-path <path>  path to the configuration file. defaults to the following files respectively in the current working directory: mesh.config.ts, mesh.config.mts,
+                            mesh.config.cts, mesh.config.js, mesh.config.mjs, mesh.config.cjs (env: CONFIG_PATH)
+  -h, --host <hostname>     host to use for serving (default: "127.0.0.1")
   -p, --port <number>       port to use for serving (default: 4000, env: PORT)
   --supergraph <path>       path to the supergraph schema
   --polling <intervalInMs>  schema polling interval in milliseconds (env: POLLING)
-  --masked-errors           mask unexpected errors in responses (default: true)
+  --masked-errors           mask unexpected errors in responses
+  --subgraph <path>         path to the subgraph schema
+  --proxy <endpoint>        proxy all requests to this endpoint (env: PROXY_ENDPOINT)
   --help                    display help for command
 ```
 

--- a/website/src/pages/v1/serve/references/config.mdx
+++ b/website/src/pages/v1/serve/references/config.mdx
@@ -231,6 +231,12 @@ export const serveConfig = defineConfig({
 })
 ```
 
+<Callout>
+  By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
+  validation and schema aware features. But if you have configured Hive CDN endpoint and key in the
+  configuration, Mesh Serve will fetch the schema from the Hive CDN.
+</Callout>
+
 ### Configure Server
 
 #### `sslCredentials` for HTTPS

--- a/website/src/pages/v1/serve/references/config.mdx
+++ b/website/src/pages/v1/serve/references/config.mdx
@@ -169,9 +169,9 @@ export const serveConfig = defineConfig({
 ```
 
 <Callout>
-  By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
-  validation and schema aware features. But if you have configured Hive CDN endpoint and key in the
-  configuration, Mesh Serve will fetch the schema from the Hive CDN.
+By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
+validation and schema aware features. But if Hive CDN endpoint and key have been provided in the
+configuration, Mesh Serve will fetch the schema from the Hive CDN.
 
 ```ts filename="mesh.config.ts"
 import { defineConfig } from '@graphql-mesh/serve-cli'

--- a/website/src/pages/v1/serve/references/config.mdx
+++ b/website/src/pages/v1/serve/references/config.mdx
@@ -168,6 +168,27 @@ export const serveConfig = defineConfig({
 })
 ```
 
+<Callout>
+  By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
+  validation and schema aware features. But if you have configured Hive CDN endpoint and key in the
+  configuration, Mesh Serve will fetch the schema from the Hive CDN.
+
+```ts filename="mesh.config.ts"
+import { defineConfig } from '@graphql-mesh/serve-cli'
+
+export const serveConfig = defineConfig({
+  proxy: {
+    endpoint: 'https://example.com/graphql'
+  },
+  hive: {
+    endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/0123-3434/sdl',
+    key: 'SOME_HIVE_KEY'
+  }
+})
+```
+
+</Callout>
+
 ##### `endpoint`
 
 The URL of the GraphQL endpoint to proxy requests to.
@@ -230,12 +251,6 @@ export const serveConfig = defineConfig({
   skipValidation: true
 })
 ```
-
-<Callout>
-  By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
-  validation and schema aware features. But if you have configured Hive CDN endpoint and key in the
-  configuration, Mesh Serve will fetch the schema from the Hive CDN.
-</Callout>
 
 ### Configure Server
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,6 +3919,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@envelop/disable-introspection@npm:6.0.0":
+  version: 6.0.0
+  resolution: "@envelop/disable-introspection@npm:6.0.0"
+  dependencies:
+    tslib: "npm:^2.5.0"
+  peerDependencies:
+    "@envelop/core": ^5.0.0
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 10c0/48b3a2c98514cd629eadc09f741a1a21cb363a6ebf940a40e39c69054cd61b3d73b37575c1c3573fdc57685b76d58694b14dfae63d357d015040e69f4363ad98
+  languageName: node
+  linkType: hard
+
 "@envelop/extended-validation@npm:^4.0.0":
   version: 4.0.0
   resolution: "@envelop/extended-validation@npm:4.0.0"
@@ -6580,6 +6592,7 @@ __metadata:
   resolution: "@graphql-mesh/serve-runtime@workspace:packages/serve-runtime"
   dependencies:
     "@envelop/core": "npm:^5.0.0"
+    "@envelop/disable-introspection": "npm:6.0.0"
     "@graphql-hive/apollo": "npm:^0.34.0"
     "@graphql-mesh/cross-helpers": "npm:^0.4.4"
     "@graphql-mesh/fusion-runtime": "npm:^0.5.10"


### PR DESCRIPTION
If Hive CDN endpoint is provided, the runtime won't introspect the schema from the endpoint, and fetch it from Hive CDN.

By default, Mesh Serve introspects the schema from the endpoint. And it fails, it skips the
validation and schema aware features. But if Hive CDN endpoint and key have been provided in the
configuration, Mesh Serve will fetch the schema from the Hive CDN.

```ts filename="mesh.config.ts"
import { defineConfig } from '@graphql-mesh/serve-cli'

export const serveConfig = defineConfig({
  proxy: {
    endpoint: 'https://example.com/graphql'
  },
  hive: {
    endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/0123-3434/sdl',
    key: 'SOME_HIVE_KEY'
  }
})
```
