### PR TITLE
fix(openapi): support alternative ref types for `discriminator.mapping`

### DIFF
--- a/.changeset/gentle-pandas-return.md
+++ b/.changeset/gentle-pandas-return.md
@@ -1,0 +1,16 @@
+---
+'@omnigraph/openapi': patch
+---
+
+Support different ref types in `discriminator.mapping`;
+
+All of the following ref formats are considered as valid;
+```yml
+discriminator:
+  mapping:
+    A: '#/components/schemas/A'
+    # or
+    A: 'A'
+    # or
+    A: '../components/schemas/A'
+```

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -105,11 +105,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
     if (mapping) {
       for (const [key, value] of Object.entries(mapping)) {
         if (typeof value === 'string') {
-          const docIdentifier = value.startsWith('#')
-            ? '#'
-            : value.startsWith('../')
-              ? '../'
-              : null;
+          const docIdentifier = value.startsWith('#') ? '#' : value.startsWith('..') ? '..' : null;
           if (docIdentifier) {
             const [, ref] = value.split(docIdentifier);
             (schema as any).discriminatorMapping = (schema as any).discriminatorMapping || {};

--- a/packages/loaders/openapi/tests/fixtures/pet.yml
+++ b/packages/loaders/openapi/tests/fixtures/pet.yml
@@ -29,8 +29,8 @@ components:
       discriminator:
         propertyName: petType
         mapping:
-          Dog: '#/components/schemas/Dog'
-          Cat: '#/components/schemas/Cat'
+          Dog: Dog
+          Cat: '../components/schemas/Cat'
       properties:
         name:
           type: string


### PR DESCRIPTION
Fixes https://github.com/ardatan/graphql-mesh/issues/7561

Support different ref types in `discriminator.mapping`;

All of the following ref formats are considered as valid;
```yml
discriminator:
  mapping:
    A: '#/components/schemas/A'
    # or
    A: 'A'
    # or
    A: '../components/schemas/A'
```
