### PR TITLE
fix(composition): do not add multiple `@hidden` directives

### DIFF
--- a/.changeset/sharp-dodos-visit.md
+++ b/.changeset/sharp-dodos-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-composition': patch
+---
+
+Do not add another `@hidden` directive definition if it already exists

--- a/packages/fusion/composition/src/transforms/encapsulate.ts
+++ b/packages/fusion/composition/src/transforms/encapsulate.ts
@@ -99,10 +99,17 @@ export function createEncapsulateTransform(opts: EncapsulateTransformOpts = {}):
       }
     }
     const schemaConfig = schema.toConfig();
+    const newDirectives = [...schemaConfig.directives];
+    if (!newDirectives.some(directive => directive.name === 'resolveTo')) {
+      newDirectives.push(resolveToDirective);
+    }
+    if (!newDirectives.some(directive => directive.name === 'hidden')) {
+      newDirectives.push(hiddenDirective);
+    }
     return new GraphQLSchema({
       ...schemaConfig,
       types: undefined,
-      directives: [...schemaConfig.directives, hiddenDirective, resolveToDirective],
+      directives: newDirectives,
       ...newRootTypes,
     });
   };

--- a/packages/fusion/composition/src/transforms/filter-schema.ts
+++ b/packages/fusion/composition/src/transforms/filter-schema.ts
@@ -194,9 +194,13 @@ export function createFilterTransform({
   return function filterTransform(schema) {
     const mappedSchema = mapSchema(schema, schemaMapper);
     const mappedSchemaConfig = mappedSchema.toConfig();
+    const newDirectives = [...mappedSchemaConfig.directives];
+    if (!newDirectives.some(directive => directive.name === 'hidden')) {
+      newDirectives.push(hiddenDirective);
+    }
     return new GraphQLSchema({
       ...mappedSchemaConfig,
-      directives: [...mappedSchemaConfig.directives, hiddenDirective],
+      directives: newDirectives,
     });
   };
 }


### PR DESCRIPTION
Fixes the error for multiple definitions of `@hidden` directive when encapsulate and filter transforms are used together