### PR TITLE
Propagate headers as array from subgraphs to client

### DIFF
--- a/.changeset/fuzzy-coins-pay.md
+++ b/.changeset/fuzzy-coins-pay.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/serve-runtime': minor
+---
+
+Ability to return headers with multiple values from propagateHeaders.fromSubgraphsToClient

--- a/packages/serve-runtime/src/plugins/usePropagateHeaders.ts
+++ b/packages/serve-runtime/src/plugins/usePropagateHeaders.ts
@@ -18,10 +18,16 @@ interface FromSubgraphsToClientPayload {
 export interface PropagateHeadersOpts {
   fromClientToSubgraphs?: (
     payload: FromClientToSubgraphsPayload,
-  ) => Record<string, string> | void | Promise<Record<string, string | null | undefined> | void>;
+  ) =>
+    | Record<string, string | string[]>
+    | void
+    | Promise<Record<string, string | string[] | null | undefined> | void>;
   fromSubgraphsToClient?: (
     payload: FromSubgraphsToClientPayload,
-  ) => Record<string, string> | void | Promise<Record<string, string | null | undefined> | void>;
+  ) =>
+    | Record<string, string | string[]>
+    | void
+    | Promise<Record<string, string | string[] | null | undefined> | void>;
 }
 
 export function usePropagateHeaders<TContext>(opts: PropagateHeadersOpts): GatewayPlugin<TContext> {
@@ -74,7 +80,13 @@ export function usePropagateHeaders<TContext>(opts: PropagateHeadersOpts): Gatew
         for (const key in headers) {
           const value = headers[key];
           if (value) {
-            response.headers.set(key, value);
+            if (Array.isArray(value)) {
+              for (const v of value) {
+                response.headers.append(key, v);
+              }
+            } else {
+              response.headers.set(key, value);
+            }
           }
         }
       }

--- a/packages/serve-runtime/tests/propagateHeaders.spec.ts
+++ b/packages/serve-runtime/tests/propagateHeaders.spec.ts
@@ -1,4 +1,5 @@
 import { createSchema, createYoga, type Plugin } from 'graphql-yoga';
+import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { useCustomFetch } from '@graphql-mesh/serve-runtime';
 import { createGatewayRuntime } from '../src/createGatewayRuntime';
 
@@ -132,6 +133,125 @@ describe('usePropagateHeaders', () => {
       expect(headersObj['x-my-header']).toBe('my-value');
       expect(headersObj['x-extra-header']).toBe('extra-value');
       expect(headersObj['x-my-other']).toBe('other-value');
+    });
+  });
+  describe('From Subgraphs to the Client', () => {
+    const upstream1 = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hello1: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          hello1: () => 'world1',
+        },
+      },
+    });
+    const upstream1Fetch = createYoga({
+      schema: upstream1,
+      plugins: [
+        {
+          onResponse: ({ response }) => {
+            response.headers.set('upstream1', 'upstream1');
+            response.headers.append('set-cookie', 'cookie1=value1');
+            response.headers.append('set-cookie', 'cookie2=value2');
+          },
+        },
+      ],
+    }).fetch;
+    const upstream2 = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hello2: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          hello2: () => 'world2',
+        },
+      },
+    });
+    const upstream2Fetch = createYoga({
+      schema: upstream2,
+      plugins: [
+        {
+          onResponse: ({ response }) => {
+            response.headers.set('upstream2', 'upstream2');
+            response.headers.append('set-cookie', 'cookie3=value3');
+            response.headers.append('set-cookie', 'cookie4=value4');
+          },
+        },
+      ],
+    }).fetch;
+    it('Aggregates cookies from all subgraphs', async () => {
+      await using serveRuntime = createGatewayRuntime({
+        supergraph: () => {
+          return getUnifiedGraphGracefully([
+            {
+              name: 'upstream1',
+              schema: upstream1,
+              url: 'http://localhost:4001/graphql',
+            },
+            {
+              name: 'upstream2',
+              schema: upstream2,
+              url: 'http://localhost:4002/graphql',
+            },
+          ]);
+        },
+        propagateHeaders: {
+          fromSubgraphsToClient({ response }) {
+            const cookies = response.headers.getSetCookie();
+            return {
+              upstream1: response.headers.get('upstream1'),
+              upstream2: response.headers.get('upstream2'),
+              'set-cookie': cookies,
+            };
+          },
+        },
+        plugins: () => [
+          useCustomFetch((url, options, context, info) => {
+            switch (url) {
+              case 'http://localhost:4001/graphql':
+                return upstream1Fetch(url, options, context, info);
+              case 'http://localhost:4002/graphql':
+                return upstream2Fetch(url, options, context, info);
+              default:
+                throw new Error('Invalid URL');
+            }
+          }),
+        ],
+        logging: !!process.env.DEBUG,
+      });
+      const response = await serveRuntime.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              hello1
+              hello2
+            }
+          `,
+        }),
+      });
+
+      const resJson = await response.json();
+      expect(resJson).toEqual({
+        data: {
+          hello1: 'world1',
+          hello2: 'world2',
+        },
+      });
+
+      expect(response.headers.get('upstream1')).toBe('upstream1');
+      expect(response.headers.get('upstream2')).toBe('upstream2');
+      expect(response.headers.get('set-cookie')).toBe(
+        'cookie1=value1, cookie2=value2, cookie3=value3, cookie4=value4',
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

Will allow users to return headers as array to be returned to the client. Will aggregate headers from multiple subgraphs if they return the same header value.

Fixes https://github.com/ardatan/graphql-mesh/issues/7815

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] packages/serve-runtime/tests/propagateHeaders.spec.ts

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
