### PR TITLE
fix(compose/hoist-field): create new field if the target does not exist

### DIFF
--- a/.changeset/polite-mangos-beg.md
+++ b/.changeset/polite-mangos-beg.md
@@ -21,7 +21,7 @@ createHoistFieldTransform({
 ```diff
 type Query {
   users(limit: Int!, page: Int): UserSearchResult # Keep this
-+  usersResults(limit: Int!, page: Int): [User!]! # Add a new one
++ usersResults(limit: Int!, page: Int): [User!]! # Add a new one
 }
 
 scalar _HoistConfig
@@ -34,3 +34,4 @@ type User {
   id: ID!
   name: String!
 }
+```

--- a/.changeset/polite-mangos-beg.md
+++ b/.changeset/polite-mangos-beg.md
@@ -1,0 +1,36 @@
+---
+'@graphql-mesh/fusion-composition': patch
+'@graphql-mesh/fusion-runtime': patch
+---
+
+If the target hoisted field is a new field name that doesn't exist, create that field and keep the
+existing one;
+
+```ts
+createHoistFieldTransform({
+  mapping: [
+    {
+      typeName: 'Query',
+      pathConfig: ['users', 'results'],
+      newFieldName: 'usersResults',
+    },
+  ],
+})
+```
+
+```diff
+type Query {
+  users(limit: Int!, page: Int): UserSearchResult # Keep this
++  usersResults(limit: Int!, page: Int): [User!]! # Add a new one
+}
+
+scalar _HoistConfig
+
+type UserSearchResult {
+  page: Int!
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/e2e/auto-type-merging/__snapshots__/auto-type-merging.test.ts.snap
+++ b/e2e/auto-type-merging/__snapshots__/auto-type-merging.test.ts.snap
@@ -121,7 +121,7 @@ directive @merge(
   additionalArgs: String
 ) repeatable on FIELD_DEFINITION
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
@@ -153,8 +153,6 @@ The \`File\` scalar type represents a file upload.
 scalar File @join__type(graph: PETSTORE) 
 
 scalar ObjMap @join__type(graph: PETSTORE) 
-
-scalar _HoistConfig @join__type(graph: PETSTORE)  @join__type(graph: VACCINATION) 
 
 scalar _DirectiveExtensions @join__type(graph: PETSTORE)  @join__type(graph: VACCINATION) 
 

--- a/e2e/federation-mixed/__snapshots__/federation-mixed.test.ts.snap
+++ b/e2e/federation-mixed/__snapshots__/federation-mixed.test.ts.snap
@@ -119,13 +119,11 @@ directive @transport(
   options: TransportOptions
 ) repeatable on SCHEMA
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
 scalar ObjMap @join__type(graph: ACCOUNTS) 
-
-scalar _HoistConfig @join__type(graph: ACCOUNTS) 
 
 scalar _DirectiveExtensions @join__type(graph: ACCOUNTS)  @join__type(graph: INVENTORY)  @join__type(graph: PRODUCTS)  @join__type(graph: REVIEWS) 
 

--- a/e2e/openapi-arg-rename/__snapshots__/openapi-arg-rename.test.ts.snap
+++ b/e2e/openapi-arg-rename/__snapshots__/openapi-arg-rename.test.ts.snap
@@ -106,13 +106,11 @@ directive @transport(
   queryParams: [[String]]
 ) repeatable on SCHEMA
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
 scalar ObjMap @join__type(graph: WIKI) 
-
-scalar _HoistConfig @join__type(graph: WIKI) 
 
 scalar _DirectiveExtensions @join__type(graph: WIKI) 
 

--- a/e2e/openapi-naming-convention/__snapshots__/openapi-naming-convention.test.ts.snap
+++ b/e2e/openapi-naming-convention/__snapshots__/openapi-naming-convention.test.ts.snap
@@ -108,15 +108,13 @@ directive @transport(
   queryParams: [[String]]
 ) repeatable on SCHEMA
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
 directive @extraEnumValueDirective(name: String!, value: String!, directives: _DirectiveExtensions)  repeatable on OBJECT
 
 scalar ObjMap @join__type(graph: WIKI) 
-
-scalar _HoistConfig @join__type(graph: WIKI) 
 
 scalar _DirectiveExtensions @join__type(graph: WIKI) 
 

--- a/e2e/openapi-prune/__snapshots__/openapi-prune.test.ts.snap
+++ b/e2e/openapi-prune/__snapshots__/openapi-prune.test.ts.snap
@@ -106,13 +106,11 @@ directive @transport(
   queryParams: [[String]]
 ) repeatable on SCHEMA
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
 scalar ObjMap @join__type(graph: WIKI) 
-
-scalar _HoistConfig @join__type(graph: WIKI) 
 
 scalar _DirectiveExtensions @join__type(graph: WIKI) 
 

--- a/e2e/type-merging-batching/__snapshots__/type-merging-batching.test.ts.snap
+++ b/e2e/type-merging-batching/__snapshots__/type-merging-batching.test.ts.snap
@@ -25,7 +25,7 @@ directive @merge(subgraph: String, argsExpr: String, keyArg: String, keyField: S
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions) repeatable on OBJECT
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @additionalField on FIELD_DEFINITION
 
@@ -52,8 +52,6 @@ enum join__Graph {
 scalar TransportOptions @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
 
 scalar _DirectiveExtensions @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
-
-scalar _HoistConfig @join__type(graph: BOOKS)
 
 type Query @extraSchemaDefinitionDirective(directives: {transport: [{kind: "http", subgraph: "authors", location: "http://localhost:<authors_port>/graphql", options: {}}]}) @extraSchemaDefinitionDirective(directives: {transport: [{kind: "http", subgraph: "books", location: "http://localhost:<books_port>/graphql", options: {}}]}) @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
   author(id: ID!): Author @merge(subgraph: "authors", keyField: "id", keyArg: "id") @merge(subgraph: "books", keyField: "id", keyArg: "id") @source(name: "authorWithBooks", type: "AuthorWithBooks", subgraph: "books")

--- a/packages/fusion/composition/src/compose.ts
+++ b/packages/fusion/composition/src/compose.ts
@@ -507,14 +507,10 @@ export function getAnnotatedSubgraphs(
     }
     if (sourceDirectiveUsed) {
       importedDirectivesAST.add(/* GraphQL */ `
-        scalar _HoistConfig
-      `);
-      importedDirectivesAST.add(/* GraphQL */ `
         directive @source(
           name: String!
           type: String
           subgraph: String!
-          hoist: _HoistConfig
         ) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
       `);
     }

--- a/packages/fusion/composition/tests/__snapshots__/composition.spec.ts.snap
+++ b/packages/fusion/composition/tests/__snapshots__/composition.spec.ts.snap
@@ -195,7 +195,7 @@ enum join__Graph {
   B @join__graph(name: "B", url: "") 
 }
 
-directive @source(name: String!, type: String, subgraph: String!, hoist: _HoistConfig)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @merge(
   subgraph: String
@@ -205,8 +205,6 @@ directive @merge(
   key: [String!]
   additionalArgs: String
 ) repeatable on FIELD_DEFINITION
-
-scalar _HoistConfig @join__type(graph: A)  @join__type(graph: B) 
 
 type Query @source(name: "Query", subgraph: "A")  @source(name: "Query", subgraph: "B")  @join__type(graph: A)  @join__type(graph: B)  {
   A_myFoo: A_Foo! @source(name: "myFoo", type: "Foo!", subgraph: "A")  @join__field(graph: A) 

--- a/packages/fusion/runtime/tests/transforms/filter-schema.test.ts
+++ b/packages/fusion/runtime/tests/transforms/filter-schema.test.ts
@@ -57,8 +57,6 @@ type Post {
 type Query {
   user(name: String, age: Int): User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -118,8 +116,6 @@ type Post {
 type Query {
   user(name: String, age: Int): User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -203,8 +199,6 @@ type Post {
 type Query {
   user(name: String, age: Int): User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -246,8 +240,6 @@ type Query {
   userOne(name: String, age: Int): User
   userTwo(name: String, age: Int): User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -289,8 +281,6 @@ type Query {
   userOne(name: String): User
   userTwo(name: String, age: Int): User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -349,8 +339,6 @@ type Book {
 type Query {
   user: User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -383,8 +371,6 @@ type Query {
   foo: String
   bar: String
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -440,8 +426,6 @@ type User {
 type Query {
   user: User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -500,8 +484,6 @@ type Query {
   user: User
   admin: User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -570,8 +552,6 @@ type Post {
 type Query {
   user(id: ID!): User
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -625,8 +605,6 @@ scalar _HoistConfig
     expectTheSchemaSDLToBe(
       schema,
       /* GraphQL */ `
-scalar _HoistConfig
-
 type User {
   id: ID
   name: String
@@ -697,8 +675,6 @@ type Book {
 type Query {
   book: Book
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });
@@ -768,8 +744,6 @@ type User {
   e: String
 }
 
-scalar _HoistConfig
-
 type Book {
   id: ID
   name: String
@@ -823,8 +797,6 @@ type User {
   name: String
   username: String
 }
-
-scalar _HoistConfig
 
 type Book {
   id: ID
@@ -881,8 +853,6 @@ type Test implements ITest {
   username: String
 }
 
-scalar _HoistConfig
-
 type Query {
   test: Test
 }
@@ -915,8 +885,6 @@ type Query {
 type Query {
   foo: String
 }
-
-scalar _HoistConfig
 `.trim(),
     );
   });

--- a/packages/fusion/runtime/tests/transforms/naming-convention.test.ts
+++ b/packages/fusion/runtime/tests/transforms/naming-convention.test.ts
@@ -92,8 +92,6 @@ describe('Naming Convention', () => {
         }
 
         scalar _DirectiveExtensions
-
-        scalar _HoistConfig
       `,
     );
   });

--- a/packages/fusion/runtime/tests/transforms/prefix.test.ts
+++ b/packages/fusion/runtime/tests/transforms/prefix.test.ts
@@ -81,8 +81,6 @@ describe('Prefix', () => {
         }
 
         scalar _DirectiveExtensions
-
-        scalar _HoistConfig
       `,
     );
   });

--- a/packages/legacy/transforms/hoist-field/test/transform.spec.ts
+++ b/packages/legacy/transforms/hoist-field/test/transform.spec.ts
@@ -281,4 +281,48 @@ type User {
 }"
 `);
   });
+  it('should respect the new field name', () => {
+    const newSchema = wrapSchema({
+      schema,
+      transforms: [
+        new HoistFieldTransform({
+          config: [
+            {
+              typeName: 'Query',
+              pathConfig: ['users', 'results'],
+              newFieldName: 'usersResults',
+            },
+          ],
+          apiName: '',
+          cache,
+          pubsub,
+          baseDir,
+          importFn,
+          logger: new DefaultLogger(),
+        }),
+      ],
+    });
+
+    const queryType = newSchema.getType('Query') as GraphQLObjectType;
+    expect(queryType).toBeDefined();
+
+    const fields = queryType.getFields();
+    expect(fields.usersResults).toBeDefined();
+
+    expect(printSchema(newSchema)).toMatchInlineSnapshot(`
+"type Query {
+  users(limit: Int!, page: Int): UserSearchResult
+  usersResults(limit: Int!, page: Int): [User!]!
+}
+
+type UserSearchResult {
+  page: Int!
+}
+
+type User {
+  id: ID!
+  name: String!
+}"
+`);
+  });
 });


### PR DESCRIPTION
If the target hoisted field is a new field name that doesn't exist, create that field and keep the
existing one;

```ts
createHoistFieldTransform({
  mapping: [
    {
      typeName: 'Query',
      pathConfig: ['users', 'results'],
      newFieldName: 'usersResults',
    },
  ],
})
```

```diff
type Query {
  users(limit: Int!, page: Int): UserSearchResult # Keep this
+ usersResults(limit: Int!, page: Int): [User!]! # Add a new one
}

scalar _HoistConfig

type UserSearchResult {
  page: Int!
}

type User {
  id: ID!
  name: String!
}
```
