### PR TITLE
Add theme.config.tsx to tailwind content

### DIFF
--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -1,1 +1,6 @@
-export { default } from '@theguild/tailwind-config';
+import guildConfig from '@theguild/tailwind-config';
+
+export default {
+  ...guildConfig,
+  content: [...guildConfig.content, 'theme.config.tsx'],
+};


### PR DESCRIPTION
## Description

<img width="987" alt="image" src="https://github.com/user-attachments/assets/8224d5e1-29cb-4134-8cb3-34e1c8e1311d" />

Tailwind wasn't picking up `w-8`. Now it picks it up again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
