### PR TITLE
`[@graphql-mesh/plugin-opentelemetry]` Make it possible to skip initializing `NodeSDK`

### DIFF
--- a/.changeset/big-tigers-sing.md
+++ b/.changeset/big-tigers-sing.md
@@ -1,0 +1,7 @@
+---
+'@graphql-mesh/plugin-opentelemetry': minor
+---
+
+Make it possible to run with externally initialized OpenTelemetry NodeSDK.
+
+This fixes the issue of seeing a lot of errors on the form `Error: @opentelemetry/api: Attempted duplicate registration of API: trace`.

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -38,7 +38,10 @@ describe('useOpenTelemetry', () => {
         },
         plugins: () => [
           useCustomFetch(upstream.fetch),
-          useOpenTelemetry({ diagLogLevel: DiagLogLevel.NONE }),
+          useOpenTelemetry({
+            exporters: [],
+            diagLogLevel: DiagLogLevel.NONE,
+          }),
         ],
         logging: false,
       });

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -1,7 +1,5 @@
 import { createSchema, createYoga } from 'graphql-yoga';
 import { createGatewayRuntime, useCustomFetch } from '@graphql-mesh/serve-runtime';
-import type { NodeSDK } from '@opentelemetry/sdk-node';
-import { useOpenTelemetry } from '../src/index';
 
 describe('useOpenTelemetry', () => {
   if (process.env.LEAK_TEST) {
@@ -18,6 +16,7 @@ describe('useOpenTelemetry', () => {
   });
   describe('when not passing a custom sdk', () => {
     it('initializes and starts a new NodeSDK', async () => {
+      const { useOpenTelemetry } = await import('../src');
       const upstream = createYoga({
         schema: createSchema({
           typeDefs: /* GraphQL */ `
@@ -71,6 +70,7 @@ describe('useOpenTelemetry', () => {
 
   describe('when passing a custom sdk', () => {
     it('does not initialize a new NodeSDK and does not start the provided sdk instance', async () => {
+      const { useOpenTelemetry } = await import('../src');
       const upstream = createYoga({
         schema: createSchema({
           typeDefs: /* GraphQL */ `
@@ -87,7 +87,6 @@ describe('useOpenTelemetry', () => {
         logging: false,
       });
 
-      const sdk = { start: jest.fn() } as unknown as NodeSDK;
       await using serveRuntime = createGatewayRuntime({
         proxy: {
           endpoint: 'https://example.com/graphql',
@@ -117,7 +116,6 @@ describe('useOpenTelemetry', () => {
       const body = await response.json<any>();
       expect(body.data?.hello).toBe('World');
       expect(mockStartSdk).not.toHaveBeenCalled();
-      expect(sdk.start).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
+++ b/packages/plugins/opentelemetry/tests/useOpenTelemetry.spec.ts
@@ -1,0 +1,118 @@
+import { createSchema, createYoga } from 'graphql-yoga';
+import { createGatewayRuntime, useCustomFetch } from '@graphql-mesh/serve-runtime';
+import { DiagLogLevel } from '@opentelemetry/api';
+import type { NodeSDK } from '@opentelemetry/sdk-node';
+import { useOpenTelemetry } from '../src/index';
+
+const mockStartSdk = jest.fn();
+jest.mock('@opentelemetry/sdk-node', () => ({
+  NodeSDK: jest.fn(() => ({ start: mockStartSdk })),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useOpenTelemetry', () => {
+  describe('when not passing a custom sdk', () => {
+    it('initializes and starts a new NodeSDK', async () => {
+      const upstream = createYoga({
+        schema: createSchema({
+          typeDefs: /* GraphQL */ `
+            type Query {
+              hello: String
+            }
+          `,
+          resolvers: {
+            Query: {
+              hello: () => 'World',
+            },
+          },
+        }),
+        logging: false,
+      });
+
+      const serveRuntime = createGatewayRuntime({
+        proxy: {
+          endpoint: 'https://example.com/graphql',
+        },
+        plugins: () => [
+          useCustomFetch(upstream.fetch),
+          useOpenTelemetry({ diagLogLevel: DiagLogLevel.NONE }),
+        ],
+        logging: false,
+      });
+
+      const response = await serveRuntime.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              hello
+            }
+          `,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json<any>();
+      expect(body.data?.hello).toBe('World');
+      expect(mockStartSdk).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when passing a custom sdk', () => {
+    it('does not initialize a new NodeSDK and does not start the provided sdk instance', async () => {
+      const upstream = createYoga({
+        schema: createSchema({
+          typeDefs: /* GraphQL */ `
+            type Query {
+              hello: String
+            }
+          `,
+          resolvers: {
+            Query: {
+              hello: () => 'World',
+            },
+          },
+        }),
+        logging: false,
+      });
+
+      const sdk = { start: jest.fn() } as unknown as NodeSDK;
+      const serveRuntime = createGatewayRuntime({
+        proxy: {
+          endpoint: 'https://example.com/graphql',
+        },
+        plugins: () => [
+          useCustomFetch(upstream.fetch),
+          useOpenTelemetry({ initializeNodeSDK: false, diagLogLevel: DiagLogLevel.NONE }),
+        ],
+        logging: false,
+      });
+
+      const response = await serveRuntime.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              hello
+            }
+          `,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json<any>();
+      expect(body.data?.hello).toBe('World');
+      expect(mockStartSdk).not.toHaveBeenCalled();
+      expect(sdk.start).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/serve-cli/src/commands/proxy.ts
+++ b/packages/serve-cli/src/commands/proxy.ts
@@ -90,7 +90,10 @@ export const addCommand: AddCommand = (ctx, cli) =>
         pubsub,
         logger: ctx.log,
       });
-      const builtinPlugins = await getBuiltinPluginsFromConfig(loadedConfig, { cache });
+      const builtinPlugins = await getBuiltinPluginsFromConfig(loadedConfig, {
+        cache,
+        logger: ctx.log,
+      });
 
       const config: ProxyConfig = {
         ...defaultOptions,

--- a/packages/serve-cli/src/commands/subgraph.ts
+++ b/packages/serve-cli/src/commands/subgraph.ts
@@ -57,7 +57,10 @@ export const addCommand: AddCommand = (ctx, cli) =>
         pubsub,
         logger: ctx.log,
       });
-      const builtinPlugins = await getBuiltinPluginsFromConfig(loadedConfig, { cache });
+      const builtinPlugins = await getBuiltinPluginsFromConfig(loadedConfig, {
+        cache,
+        logger: ctx.log,
+      });
 
       const config: SubgraphConfig = {
         ...defaultOptions,

--- a/packages/serve-cli/src/commands/supergraph.ts
+++ b/packages/serve-cli/src/commands/supergraph.ts
@@ -156,7 +156,10 @@ export const addCommand: AddCommand = (ctx, cli) =>
         pubsub,
         logger: ctx.log,
       });
-      const builtinPlugins = await getBuiltinPluginsFromConfig(loadedConfig, { cache });
+      const builtinPlugins = await getBuiltinPluginsFromConfig(loadedConfig, {
+        cache,
+        logger: ctx.log,
+      });
 
       const config: SupergraphConfig = {
         ...defaultOptions,

--- a/packages/serve-cli/src/config.ts
+++ b/packages/serve-cli/src/config.ts
@@ -80,7 +80,7 @@ export async function loadConfig<TContext extends Record<string, any> = Record<s
 
 export async function getBuiltinPluginsFromConfig(
   config: GatewayCLIBuiltinPluginConfig,
-  ctx: { cache: KeyValueCache },
+  ctx: { cache: KeyValueCache; logger: Logger },
 ) {
   const plugins = [];
   if (config.jwt) {
@@ -93,7 +93,12 @@ export async function getBuiltinPluginsFromConfig(
   }
   if (config.openTelemetry) {
     const { useOpenTelemetry } = await import('@graphql-mesh/plugin-opentelemetry');
-    plugins.push(useOpenTelemetry(config.openTelemetry));
+    plugins.push(
+      useOpenTelemetry({
+        logger: ctx.logger,
+        ...config.openTelemetry,
+      }),
+    );
   }
 
   if (config.rateLimiting) {


### PR DESCRIPTION
## Description

Allow a user to pass `initializeNodeSDK: boolean` option to the `useOpenTelemetry` plugin, in case the userland code already initialized NodeSDK themselves and does not want this plugin to create one. The default behaviour is the same, if you don't pass `initializeNodeSDK` then it will default to true, making this feature backwards compatible.

Fixes #7754

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

None
