### PR TITLE
DefaultLogger respects the LogLevel.debug and simplify stderr usage

### DIFF
--- a/.changeset/orange-buttons-end.md
+++ b/.changeset/orange-buttons-end.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+DefaultLogger respects the LogLevel.debug

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -99,8 +99,8 @@ export class DefaultLogger implements Logger {
     return (
       this.logLevel <= LogLevel.debug ||
       truthy(process.env.DEBUG) ||
-      truthy((globalThis as any).DEBUG) ||
-      this.name.includes(process.env.DEBUG || (globalThis as any).DEBUG)
+      truthy(globalThis['DEBUG']) ||
+      this.name?.includes(process.env.DEBUG || globalThis['DEBUG'])
     );
   }
 

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -99,8 +99,8 @@ export class DefaultLogger implements Logger {
     return (
       this.logLevel <= LogLevel.debug ||
       truthy(process.env.DEBUG) ||
-      truthy(globalThis['DEBUG']) ||
-      this.name?.includes(process.env.DEBUG || globalThis['DEBUG'])
+      truthy(globalThis.DEBUG) ||
+      this.name?.includes(process.env.DEBUG || globalThis.DEBUG)
     );
   }
 

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions -- simply more convenient to do `this.stderr(m) || console.log(m)` */
 import { process, util } from '@graphql-mesh/cross-helpers';
 import type { LazyLoggerMessage, Logger } from '@graphql-mesh/types';
 


### PR DESCRIPTION
Previously the `isDebug` getter method exclusively checked the env vars; meaning, if LogLevel.debug is supplied without DEBUG=1 in the env, no debug logs will be written. This PR makes sure the `isDebug` method also respects the LogLevel.

Bonus points: simplify stderr usage.