### PR TITLE
Fix Hive Transform and additional resolvers import issues

### DIFF
--- a/.changeset/@graphql-mesh_include-8007-dependencies.md
+++ b/.changeset/@graphql-mesh_include-8007-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/include": patch
+---
+dependencies updates:
+  - Added dependency [`@graphql-mesh/utils@^0.103.4` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.103.4) (to `dependencies`)

--- a/.changeset/cuddly-spies-argue.md
+++ b/.changeset/cuddly-spies-argue.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-hive': patch
+---
+
+Do not break the request even if the operation is not able to process

--- a/.changeset/fresh-insects-give.md
+++ b/.changeset/fresh-insects-give.md
@@ -1,0 +1,8 @@
+---
+'@omnigraph/json-schema': patch
+'@omnigraph/openapi': patch
+'@omnigraph/raml': patch
+---
+
+DEBUG logs were accidentially written to the output, now it correctly prints logs to the logger not
+the output

--- a/.changeset/silver-days-sort.md
+++ b/.changeset/silver-days-sort.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/cli': patch
+'@graphql-mesh/include': patch
+---
+
+Improvements on imports

--- a/.changeset/thick-goats-type.md
+++ b/.changeset/thick-goats-type.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+Always pass a valid info

--- a/packages/fusion/composition/tests/loaders.spec.ts
+++ b/packages/fusion/composition/tests/loaders.spec.ts
@@ -1,9 +1,18 @@
 import { OperationTypeNode } from 'graphql';
 import { createGatewayRuntime, useCustomFetch } from '@graphql-hive/gateway-runtime';
+import type { Logger } from '@graphql-mesh/types';
 import { loadJSONSchemaSubgraph } from '@omnigraph/json-schema';
 import { composeSubgraphs } from '../src/compose';
 
 describe('Loaders', () => {
+  const logger: Logger = {
+    log: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: () => logger,
+  };
   it('works', async () => {
     const loadedSubgraph = loadJSONSchemaSubgraph('TEST', {
       endpoint: 'http://localhost/my-test-api',
@@ -24,6 +33,7 @@ describe('Loaders', () => {
     })({
       fetch,
       cwd: process.cwd(),
+      logger,
     });
     const { supergraphSdl } = composeSubgraphs([
       {

--- a/packages/include/package.json
+++ b/packages/include/package.json
@@ -46,6 +46,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "dependencies": {
+    "@graphql-mesh/utils": "^0.103.4",
     "dotenv": "^16.3.1",
     "get-tsconfig": "^4.7.6",
     "jiti": "^2.0.0",

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -25,11 +25,11 @@ const jiti = createJiti(
  *
  * If the module at {@link path} is not found, `null` will be returned.
  */
-export function include<T = any>(path: string): Promise<T> {
+export async function include<T = any>(path: string): Promise<T> {
   try {
     // JITI's tryNative tries native at first but with \`import\`
     // So in CJS, this becomes \`require\`, but it still satisfies JITI's native import
-    return defaultImportFn(path).then(mod => mod.default ?? mod);
+    return await defaultImportFn(path).then(mod => mod.default ?? mod);
   } catch {
     return jiti.import(path, {
       default: true,

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -29,7 +29,7 @@ export async function include<T = any>(path: string): Promise<T> {
   try {
     // JITI's tryNative tries native at first but with \`import\`
     // So in CJS, this becomes \`require\`, but it still satisfies JITI's native import
-    return await defaultImportFn(path).then(mod => mod.default ?? mod);
+    return await defaultImportFn(path);
   } catch {
     return jiti.import(path, {
       default: true,

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -13,7 +13,6 @@ const jiti = createJiti(
    */
   typeof __filename === 'undefined' ? '' : __filename,
   {
-    tryNative: true,
     debug: !!process.env.DEBUG,
   },
 );
@@ -31,9 +30,13 @@ export async function include<T = any>(path: string): Promise<T> {
     // So in CJS, this becomes \`require\`, but it still satisfies JITI's native import
     return await defaultImportFn(path);
   } catch {
-    return jiti.import(path, {
+    const mod = await jiti.import<T>(path, {
       default: true,
     });
+    if (!mod) {
+      throw new Error(`Module at path "${path}" not found`);
+    }
+    return mod;
   }
 }
 

--- a/packages/include/src/index.ts
+++ b/packages/include/src/index.ts
@@ -11,7 +11,7 @@ const jiti = createJiti(
    * This is because `import.meta.url` is not available in CJS (and cant even be in the syntax)
    * and `__filename` is not available in ESM.
    */
-  typeof __filename === 'undefined' ? '' : __filename,
+  '',
   {
     debug: !!process.env.DEBUG,
   },

--- a/packages/legacy/cli/src/index.ts
+++ b/packages/legacy/cli/src/index.ts
@@ -124,6 +124,7 @@ export async function graphqlMesh(
             configName: cliParams.configName,
             additionalPackagePrefixes: cliParams.additionalPackagePrefixes,
             initialLoggerPrefix: cliParams.initialLoggerPrefix,
+            importFn: include,
           });
           logger = meshConfig.logger;
 

--- a/packages/legacy/transforms/hive/src/index.ts
+++ b/packages/legacy/transforms/hive/src/index.ts
@@ -1,4 +1,4 @@
-import { isSchema, type ExecutionResult, type GraphQLSchema } from 'graphql';
+import { isSchema, Kind, visit, type ExecutionResult, type GraphQLSchema } from 'graphql';
 import type { HiveClient, HivePluginOptions } from '@graphql-hive/core';
 import { createHive } from '@graphql-hive/yoga';
 import { process } from '@graphql-mesh/cross-helpers';
@@ -130,7 +130,16 @@ export default class HiveTransform implements MeshTransform {
             schema: isSchema(delegationContext.subschema)
               ? delegationContext.subschema
               : delegationContext.subschema.schema,
-            document: transformationContext.request.document,
+            document: visit(transformationContext.request.document, {
+              [Kind.FIELD](node) {
+                if (!node.arguments) {
+                  return {
+                    ...node,
+                    arguments: [],
+                  };
+                }
+              },
+            }),
             rootValue: transformationContext.request.rootValue,
             contextValue: transformationContext.request.context,
             variableValues: transformationContext.request.variables,

--- a/packages/legacy/transforms/hive/src/index.ts
+++ b/packages/legacy/transforms/hive/src/index.ts
@@ -15,6 +15,7 @@ interface TransformationContext {
 export default class HiveTransform implements MeshTransform {
   private hiveClient: HiveClient;
   private logger: MeshTransformOptions<YamlConfig.HivePlugin>['logger'];
+  private schema: GraphQLSchema;
   constructor({ config, pubsub, logger }: MeshTransformOptions<YamlConfig.HivePlugin>) {
     this.logger = logger;
     const enabled =
@@ -100,6 +101,7 @@ export default class HiveTransform implements MeshTransform {
 
   transformSchema(schema: GraphQLSchema) {
     this.hiveClient.reportSchema({ schema });
+    this.schema = schema;
     return schema;
   }
 
@@ -127,9 +129,7 @@ export default class HiveTransform implements MeshTransform {
       transformationContext
         .collectUsageCallback?.(
           {
-            schema: isSchema(delegationContext.subschema)
-              ? delegationContext.subschema
-              : delegationContext.subschema.schema,
+            schema: this.schema,
             document: visit(transformationContext.request.document, {
               [Kind.FIELD](node) {
                 if (!node.arguments) {

--- a/packages/legacy/transforms/hive/src/index.ts
+++ b/packages/legacy/transforms/hive/src/index.ts
@@ -76,7 +76,7 @@ export default class HiveTransform implements MeshTransform {
       agent,
       usage,
       reporting,
-      autoDispose: ['SIGINT', 'SIGTERM'],
+      autoDispose: false,
       selfHosting: config.selfHosting,
     });
     const id = pubsub.subscribe('destroy', () => {

--- a/packages/loaders/json-schema/src/index.ts
+++ b/packages/loaders/json-schema/src/index.ts
@@ -1,6 +1,6 @@
 import type { TransportGetSubgraphExecutor } from '@graphql-mesh/transport-common';
 import transportRest, { type RESTTransportOptions } from '@graphql-mesh/transport-rest';
-import type { MeshFetch } from '@graphql-mesh/types';
+import type { Logger, MeshFetch } from '@graphql-mesh/types';
 import {
   loadGraphQLSchemaFromJSONSchemas,
   loadNonExecutableGraphQLSchemaFromJSONSchemas,
@@ -15,12 +15,13 @@ export * from './getGraphQLSchemaFromDereferencedJSONSchema.js';
 export type * from './types.js';
 
 export function loadJSONSchemaSubgraph(name: string, options: JSONSchemaLoaderOptions) {
-  return (ctx: { fetch: MeshFetch; cwd: string }) => ({
+  return (ctx: { fetch: MeshFetch; cwd: string; logger: Logger }) => ({
     name,
     schema$: loadNonExecutableGraphQLSchemaFromJSONSchemas(name, {
       ...options,
       fetch: ctx.fetch,
       cwd: ctx.cwd,
+      logger: ctx.logger,
     }),
   });
 }

--- a/packages/loaders/openapi/src/index.ts
+++ b/packages/loaders/openapi/src/index.ts
@@ -1,4 +1,4 @@
-import type { MeshFetch } from '@graphql-mesh/types';
+import type { Logger, MeshFetch } from '@graphql-mesh/types';
 import { loadNonExecutableGraphQLSchemaFromOpenAPI } from './loadGraphQLSchemaFromOpenAPI.js';
 import type { OpenAPILoaderOptions } from './types.js';
 
@@ -8,12 +8,13 @@ export { getJSONSchemaOptionsFromOpenAPIOptions } from './getJSONSchemaOptionsFr
 export type { OpenAPILoaderOptions } from './types.js';
 
 export function loadOpenAPISubgraph(name: string, options: OpenAPILoaderOptions) {
-  return (ctx: { fetch: MeshFetch; cwd: string }) => ({
+  return (ctx: { fetch: MeshFetch; cwd: string; logger: Logger }) => ({
     name,
     schema$: loadNonExecutableGraphQLSchemaFromOpenAPI(name, {
       ...options,
       fetch: ctx.fetch,
       cwd: ctx.cwd,
+      logger: ctx.logger,
     }),
   });
 }

--- a/packages/loaders/raml/src/index.ts
+++ b/packages/loaders/raml/src/index.ts
@@ -1,4 +1,4 @@
-import type { MeshFetch } from '@graphql-mesh/types';
+import type { Logger, MeshFetch } from '@graphql-mesh/types';
 import { loadGraphQLSchemaFromRAML } from './loadGraphQLSchemaFromRAML.js';
 import type { RAMLLoaderOptions } from './types.js';
 
@@ -8,12 +8,13 @@ export { getJSONSchemaOptionsFromRAMLOptions } from './getJSONSchemaOptionsFromR
 export type { RAMLLoaderOptions } from './types.js';
 
 export function loadRAMLSubgraph(name: string, options: RAMLLoaderOptions) {
-  return (ctx: { fetch: MeshFetch; cwd: string }) => ({
+  return (ctx: { fetch: MeshFetch; cwd: string; logger: Logger }) => ({
     name,
     schema$: loadGraphQLSchemaFromRAML(name, {
       ...options,
       fetch: ctx.fetch,
       cwd: ctx.cwd,
+      logger: ctx.logger,
     }),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6199,6 +6199,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-mesh/include@workspace:packages/include"
   dependencies:
+    "@graphql-mesh/utils": "npm:^0.103.4"
     dotenv: "npm:^16.3.1"
     get-tsconfig: "npm:^4.7.6"
     glob: "npm:^11.0.0"


### PR DESCRIPTION
- Do not break the request even if the operation is not able to process
- Do not fail on process termination even if the disposal fails
- Remove the need of mod.default || mod workaround
- Fix import issue of additionalResolvers in mesh dev - Fixes https://github.com/ardatan/graphql-mesh/issues/7963
- Fix passed upstream operation in Hive transform