### PR TITLE
fix(transport-http): add missing `process` for cross platform support

### DIFF
--- a/.changeset/@graphql-mesh_transport-http-7826-dependencies.md
+++ b/.changeset/@graphql-mesh_transport-http-7826-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/transport-http": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-mesh/cross-helpers@^0.4.7` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cross-helpers/v/0.4.7) (to `dependencies`)

--- a/.changeset/proud-hounds-happen.md
+++ b/.changeset/proud-hounds-happen.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transport-http': patch
+---
+
+Add missing \`process\` import for cross platform support

--- a/packages/transports/http/package.json
+++ b/packages/transports/http/package.json
@@ -36,6 +36,7 @@
     "tslib": "^2.4.0"
   },
   "dependencies": {
+    "@graphql-mesh/cross-helpers": "^0.4.7",
     "@graphql-mesh/string-interpolation": "^0.5.6",
     "@graphql-mesh/transport-common": "^0.7.10",
     "@graphql-mesh/utils": "^0.102.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8333,6 +8333,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-mesh/transport-http@workspace:packages/transports/http"
   dependencies:
+    "@graphql-mesh/cross-helpers": "npm:^0.4.7"
     "@graphql-mesh/string-interpolation": "npm:^0.5.6"
     "@graphql-mesh/transport-common": "npm:^0.7.10"
     "@graphql-mesh/utils": "npm:^0.102.9"


### PR DESCRIPTION
Fixes #7824 