### PR TITLE
Update Hive libs to latest

### DIFF
--- a/.changeset/@graphql-mesh_plugin-hive-7767-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-hive-7767-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-mesh/plugin-hive": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-hive/core@^0.8.1` ↗︎](https://www.npmjs.com/package/@graphql-hive/core/v/0.8.1) (from `^0.8.0`, in `dependencies`)
+  - Updated dependency [`@graphql-hive/yoga@^0.38.1` ↗︎](https://www.npmjs.com/package/@graphql-hive/yoga/v/0.38.1) (from `^0.38.0`, in `dependencies`)

--- a/.changeset/@graphql-mesh_serve-runtime-7767-dependencies.md
+++ b/.changeset/@graphql-mesh_serve-runtime-7767-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/serve-runtime": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-hive/core@^0.8.1` ↗︎](https://www.npmjs.com/package/@graphql-hive/core/v/0.8.1) (from `^0.8.0`, in `dependencies`)

--- a/.changeset/@graphql-mesh_transform-hive-7767-dependencies.md
+++ b/.changeset/@graphql-mesh_transform-hive-7767-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-mesh/transform-hive": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-hive/core@^0.8.1` ↗︎](https://www.npmjs.com/package/@graphql-hive/core/v/0.8.1) (from `^0.8.0`, in `dependencies`)
+  - Updated dependency [`@graphql-hive/yoga@^0.38.1` ↗︎](https://www.npmjs.com/package/@graphql-hive/yoga/v/0.38.1) (from `^0.38.0`, in `dependencies`)

--- a/packages/legacy/transforms/hive/package.json
+++ b/packages/legacy/transforms/hive/package.json
@@ -39,8 +39,8 @@
     "tslib": "^2.4.0"
   },
   "dependencies": {
-    "@graphql-hive/core": "^0.8.0",
-    "@graphql-hive/yoga": "^0.38.0",
+    "@graphql-hive/core": "^0.8.1",
+    "@graphql-hive/yoga": "^0.38.1",
     "@graphql-mesh/string-interpolation": "^0.5.6",
     "@graphql-tools/delegate": "^10.0.21"
   },

--- a/packages/plugins/hive/package.json
+++ b/packages/plugins/hive/package.json
@@ -39,8 +39,8 @@
     "tslib": "^2.4.0"
   },
   "dependencies": {
-    "@graphql-hive/core": "^0.8.0",
-    "@graphql-hive/yoga": "^0.38.0",
+    "@graphql-hive/core": "^0.8.1",
+    "@graphql-hive/yoga": "^0.38.1",
     "@graphql-mesh/string-interpolation": "0.5.6"
   },
   "publishConfig": {

--- a/packages/serve-runtime/package.json
+++ b/packages/serve-runtime/package.json
@@ -41,7 +41,7 @@
     "@envelop/core": "^5.0.0",
     "@envelop/disable-introspection": "^6.0.0",
     "@envelop/generic-auth": "^8.0.0",
-    "@graphql-hive/core": "^0.8.0",
+    "@graphql-hive/core": "^0.8.1",
     "@graphql-mesh/cross-helpers": "^0.4.6",
     "@graphql-mesh/fusion-runtime": "^0.8.14",
     "@graphql-mesh/hmac-upstream-signature": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6061,7 +6061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-hive/core@npm:0.8.0, @graphql-hive/core@npm:^0.8.0":
+"@graphql-hive/core@npm:0.8.0":
   version: 0.8.0
   resolution: "@graphql-hive/core@npm:0.8.0"
   dependencies:
@@ -6073,6 +6073,21 @@ __metadata:
   peerDependencies:
     graphql: ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
   checksum: 10c0/144bc14e2d20e9624acd15324664668b45e29a7199c490705068e5db8c9669e49047820373d180fccec4b4ef44706f363f6f0deda1fe8ec7d5763baa0f57b0a7
+  languageName: node
+  linkType: hard
+
+"@graphql-hive/core@npm:0.8.1, @graphql-hive/core@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@graphql-hive/core@npm:0.8.1"
+  dependencies:
+    "@graphql-tools/utils": "npm:^10.0.0"
+    "@whatwg-node/fetch": "npm:0.9.21"
+    async-retry: "npm:1.3.3"
+    lodash.sortby: "npm:4.7.0"
+    tiny-lru: "npm:8.0.2"
+  peerDependencies:
+    graphql: ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 10c0/0f8c0582e1e3b87fdc6d74e3ca0d45dd765a792266d1b011706e8d1ede396e6b2268254f9e59c9d0ba124948e5a324f67efac8d18e3a47fc5e0364fe12dba438
   languageName: node
   linkType: hard
 
@@ -6105,17 +6120,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphql-hive/yoga@npm:^0.38.0":
-  version: 0.38.0
-  resolution: "@graphql-hive/yoga@npm:0.38.0"
+"@graphql-hive/yoga@npm:^0.38.1":
+  version: 0.38.1
+  resolution: "@graphql-hive/yoga@npm:0.38.1"
   dependencies:
-    "@graphql-hive/core": "npm:0.8.0"
+    "@graphql-hive/core": "npm:0.8.1"
     "@graphql-yoga/plugin-persisted-operations": "npm:^3.3.1"
     tiny-lru: "npm:8.0.2"
   peerDependencies:
     graphql: ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     graphql-yoga: ^5.0.0
-  checksum: 10c0/5f299725a9e7b8a05c53043560b2103ce5dc75be926f8552b8b36af9c2e6518d1cd907aab7fee6a4b9f30d5989f07ae12ece78d56bb7323168f3b66929afbfcc
+  checksum: 10c0/412b3a0864abb044a054b586ae599dd17a4fc3051b0222a24c46d9f3f429c1e121c86efd399599645b1fe899ae3cc6be31c1b196ff71addb406ab10617dbe618
   languageName: node
   linkType: hard
 
@@ -6663,8 +6678,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-mesh/plugin-hive@workspace:packages/plugins/hive"
   dependencies:
-    "@graphql-hive/core": "npm:^0.8.0"
-    "@graphql-hive/yoga": "npm:^0.38.0"
+    "@graphql-hive/core": "npm:^0.8.1"
+    "@graphql-hive/yoga": "npm:^0.38.1"
     "@graphql-mesh/string-interpolation": "npm:0.5.6"
   peerDependencies:
     "@graphql-mesh/cross-helpers": ^0.4.6
@@ -7034,7 +7049,7 @@ __metadata:
     "@envelop/core": "npm:^5.0.0"
     "@envelop/disable-introspection": "npm:6.0.0"
     "@envelop/generic-auth": "npm:^8.0.0"
-    "@graphql-hive/core": "npm:^0.8.0"
+    "@graphql-hive/core": "npm:^0.8.1"
     "@graphql-mesh/cross-helpers": "npm:^0.4.6"
     "@graphql-mesh/fusion-runtime": "npm:^0.8.14"
     "@graphql-mesh/hmac-upstream-signature": "npm:^1.0.5"
@@ -7240,8 +7255,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-mesh/transform-hive@workspace:packages/legacy/transforms/hive"
   dependencies:
-    "@graphql-hive/core": "npm:^0.8.0"
-    "@graphql-hive/yoga": "npm:^0.38.0"
+    "@graphql-hive/core": "npm:^0.8.1"
+    "@graphql-hive/yoga": "npm:^0.38.1"
     "@graphql-mesh/string-interpolation": "npm:^0.5.6"
     "@graphql-tools/delegate": "npm:^10.0.21"
   peerDependencies:


### PR DESCRIPTION
A new version of hive gateway needs to be released as new versions of `@graphql-hive/core` and `@graphql-hive/yoga` were released.