### PR TITLE
[docs] Give access to the legacy docs and fix navigation menu

### DIFF
--- a/website/src/pages/_meta.tsx
+++ b/website/src/pages/_meta.tsx
@@ -27,14 +27,6 @@ export default {
       layout: 'raw',
     },
   },
-  docs: {
-    title: 'Legacy Docs',
-    type: 'page',
-    display: 'hidden',
-    theme: {
-      topContent: LegacyDocsBanner,
-    },
-  },
   examples: {
     title: 'Examples',
     type: 'page',
@@ -45,7 +37,14 @@ export default {
     },
   },
   v1: {
-    title: 'Docs',
+    title: 'v1',
     type: 'page',
+  },
+  docs: {
+    title: 'v0',
+    type: 'page',
+    theme: {
+      topContent: LegacyDocsBanner,
+    },
   },
 };

--- a/website/src/pages/v1/getting-started.mdx
+++ b/website/src/pages/v1/getting-started.mdx
@@ -94,7 +94,11 @@ For example, the following configuration adds `Countries_` to the types and fiel
 by using [Prefix Transform](/v1/transforms/prefix).
 
 ```ts filename="mesh.config.ts" {12-16}
-import { createPrefixTransform, defineConfig, loadGraphQLHTTPSubgraph } from '@graphql-mesh/compose-cli'
+import {
+  createPrefixTransform,
+  defineConfig,
+  loadGraphQLHTTPSubgraph
+} from '@graphql-mesh/compose-cli'
 
 export const composeConfig = defineConfig({
   subgraphs: [


### PR DESCRIPTION
This PR adds a `v1` and `v0` links in the header (as in Yoga and Envelop docs)
![image](https://github.com/user-attachments/assets/0cae2adc-5735-4105-9571-d367b7ea8834)
