### PR TITLE
Fix the asset name of the binary and installation scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,6 @@ jobs:
             'Windows' && '.exe.gz' || '.gz' }}
           asset_name:
             ${{ matrix.productname }}-${{ runner.os }}-${{ runner.arch }}${{ runner.os == 'Windows'
-            && '.exe' || ''}}
+            && '.exe.gz' || '.gz'}}
           tag: v${{fromJSON(steps.ver-mesh-serve.outputs.result).version}}
           overwrite: true

--- a/website/public/install-hive-gateway.sh
+++ b/website/public/install-hive-gateway.sh
@@ -47,7 +47,7 @@ fetch_and_prepare_binary() {
   DOWNLOAD_URL=$(echo "$API_RESPONSE" | jq -r ".assets[] | select(.name == \"$BINARY_NAME-${architecture}\") | .browser_download_url")
 
   if [ -n "$DOWNLOAD_URL" ]; then
-    destination_file="./$BINARY_NAME-${architecture}.zip"
+    destination_file="./$BINARY_NAME-${architecture}.gz"
     echo "Downloading $BINARY_NAME from $DOWNLOAD_URL ..."
     curl -sSfL "$DOWNLOAD_URL" -o "$destination_file"
 

--- a/website/public/install-mesh-serve.sh
+++ b/website/public/install-mesh-serve.sh
@@ -47,7 +47,7 @@ fetch_and_prepare_binary() {
   DOWNLOAD_URL=$(echo "$API_RESPONSE" | jq -r ".assets[] | select(.name == \"$BINARY_NAME-${architecture}\") | .browser_download_url")
 
   if [ -n "$DOWNLOAD_URL" ]; then
-    destination_file="./$BINARY_NAME-${architecture}.zip"
+    destination_file="./$BINARY_NAME-${architecture}.gz"
     echo "Downloading $BINARY_NAME from $DOWNLOAD_URL ..."
     curl -sSfL "$DOWNLOAD_URL" -o "$destination_file"
 


### PR DESCRIPTION
- Add `.gz` extension is missing in the assets of each binary release
- Add `.gz` extension to the installation scripts `install-*.sh`