### PR TITLE
hotfix: specify the --font-sans in a .css file

### DIFF
--- a/website/src/hotfix.css
+++ b/website/src/hotfix.css
@@ -1,0 +1,3 @@
+:root {
+  --font-sans: ui-sans-serif;
+}

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react';
 import { AppProps } from 'next/app';
 import '@theguild/components/style.css';
+import '../hotfix.css';
 
 export default function App({ Component, pageProps }: AppProps): ReactElement {
   return <Component {...pageProps} />;


### PR DESCRIPTION
`--font-sans` isn't resolved, and the entire `font-family` property is skipped because of it.
this fixes the serif font we see in the docs
there's already another fix upstream in Components, but it wasn't merged yet if I remember correctly