### PR TITLE
No default importFn for findAndParseConfig, making the processor use utils importFn

### DIFF
--- a/.changeset/shaggy-cycles-eat.md
+++ b/.changeset/shaggy-cycles-eat.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/cli': patch
+---
+
+No default importFn for findAndParseConfig, making the processor use utils importFn

--- a/packages/legacy/cli/src/config.ts
+++ b/packages/legacy/cli/src/config.ts
@@ -55,7 +55,7 @@ export async function findAndParseConfig(options?: ConfigProcessOptions) {
     configName = 'mesh',
     dir: configDir = '',
     initialLoggerPrefix = '🕸️  Mesh',
-    importFn = include,
+    importFn,
     ...restOptions
   } = options || {};
   const dir = path.isAbsolute(configDir) ? configDir : path.join(process.cwd(), configDir);


### PR DESCRIPTION
Closes #7405