### PR TITLE
fix(runtime): keep polling even if fetching fails

### DIFF
--- a/.changeset/shiny-dragons-stare.md
+++ b/.changeset/shiny-dragons-stare.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-runtime': patch
+---
+
+Should keep polling even if it throws once

--- a/.changeset/shiny-dragons-stare.md
+++ b/.changeset/shiny-dragons-stare.md
@@ -2,4 +2,7 @@
 '@graphql-mesh/fusion-runtime': patch
 ---
 
-Should keep polling even if it throws once
+If the first poll fails, keep polling but fail on requests
+If any poll fails in somewhere, keep polling but keep using the last successful supergraph
+
+So if the CDN is down at some point, the gateway will keep polling the supergraph, but will keep using the last successful supergraph. This is useful for cases where the CDN is down, but the supergraph is still available.

--- a/packages/fusion/runtime/tests/polling.test.ts
+++ b/packages/fusion/runtime/tests/polling.test.ts
@@ -183,7 +183,9 @@ describe('Polling', () => {
     jest.advanceTimersByTime(pollingInterval);
     // Should not fail again once it has succeeded
     await compareTimes();
+    jest.advanceTimersByTime(pollingInterval);
+    // Should keep polling even if it fails in somewhere
     await manager[DisposableSymbols.asyncDispose]();
-    expect(unifiedGraphFetcher).toHaveBeenCalledTimes(3);
+    expect(unifiedGraphFetcher).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/fusion/runtime/tests/polling.test.ts
+++ b/packages/fusion/runtime/tests/polling.test.ts
@@ -39,7 +39,7 @@ describe('Polling', () => {
       ]);
     };
     const disposeFn = jest.fn();
-    const manager = new UnifiedGraphManager({
+    await using manager = new UnifiedGraphManager({
       getUnifiedGraph: unifiedGraphFetcher,
       pollingInterval: pollingInterval,
       batch: false,
@@ -136,7 +136,7 @@ describe('Polling', () => {
         },
       ]);
     });
-    const manager = new UnifiedGraphManager({
+    await using manager = new UnifiedGraphManager({
       getUnifiedGraph: unifiedGraphFetcher,
       pollingInterval: pollingInterval,
       batch: false,
@@ -185,7 +185,6 @@ describe('Polling', () => {
     await compareTimes();
     jest.advanceTimersByTime(pollingInterval);
     // Should keep polling even if it fails in somewhere
-    await manager[DisposableSymbols.asyncDispose]();
     expect(unifiedGraphFetcher).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/fusion/runtime/tests/polling.test.ts
+++ b/packages/fusion/runtime/tests/polling.test.ts
@@ -102,4 +102,88 @@ describe('Polling', () => {
     // Check if transport executor is disposed on global shutdown
     expect(disposeFn).toHaveBeenCalledTimes(3);
   });
+  it('continues polling after failing initial fetch', async () => {
+    jest.useFakeTimers();
+    const pollingInterval = 35_000;
+    let schema: GraphQLSchema;
+    let shouldFail = true;
+    const unifiedGraphFetcher = jest.fn(() => {
+      if (shouldFail) {
+        throw new Error('Failed to fetch schema');
+      }
+      const time = new Date().toISOString();
+      schema = createSchema({
+        typeDefs: /* GraphQL */ `
+          """
+          Fetched on ${time}
+          """
+          type Query {
+            time: String
+          }
+        `,
+        resolvers: {
+          Query: {
+            time() {
+              return time;
+            },
+          },
+        },
+      });
+      return getUnifiedGraphGracefully([
+        {
+          name: 'Test',
+          schema,
+        },
+      ]);
+    });
+    const manager = new UnifiedGraphManager({
+      getUnifiedGraph: unifiedGraphFetcher,
+      pollingInterval: pollingInterval,
+      batch: false,
+      transports() {
+        return {
+          getSubgraphExecutor() {
+            return createDefaultExecutor(schema);
+          },
+        };
+      },
+    });
+    async function getFetchedTimeOnComment() {
+      const schema = await manager.getUnifiedGraph();
+      const queryType = schema.getQueryType();
+      const lastFetchedDateStr = queryType.description.match(/Fetched on (.*)/)[1];
+      const lastFetchedDate = new Date(lastFetchedDateStr);
+      return lastFetchedDate;
+    }
+    async function getFetchedTimeFromResolvers() {
+      const schema = await manager.getUnifiedGraph();
+      const result = await normalizedExecutor({
+        schema,
+        document: parse(/* GraphQL */ `
+          query {
+            time
+          }
+        `),
+      });
+      if (isAsyncIterable(result)) {
+        throw new Error('Unexpected async iterable');
+      }
+      return new Date(result.data.time);
+    }
+    async function compareTimes() {
+      const timeFromComment = await getFetchedTimeOnComment();
+      const timeFromResolvers = await getFetchedTimeFromResolvers();
+      expect(timeFromComment).toEqual(timeFromResolvers);
+    }
+    await expect(async () => manager.getUnifiedGraph()).rejects.toThrow();
+    shouldFail = false;
+    jest.advanceTimersByTime(pollingInterval);
+    await compareTimes();
+    shouldFail = true;
+    jest.advanceTimersByTime(pollingInterval);
+    // Should not fail again once it has succeeded
+    await compareTimes();
+    await manager[DisposableSymbols.asyncDispose]();
+    expect(unifiedGraphFetcher).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
If the first poll fails, keep polling but fail on requests
If any poll fails in somewhere, keep polling but keep using the last successful supergraph

So if the CDN is down at some point, the gateway will keep polling the supergraph, but will keep using the last successful supergraph. This is useful for cases where the CDN is down, but the supergraph is still available.
