### PR TITLE
[legacy] allow for non string values in additionalArgs

### DIFF
--- a/.changeset/fair-students-tease.md
+++ b/.changeset/fair-students-tease.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+Allow for static values in `additionalArgs` instead of only interpolated strings.

--- a/packages/legacy/utils/src/resolve-additional-resolvers.ts
+++ b/packages/legacy/utils/src/resolve-additional-resolvers.ts
@@ -199,10 +199,11 @@ export function resolveAdditionalResolversWithoutImport(
             const resolverData = { root, args, context, info, env: process.env };
             const targetArgs: any = {};
             for (const argPath in additionalResolver.additionalArgs || {}) {
+              const value = additionalResolver.additionalArgs[argPath];
               dset(
                 targetArgs,
                 argPath,
-                stringInterpolator.parse(additionalResolver.additionalArgs[argPath], resolverData),
+                typeof value === 'string' ? stringInterpolator.parse(value, resolverData) : value,
               );
             }
             const options: any = {


### PR DESCRIPTION
## Description

Allow to provide values instead of only interpolated strings for `additionalArgs`.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
