### PR TITLE
Expose `getBuiltinPluginsFromConfig` and `getCacheInstanceFromConfig`

### DIFF
--- a/.changeset/curly-pants-trade.md
+++ b/.changeset/curly-pants-trade.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/serve-cli': patch
+---
+
+Expose getBuiltinPluginsFromConfig and getCacheInstanceFromConfig from serve-cli

--- a/packages/serve-cli/src/index.ts
+++ b/packages/serve-cli/src/index.ts
@@ -1,4 +1,5 @@
 export * from './cli.js';
+export { getBuiltinPluginsFromConfig, getCacheInstanceFromConfig } from './config.js';
 export * from '@graphql-mesh/serve-runtime';
 export { PubSub } from '@graphql-mesh/utils';
 export * from '@graphql-mesh/plugin-jwt-auth';


### PR DESCRIPTION
## Description

Expose `getBuiltinPluginsFromConfig` and `getCacheInstanceFromConfig`

Fixes #7764

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


