### PR TITLE
[examples/v1] compose-to-output

### DIFF
--- a/e2e/compose-to-output/package.json
+++ b/e2e/compose-to-output/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@graphql-mesh/compose-cli": "workspace:*",
-    "@graphql-mesh/serve-cli": "workspace:*",
     "graphql": "16.9.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3536,6 +3536,7 @@ __metadata:
     "@omnigraph/openapi": "workspace:*"
     graphql: "npm:^16.9.0"
     graphql-yoga: "npm:^5.7.0"
+    tsx: "npm:^4.19.1"
   languageName: unknown
   linkType: soft
 
@@ -3554,7 +3555,6 @@ __metadata:
   resolution: "@e2e/compose-to-output@workspace:e2e/compose-to-output"
   dependencies:
     "@graphql-mesh/compose-cli": "workspace:*"
-    "@graphql-mesh/serve-cli": "workspace:*"
     graphql: "npm:16.9.0"
   languageName: unknown
   linkType: soft
@@ -36540,7 +36540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.16.5, tsx@npm:^4.19.0":
+"tsx@npm:^4.16.5, tsx@npm:^4.19.0, tsx@npm:^4.19.1":
   version: 4.19.1
   resolution: "tsx@npm:4.19.1"
   dependencies:


### PR DESCRIPTION
Not sure this example needs to be actually runnable... It's more an test than an actual example.

I've just updated the package.json to not depend on `@graphql-mesh/serve-cli`.