### PR TITLE
enhance(compose): avoid extra `@transport` annotation if unnecessary

### DIFF
--- a/.changeset/pink-eyes-search.md
+++ b/.changeset/pink-eyes-search.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/fusion-composition': patch
+---
+
+Do not create extra \`@transport\` annotation if the subgraph is a regular HTTP subgraph

--- a/e2e/auto-type-merging/__snapshots__/auto-type-merging.test.ts.snap
+++ b/e2e/auto-type-merging/__snapshots__/auto-type-merging.test.ts.snap
@@ -101,13 +101,12 @@ directive @httpOperation(
 ) repeatable on FIELD_DEFINITION
 
 directive @transport(
-  subgraph: String!
-  kind: String!
-  location: String!
+  subgraph: String
+  kind: String
+  location: String
   headers: [[String]]
   queryStringOptions: ObjMap
   queryParams: [[String]]
-  options: TransportOptions
 ) repeatable on SCHEMA
 
 directive @hidden on FIELD_DEFINITION | OBJECT | INTERFACE | INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_OBJECT
@@ -154,14 +153,12 @@ scalar File @join__type(graph: PETSTORE)
 
 scalar ObjMap @join__type(graph: PETSTORE) 
 
-scalar _DirectiveExtensions @join__type(graph: PETSTORE)  @join__type(graph: VACCINATION) 
+scalar _DirectiveExtensions @join__type(graph: PETSTORE) 
 
 scalar TransportOptions @join__type(graph: VACCINATION) 
 
 type Query @extraSchemaDefinitionDirective(
   directives: {transport: [{subgraph: "petstore", kind: "rest", location: "http://localhost:<petstore_port>/api/v3"}]}
-) @extraSchemaDefinitionDirective(
-  directives: {transport: [{kind: "http", subgraph: "vaccination", location: "http://localhost:<vaccination_port>/graphql", options: {}}]}
 ) @join__type(graph: PETSTORE)  @join__type(graph: VACCINATION)  {
   """
   Multiple status values can be provided with comma separated strings

--- a/e2e/federation-mixed/__snapshots__/federation-mixed.test.ts.snap
+++ b/e2e/federation-mixed/__snapshots__/federation-mixed.test.ts.snap
@@ -110,13 +110,12 @@ directive @httpOperation(
 ) repeatable on FIELD_DEFINITION
 
 directive @transport(
-  subgraph: String!
-  kind: String!
-  location: String!
+  subgraph: String
+  kind: String
+  location: String
   headers: [[String]]
   queryStringOptions: ObjMap
   queryParams: [[String]]
-  options: TransportOptions
 ) repeatable on SCHEMA
 
 directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
@@ -125,18 +124,12 @@ directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  rep
 
 scalar ObjMap @join__type(graph: ACCOUNTS) 
 
-scalar _DirectiveExtensions @join__type(graph: ACCOUNTS)  @join__type(graph: INVENTORY)  @join__type(graph: PRODUCTS)  @join__type(graph: REVIEWS) 
+scalar _DirectiveExtensions @join__type(graph: ACCOUNTS) 
 
 scalar TransportOptions @join__type(graph: INVENTORY)  @join__type(graph: PRODUCTS)  @join__type(graph: REVIEWS) 
 
 type Query @extraSchemaDefinitionDirective(
   directives: {transport: [{subgraph: "accounts", kind: "rest", location: "http://localhost:<accounts_port>"}]}
-) @extraSchemaDefinitionDirective(
-  directives: {transport: [{kind: "http", subgraph: "inventory", location: "http://localhost:<inventory_port>/graphql", options: {}}]}
-) @extraSchemaDefinitionDirective(
-  directives: {transport: [{kind: "http", subgraph: "products", location: "http://localhost:<products_port>/graphql", options: {}}]}
-) @extraSchemaDefinitionDirective(
-  directives: {transport: [{kind: "http", subgraph: "reviews", location: "http://localhost:<reviews_port>/graphql", options: {}}]}
 ) @join__type(graph: ACCOUNTS)  @join__type(graph: INVENTORY)  @join__type(graph: PRODUCTS)  @join__type(graph: REVIEWS)  {
   me: User @httpOperation(
     subgraph: "accounts"

--- a/e2e/hoist-and-prefix-transform/__snapshots__/hoist-and-prefix-transform.test.ts.snap
+++ b/e2e/hoist-and-prefix-transform/__snapshots__/hoist-and-prefix-transform.test.ts.snap
@@ -12,7 +12,7 @@ schema
   
   @link(
   url: "https://the-guild.dev/graphql/mesh/spec/v1.0"
-  import: ["@transport", "@hoist", "@source", "@extraSchemaDefinitionDirective"]
+  import: ["@hoist", "@source"]
 )
 {
   query: Query
@@ -84,29 +84,15 @@ enum join__Graph {
   WEATHER @join__graph(name: "weather", url: "http://localhost:<weather_port>/graphql") 
 }
 
-directive @transport(
-  kind: String!
-  subgraph: String!
-  location: String!
-  headers: [[String]]
-  options: Test_TransportOptions
-) repeatable on SCHEMA
-
 directive @hoist(subgraph: String, pathConfig: _HoistConfig)  repeatable on FIELD_DEFINITION
 
 directive @source(name: String!, type: String, subgraph: String!)  repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-
-directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
 scalar Test_TransportOptions @source(name: "TransportOptions", subgraph: "weather")  @join__type(graph: WEATHER) 
 
 scalar _HoistConfig @join__type(graph: WEATHER) 
 
-scalar _DirectiveExtensions @join__type(graph: WEATHER) 
-
-type Query @source(name: "Query", subgraph: "weather")  @extraSchemaDefinitionDirective(
-  directives: {transport: [{kind: "http", subgraph: "weather", location: "http://localhost:<weather_port>/graphql", options: {}}]}
-) @join__type(graph: WEATHER)  {
+type Query @source(name: "Query", subgraph: "weather")  @join__type(graph: WEATHER)  {
   here: Test_Weather @source(name: "here", type: "Weather", subgraph: "weather") 
 }
 

--- a/e2e/manual-transport-def/__snapshots__/manual-transport-def.test.ts.snap
+++ b/e2e/manual-transport-def/__snapshots__/manual-transport-def.test.ts.snap
@@ -99,27 +99,24 @@ directive @httpOperation(
 ) repeatable on FIELD_DEFINITION
 
 directive @transport(
-  subgraph: String!
-  kind: String!
-  location: String!
+  subgraph: String
+  kind: String
+  location: String
   headers: [[String]]
   queryStringOptions: ObjMap
   queryParams: [[String]]
-  options: TransportOptions
 ) repeatable on SCHEMA
 
 directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
 
 scalar ObjMap @join__type(graph: GREETINGS) 
 
-scalar _DirectiveExtensions @join__type(graph: GREETINGS)  @join__type(graph: HELLOER) 
+scalar _DirectiveExtensions @join__type(graph: GREETINGS) 
 
 scalar TransportOptions @join__type(graph: HELLOER) 
 
 type Query @extraSchemaDefinitionDirective(
   directives: {transport: [{subgraph: "greetings", kind: "rest", location: "http://localhost:<greetings_port>"}]}
-) @extraSchemaDefinitionDirective(
-  directives: {transport: [{kind: "http", subgraph: "helloer", location: "http://localhost:<helloer_port>/graphql", options: {}}]}
 ) @join__type(graph: GREETINGS)  @join__type(graph: HELLOER)  {
   greet(name: String!) : greet_200_response @httpOperation(
     subgraph: "greetings"

--- a/e2e/type-merging-batching/__snapshots__/type-merging-batching.test.ts.snap
+++ b/e2e/type-merging-batching/__snapshots__/type-merging-batching.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should compose the appropriate schema 1`] = `
-"schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@transport", "@merge", "@extraSchemaDefinitionDirective", "@source"]) {
+"schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@merge", "@source"]) {
   query: Query
 }
 
@@ -19,11 +19,7 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-directive @transport(kind: String!, subgraph: String!, location: String!, headers: [[String]], options: TransportOptions) repeatable on SCHEMA
-
 directive @merge(subgraph: String, argsExpr: String, keyArg: String, keyField: String, key: [String!], additionalArgs: String) repeatable on FIELD_DEFINITION
-
-directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions) repeatable on OBJECT
 
 directive @source(name: String!, type: String, subgraph: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
@@ -51,9 +47,7 @@ enum join__Graph {
 
 scalar TransportOptions @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
 
-scalar _DirectiveExtensions @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
-
-type Query @extraSchemaDefinitionDirective(directives: {transport: [{kind: "http", subgraph: "authors", location: "http://localhost:<authors_port>/graphql", options: {}}]}) @extraSchemaDefinitionDirective(directives: {transport: [{kind: "http", subgraph: "books", location: "http://localhost:<books_port>/graphql", options: {}}]}) @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+type Query @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
   author(id: ID!): Author @merge(subgraph: "authors", keyField: "id", keyArg: "id") @merge(subgraph: "books", keyField: "id", keyArg: "id") @source(name: "authorWithBooks", type: "AuthorWithBooks", subgraph: "books")
   authors(ids: [ID]): [Author] @merge(subgraph: "authors", keyField: "id", keyArg: "ids") @join__field(graph: AUTHORS)
   book(id: ID!): Book @merge(subgraph: "books", keyField: "id", keyArg: "id") @join__field(graph: BOOKS)

--- a/packages/compose-cli/src/getComposedSchemaFromConfig.ts
+++ b/packages/compose-cli/src/getComposedSchemaFromConfig.ts
@@ -91,6 +91,7 @@ export async function getComposedSchemaFromConfig(config: MeshComposeCLIConfig, 
   if (config.subgraph) {
     const annotatedSubgraphs = getAnnotatedSubgraphs(subgraphConfigsForComposition, {
       ignoreSemanticConventions: config.ignoreSemanticConventions,
+      alwaysAddTransportDirective: true,
     });
     const subgraph = annotatedSubgraphs.find(sg => sg.name === config.subgraph);
     if (!subgraph) {

--- a/packages/fusion/composition/src/compose.ts
+++ b/packages/fusion/composition/src/compose.ts
@@ -91,6 +91,7 @@ export function getAnnotatedSubgraphs(
     if (transportDirective) {
       url = transportDirective.location;
       if (
+        !options.alwaysAddTransportDirective &&
         transportDirective.kind === 'http' &&
         !transportDirective.headers &&
         isEmptyObject(transportDirective.options)
@@ -551,6 +552,8 @@ export interface GetAnnotatedSubgraphsOptions {
    * @default false
    */
   ignoreSemanticConventions?: boolean;
+
+  alwaysAddTransportDirective?: boolean;
 }
 
 export type ComposeSubgraphsOptions = GetAnnotatedSubgraphsOptions;

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -553,9 +553,6 @@
         "operationFieldPermissions": {
           "$ref": "#/definitions/OperationFieldPermissionsConfig"
         },
-        "prometheus": {
-          "$ref": "#/definitions/PrometheusConfig"
-        },
         "rateLimit": {
           "$ref": "#/definitions/RateLimitPluginConfig",
           "description": "RateLimit plugin"
@@ -569,6 +566,9 @@
         },
         "statsd": {
           "$ref": "#/definitions/StatsdPlugin"
+        },
+        "prometheus": {
+          "$ref": "#/definitions/PrometheusConfig"
         }
       }
     },
@@ -2587,191 +2587,6 @@
         }
       }
     },
-    "PrometheusConfig": {
-      "additionalProperties": false,
-      "type": "object",
-      "title": "PrometheusConfig",
-      "properties": {
-        "requestCount": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "requestTotalDuration": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "requestSummary": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "parse": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "validate": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "contextBuilding": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "execute": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "errors": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "deprecatedFields": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "skipIntrospection": {
-          "type": "boolean"
-        },
-        "registry": {
-          "type": "string"
-        },
-        "delegation": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "delegationArgs": {
-          "type": "boolean"
-        },
-        "delegationKey": {
-          "type": "boolean"
-        },
-        "subgraphExecute": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "fetchMetrics": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "fetchRequestHeaders": {
-          "type": "boolean"
-        },
-        "fetchResponseHeaders": {
-          "type": "boolean"
-        },
-        "http": {
-          "description": "Any of: Boolean, String",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "httpRequestHeaders": {
-          "type": "boolean"
-        },
-        "httpResponseHeaders": {
-          "type": "boolean"
-        },
-        "endpoint": {
-          "description": "The path to the metrics endpoint\ndefault: `/metrics` (Any of: Boolean, String)",
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        }
-      }
-    },
     "RateLimitPluginConfig": {
       "additionalProperties": false,
       "type": "object",
@@ -4306,6 +4121,191 @@
         "infile": {
           "type": "string",
           "description": "Path to the SQL Dump file if you want to build a in-memory database"
+        }
+      }
+    },
+    "PrometheusConfig": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "PrometheusConfig",
+      "properties": {
+        "requestCount": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "requestTotalDuration": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "requestSummary": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "parse": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "validate": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "contextBuilding": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "execute": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "errors": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "deprecatedFields": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "skipIntrospection": {
+          "type": "boolean"
+        },
+        "registry": {
+          "type": "string"
+        },
+        "delegation": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "delegationArgs": {
+          "type": "boolean"
+        },
+        "delegationKey": {
+          "type": "boolean"
+        },
+        "subgraphExecute": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "fetchMetrics": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "fetchRequestHeaders": {
+          "type": "boolean"
+        },
+        "fetchResponseHeaders": {
+          "type": "boolean"
+        },
+        "http": {
+          "description": "Any of: Boolean, String",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "httpRequestHeaders": {
+          "type": "boolean"
+        },
+        "httpResponseHeaders": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "The path to the metrics endpoint\ndefault: `/metrics` (Any of: Boolean, String)",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
         }
       }
     }

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -1858,11 +1858,11 @@ export interface Plugin {
   mock?: MockingConfig;
   newrelic?: NewrelicConfig;
   operationFieldPermissions?: OperationFieldPermissionsConfig;
-  prometheus?: PrometheusConfig;
   rateLimit?: RateLimitPluginConfig;
   responseCache?: ResponseCacheConfig;
   snapshot?: SnapshotPluginConfig;
   statsd?: StatsdPlugin;
+  prometheus?: PrometheusConfig;
   [k: string]: any;
 }
 export interface MaskedErrorsPluginConfig {
@@ -2210,73 +2210,6 @@ export interface OperationFieldPermission {
   if?: string;
   allow?: string[];
 }
-export interface PrometheusConfig {
-  /**
-   * Any of: Boolean, String
-   */
-  requestCount?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  requestTotalDuration?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  requestSummary?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  parse?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  validate?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  contextBuilding?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  execute?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  errors?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  deprecatedFields?: boolean | string;
-  skipIntrospection?: boolean;
-  registry?: string;
-  /**
-   * Any of: Boolean, String
-   */
-  delegation?: boolean | string;
-  delegationArgs?: boolean;
-  delegationKey?: boolean;
-  /**
-   * Any of: Boolean, String
-   */
-  subgraphExecute?: boolean | string;
-  /**
-   * Any of: Boolean, String
-   */
-  fetchMetrics?: boolean | string;
-  fetchRequestHeaders?: boolean;
-  fetchResponseHeaders?: boolean;
-  /**
-   * Any of: Boolean, String
-   */
-  http?: boolean | string;
-  httpRequestHeaders?: boolean;
-  httpResponseHeaders?: boolean;
-  /**
-   * The path to the metrics endpoint
-   * default: `/metrics` (Any of: Boolean, String)
-   */
-  endpoint?: boolean | string;
-}
 /**
  * RateLimit plugin
  */
@@ -2429,4 +2362,71 @@ export interface StatsdClientConfiguration {
 }
 export interface StatsdClientBufferHolder {
   buffer: string;
+}
+export interface PrometheusConfig {
+  /**
+   * Any of: Boolean, String
+   */
+  requestCount?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  requestTotalDuration?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  requestSummary?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  parse?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  validate?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  contextBuilding?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  execute?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  errors?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  deprecatedFields?: boolean | string;
+  skipIntrospection?: boolean;
+  registry?: string;
+  /**
+   * Any of: Boolean, String
+   */
+  delegation?: boolean | string;
+  delegationArgs?: boolean;
+  delegationKey?: boolean;
+  /**
+   * Any of: Boolean, String
+   */
+  subgraphExecute?: boolean | string;
+  /**
+   * Any of: Boolean, String
+   */
+  fetchMetrics?: boolean | string;
+  fetchRequestHeaders?: boolean;
+  fetchResponseHeaders?: boolean;
+  /**
+   * Any of: Boolean, String
+   */
+  http?: boolean | string;
+  httpRequestHeaders?: boolean;
+  httpResponseHeaders?: boolean;
+  /**
+   * The path to the metrics endpoint
+   * default: `/metrics` (Any of: Boolean, String)
+   */
+  endpoint?: boolean | string;
 }


### PR DESCRIPTION
Do not create extra \`@transport\` annotation if the subgraph is a regular HTTP subgraph