### PR TITLE
fix(serve-cli): No "Starting Mesh" log

### DIFF
--- a/packages/serve-cli/src/cli.ts
+++ b/packages/serve-cli/src/cli.ts
@@ -304,14 +304,12 @@ export function run(userCtx: Partial<CLIContext>) {
     ...userCtx,
   };
 
-  const { binName, productName, productDescription, version } = ctx;
+  const { binName, productDescription, version } = ctx;
   cli = cli.name(binName).description(productDescription);
   cli.version(version);
 
   if (cluster.worker?.id) {
     ctx.log = ctx.log.child(`Worker #${cluster.worker.id}`);
-  } else {
-    ctx.log.info(`Starting ${productName} ${version || ''}`);
   }
 
   const internalWarningLog = ctx.log.child('internal');


### PR DESCRIPTION
Unnecessary log because there's a "starting" log for each of the subcommands. Also, looks hella weird when just printing help.
<img width="1125" alt="Screenshot 2024-09-03 at 16 57 29" src="https://github.com/user-attachments/assets/14e0786b-8097-49e4-82c4-c256a60d0a07">
