### PR TITLE
fix(serve-cli): suppress node warnings by default, and expose them only in debug mode

### DIFF
--- a/.changeset/chilled-flowers-turn.md
+++ b/.changeset/chilled-flowers-turn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/serve-cli': patch
+---
+
+Suppress Node Warnings, and expose them only if \`DEBUG\` env var is truthy

--- a/packages/hive-gateway/src/bin.ts
+++ b/packages/hive-gateway/src/bin.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
-import { run } from '@graphql-mesh/serve-cli';
+import { handleNodeWarnings, run } from '@graphql-mesh/serve-cli';
 import { DefaultLogger } from '@graphql-mesh/utils';
 import { hiveProductConfig } from './hiveProductConfig.js';
 
 // @inject-version globalThis.__VERSION__ here
+
+handleNodeWarnings();
 
 const log = new DefaultLogger();
 

--- a/packages/serve-cli/src/bin.ts
+++ b/packages/serve-cli/src/bin.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { DefaultLogger } from '@graphql-mesh/utils';
-import { run } from './cli.js';
+import { handleNodeWarnings, run } from './cli.js';
 
 // @inject-version globalThis.__VERSION__ here
+
+handleNodeWarnings();
 
 const log = new DefaultLogger();
 

--- a/packages/serve-cli/src/cli.ts
+++ b/packages/serve-cli/src/cli.ts
@@ -314,18 +314,9 @@ export function run(userCtx: Partial<CLIContext>) {
     ctx.log.info(`Starting ${productName} ${version || ''}`);
   }
 
-  const internalWarningLog = ctx.log.child('internal');
-
-  process.on('warning', warning => {
-    if (warning.name === 'MaxListenersExceededWarning') {
-      ctx.log.warn(
-        'Potential memory leak detected.\nPlease report this to the maintainers.\nEnable debug mode to see more details.',
-      );
-    }
-    internalWarningLog.warn(warning);
-  });
-
   addCommands(ctx, cli);
+
+  handleNodeWarnings();
 
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   warnIfNodeLibcurlMissing(ctx);
@@ -340,4 +331,13 @@ async function warnIfNodeLibcurlMissing(ctx: CLIContext) {
       'node-libcurl is not installed properly which is used for better performance and developer experience. Falling back to "node:http".',
     );
   }
+}
+
+function handleNodeWarnings() {
+  const originalProcessEmitWarning = process.emitWarning.bind(process);
+  process.emitWarning = function gatewayEmitWarning(warning: string | Error, ...opts: any[]) {
+    if (['1', 'y', 'yes', 't', 'true'].includes(String(process.env.DEBUG))) {
+      originalProcessEmitWarning(warning, ...opts);
+    }
+  };
 }

--- a/packages/serve-cli/src/cli.ts
+++ b/packages/serve-cli/src/cli.ts
@@ -316,8 +316,6 @@ export function run(userCtx: Partial<CLIContext>) {
 
   addCommands(ctx, cli);
 
-  handleNodeWarnings();
-
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   warnIfNodeLibcurlMissing(ctx);
 
@@ -333,7 +331,7 @@ async function warnIfNodeLibcurlMissing(ctx: CLIContext) {
   }
 }
 
-function handleNodeWarnings() {
+export function handleNodeWarnings() {
   const originalProcessEmitWarning = process.emitWarning.bind(process);
   process.emitWarning = function gatewayEmitWarning(warning: string | Error, ...opts: any[]) {
     if (['1', 'y', 'yes', 't', 'true'].includes(String(process.env.DEBUG))) {


### PR DESCRIPTION
Suppress Node Warnings, and expose them only if \`DEBUG\` env var is truthy