### PR TITLE
fix(utils): DefaultLogger does not trim messages by default and accepts more truthy strings for DEBUG env var

### DIFF
--- a/.changeset/gorgeous-moons-sleep.md
+++ b/.changeset/gorgeous-moons-sleep.md
@@ -1,0 +1,12 @@
+---
+'@graphql-mesh/utils': minor
+---
+
+Trimming log messages is an option independant of the DEBUG environment variable.
+
+Instead of trimming messages at 100 characters by default when the `DEBUG` environment variable is falsy, have the user configure the trim length that is not set by default.
+
+```js
+import { DefaultLogger } from '@graphql-mesh/utils';
+const trimmedLogger = new DefaultLogger('my-logger', undefined, 100 /* trim at 100 characters*/);
+``

--- a/.changeset/twenty-apes-refuse.md
+++ b/.changeset/twenty-apes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+Accept '1', 't', 'true', 'y' and 'yes' as truthy values for DEBUG environment variable

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -43,38 +43,28 @@ export class DefaultLogger implements Logger {
     public logLevel = process.env.DEBUG === '1' ? LogLevel.debug : LogLevel.info,
   ) {}
 
-  private getLoggerMessage({ args = [], trim = !this.isDebug }: { args: any[]; trim?: boolean }) {
+  private getLoggerMessage({ args = [] }: { args: any[] }) {
     return args
       .flat(Infinity)
       .map(arg => {
         if (typeof arg === 'string') {
-          if (trim && arg.length > 100) {
-            return (
-              arg.slice(0, 100) +
-              '...' +
-              '<Message is too long. Enable DEBUG=1 to see the full message.>'
-            );
-          }
           return arg;
         } else if (typeof arg === 'object' && arg?.stack != null) {
           return arg.stack;
         }
         return util.inspect(arg);
       })
-      .join(` `);
+      .join(' ');
   }
 
-  private handleLazyMessage({ lazyArgs, trim }: { lazyArgs: LazyLoggerMessage[]; trim?: boolean }) {
+  private handleLazyMessage({ lazyArgs }: { lazyArgs: LazyLoggerMessage[] }) {
     const flattenedArgs = lazyArgs.flat(Infinity).flatMap(arg => {
       if (typeof arg === 'function') {
         return arg();
       }
       return arg;
     });
-    return this.getLoggerMessage({
-      args: flattenedArgs,
-      trim,
-    });
+    return this.getLoggerMessage({ args: flattenedArgs });
   }
 
   private get isDebug() {
@@ -96,9 +86,7 @@ export class DefaultLogger implements Logger {
     if (this.logLevel > LogLevel.info) {
       return noop;
     }
-    const message = this.getLoggerMessage({
-      args,
-    });
+    const message = this.getLoggerMessage({ args });
     const fullMessage = `[${getTimestamp()}] ${this.prefix} ${message}`;
     if (process?.stderr?.write(fullMessage + '\n')) {
       return;
@@ -110,9 +98,7 @@ export class DefaultLogger implements Logger {
     if (this.logLevel > LogLevel.warn) {
       return noop;
     }
-    const message = this.getLoggerMessage({
-      args,
-    });
+    const message = this.getLoggerMessage({ args });
     const fullMessage = `[${getTimestamp()}] ${this.prefix} WARN  ${warnColor(message)}`;
     if (process?.stderr?.write(fullMessage + '\n')) {
       return;
@@ -139,10 +125,7 @@ export class DefaultLogger implements Logger {
     if (this.logLevel > LogLevel.error) {
       return noop;
     }
-    const message = this.getLoggerMessage({
-      args,
-      trim: false,
-    });
+    const message = this.getLoggerMessage({ args });
     const fullMessage = `[${getTimestamp()}] ERROR ${this.prefix} ${errorColor(message)}`;
     if (typeof process?.stderr?.write === 'function') {
       process.stderr.write(fullMessage + '\n');

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -33,6 +33,10 @@ export enum LogLevel {
 
 const noop: VoidFunction = () => {};
 
+function truthy(str: unknown) {
+  return str === true || str === 1 || ['1', 't', 'true', 'y', 'yes'].includes(String(str));
+}
+
 function getTimestamp() {
   return new Date().toISOString();
 }
@@ -40,7 +44,7 @@ function getTimestamp() {
 export class DefaultLogger implements Logger {
   constructor(
     public name?: string,
-    public logLevel = process.env.DEBUG === '1' ? LogLevel.debug : LogLevel.info,
+    public logLevel = truthy(process.env.DEBUG) ? LogLevel.debug : LogLevel.info,
     private trim?: number,
   ) {}
 
@@ -78,8 +82,8 @@ export class DefaultLogger implements Logger {
   private get isDebug() {
     if (process.env.DEBUG) {
       return (
-        process.env.DEBUG === '1' ||
-        (globalThis as any).DEBUG === '1' ||
+        truthy(process.env.DEBUG) ||
+        truthy((globalThis as any).DEBUG) ||
         this.name.includes(process.env.DEBUG || (globalThis as any).DEBUG)
       );
     }

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -41,6 +41,7 @@ export class DefaultLogger implements Logger {
   constructor(
     public name?: string,
     public logLevel = process.env.DEBUG === '1' ? LogLevel.debug : LogLevel.info,
+    private trim?: number,
   ) {}
 
   private getLoggerMessage({ args = [] }: { args: any[] }) {
@@ -48,6 +49,13 @@ export class DefaultLogger implements Logger {
       .flat(Infinity)
       .map(arg => {
         if (typeof arg === 'string') {
+          if (this.trim && arg.length > this.trim) {
+            return (
+              arg.slice(0, this.trim) +
+              '...' +
+              '<Message is trimmed. Enable DEBUG=1 to see the full message.>'
+            );
+          }
           return arg;
         } else if (typeof arg === 'object' && arg?.stack != null) {
           return arg.stack;


### PR DESCRIPTION
Trimmed messages are annoying and have no real value.

Users should never find themselves in situations where log messages contains mission critical info but are trimmed because DEBUG is not enabled.

Furthermore, no one will know ahead of time that messages are trimmed without DEBUG=1 and until they hit the "Message is too long. Enable DEBUG=1 to see the full message." it might be too late.