### PR TITLE
Make `usePrometheus` available from `@graphql-mesh/plugin-prometheus`

### DIFF
--- a/.changeset/eighty-singers-check.md
+++ b/.changeset/eighty-singers-check.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-prometheus': patch
+---
+
+Make the plugin `usePrometheus` exposed by name and not only default

--- a/packages/plugins/prometheus/src/index.ts
+++ b/packages/plugins/prometheus/src/index.ts
@@ -23,7 +23,7 @@ import {
   createSummary,
   getCounterFromConfig,
   getHistogramFromConfig,
-  usePrometheus,
+  usePrometheus as useYogaPrometheus,
 } from '@graphql-yoga/plugin-prometheus';
 
 export { createCounter, createHistogram, createSummary };
@@ -138,7 +138,7 @@ type SubgraphMetricsLabelParams = {
   executionRequest: ExecutionRequest;
 };
 
-export default function useMeshPrometheus(
+export default function usePrometheus(
   pluginOptions: Omit<
     PrometheusPluginOptions,
     // Remove this after Mesh v1 is released;
@@ -245,7 +245,7 @@ export default function useMeshPrometheus(
 
   return {
     onPluginInit({ addPlugin }) {
-      addPlugin(usePrometheus(config));
+      addPlugin(useYogaPrometheus(config));
     },
     onSubgraphExecute(payload) {
       if (subgraphExecuteHistogram) {
@@ -313,6 +313,8 @@ export default function useMeshPrometheus(
     },
   };
 }
+
+export { usePrometheus };
 
 function registryFromYamlConfig(config: YamlConfig & { logger: Logger }): Registry {
   const registry$ = loadFromModuleExportExpression<Registry>(config.registry, {

--- a/packages/plugins/prometheus/tests/prometheus.spec.ts
+++ b/packages/plugins/prometheus/tests/prometheus.spec.ts
@@ -4,7 +4,7 @@ import { register as registry } from 'prom-client';
 import { createGatewayRuntime } from '@graphql-hive/gateway';
 import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
 import { createDefaultExecutor } from '@graphql-mesh/transport-common';
-import usePrometheus from '../src/index.js';
+import { usePrometheus } from '../src/index.js';
 
 describe('Prometheus', () => {
   const subgraphSchema = createSchema({


### PR DESCRIPTION
## Description

`usePrometheus` is not available to import from `@graphql-hive/gateway`:

```ts
import { 
  useJWT, 
  useOpenTelemetry,
  // usePrometheus // Not available!
} from '@graphql-hive/gateway';
import usePrometheus from '@graphql-mesh/plugin-prometheus';
```

With this PR, it will be possible to:

```ts
import { 
  useJWT, 
  useOpenTelemetry,
  usePrometheus,
} from '@graphql-hive/gateway';
```



## Type of change

- [x] New feature (non-breaking change which adds functionality)

