### PR TITLE
Bundle custom import hooks and use path instead of injecting code

### DIFF
--- a/packages/hive-gateway/rollup.binary.config.js
+++ b/packages/hive-gateway/rollup.binary.config.js
@@ -146,9 +146,7 @@ return module.exports;
       if (includeHooksRegisterDest.test(code)) {
         code = code.replaceAll(
           includeHooksRegisterDest,
-          `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, ${JSON.stringify(
-            '@graphql-mesh/include/hooks.mjs',
-          )})`,
+          `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, '@graphql-mesh', 'include', 'hooks.mjs')`,
         );
       } else {
         throw new Error(

--- a/packages/hive-gateway/rollup.binary.config.js
+++ b/packages/hive-gateway/rollup.binary.config.js
@@ -142,7 +142,7 @@ return module.exports;
       }
 
       // replace the @graphql-mesh/include/hooks register to use the absolute path of the packed deps
-      const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/; // intentionally no closing bracked because there's more arguments
+      const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/g; // intentionally no closing bracked because there's more arguments
       if (includeHooksRegisterDest.test(code)) {
         code = code.replaceAll(
           includeHooksRegisterDest,

--- a/packages/hive-gateway/rollup.binary.config.js
+++ b/packages/hive-gateway/rollup.binary.config.js
@@ -143,7 +143,7 @@ return module.exports;
 
       // replace the @graphql-mesh/include/hooks register to use the absolute path of the packed deps
       const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/; // intentionally no closing bracked because there's more arguments
-      if (code.includes(includeHooksRegisterDest)) {
+      if (includeHooksRegisterDest.test(code)) {
         code = code.replaceAll(
           includeHooksRegisterDest,
           `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, ${JSON.stringify(

--- a/packages/hive-gateway/rollup.binary.config.js
+++ b/packages/hive-gateway/rollup.binary.config.js
@@ -141,6 +141,21 @@ return module.exports;
         throw new Error('Bundle does not have any dynamic commonjs requires');
       }
 
+      // replace the @graphql-mesh/include/hooks register to use the absolute path of the packed deps
+      const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/; // intentionally no closing bracked because there's more arguments
+      if (code.includes(includeHooksRegisterDest)) {
+        code = code.replaceAll(
+          includeHooksRegisterDest,
+          `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, ${JSON.stringify(
+            '@graphql-mesh/include/hooks.mjs',
+          )})`,
+        );
+      } else {
+        throw new Error(
+          `Include hooks path cannot be fixed, does "${includeHooksRegisterDest}" exist in the source code?`,
+        );
+      }
+
       return code;
     },
     async generateBundle() {

--- a/packages/serve-cli/rollup.binary.config.js
+++ b/packages/serve-cli/rollup.binary.config.js
@@ -146,9 +146,7 @@ return module.exports;
       if (includeHooksRegisterDest.test(code)) {
         code = code.replaceAll(
           includeHooksRegisterDest,
-          `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, ${JSON.stringify(
-            '@graphql-mesh/include/hooks.mjs',
-          )})`,
+          `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, '@graphql-mesh', 'include', 'hooks.mjs')`,
         );
       } else {
         throw new Error(

--- a/packages/serve-cli/rollup.binary.config.js
+++ b/packages/serve-cli/rollup.binary.config.js
@@ -142,7 +142,7 @@ return module.exports;
       }
 
       // replace the @graphql-mesh/include/hooks register to use the absolute path of the packed deps
-      const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/; // intentionally no closing bracked because there's more arguments
+      const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/g; // intentionally no closing bracked because there's more arguments
       if (includeHooksRegisterDest.test(code)) {
         code = code.replaceAll(
           includeHooksRegisterDest,

--- a/packages/serve-cli/rollup.binary.config.js
+++ b/packages/serve-cli/rollup.binary.config.js
@@ -143,7 +143,7 @@ return module.exports;
 
       // replace the @graphql-mesh/include/hooks register to use the absolute path of the packed deps
       const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/; // intentionally no closing bracked because there's more arguments
-      if (code.includes(includeHooksRegisterDest)) {
+      if (includeHooksRegisterDest.test(code)) {
         code = code.replaceAll(
           includeHooksRegisterDest,
           `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, ${JSON.stringify(

--- a/packages/serve-cli/rollup.binary.config.js
+++ b/packages/serve-cli/rollup.binary.config.js
@@ -141,6 +141,21 @@ return module.exports;
         throw new Error('Bundle does not have any dynamic commonjs requires');
       }
 
+      // replace the @graphql-mesh/include/hooks register to use the absolute path of the packed deps
+      const includeHooksRegisterDest = /register\(\s*'@graphql-mesh\/include\/hooks'/; // intentionally no closing bracked because there's more arguments
+      if (code.includes(includeHooksRegisterDest)) {
+        code = code.replaceAll(
+          includeHooksRegisterDest,
+          `register(require('node:path').join(globalThis.__PACKED_DEPS_PATH__, ${JSON.stringify(
+            '@graphql-mesh/include/hooks.mjs',
+          )})`,
+        );
+      } else {
+        throw new Error(
+          `Include hooks path cannot be fixed, does "${includeHooksRegisterDest}" exist in the source code?`,
+        );
+      }
+
       return code;
     },
     async generateBundle() {


### PR DESCRIPTION
Much, _much_, shorter stack trace in bundled environments (docker and bin) where imports fail.