### PR TITLE
fix(http-cache): compatibility with `@graphql-hive/gateway`

### DIFF
--- a/.changeset/loud-lemons-press.md
+++ b/.changeset/loud-lemons-press.md
@@ -9,13 +9,11 @@ but the old type of the plugin options was `MeshPluginOptions` which expects `ca
 
 ```ts
 import { defineConfig, useHttpCache } from '@graphql-hive/gateway';
-import useHTTPCache from '@graphql-mesh/plugin-http-cache';
 
 export const gatewayConfig = defineConfig({
   plugins: ctx => [
-    useHTTPCache({
+    useHttpCache({
       ...ctx, // This was failing
-
     })
   ]
 })

--- a/.changeset/loud-lemons-press.md
+++ b/.changeset/loud-lemons-press.md
@@ -1,0 +1,23 @@
+---
+'@graphql-mesh/plugin-http-cache': patch
+---
+
+Relax the typings so the plugin can be used as `GatewayPlugin`.
+
+The pointed line was previously failing because `ctx` is `GatewayConfigContext` which has `config` etc as optional,
+but the old type of the plugin options was `MeshPluginOptions` which expects `cache`, `pubsub` etc and more things that are not available in `GatewayConfigContext`.
+
+```ts
+import { defineConfig, useHttpCache } from '@graphql-hive/gateway';
+import useHTTPCache from '@graphql-mesh/plugin-http-cache';
+
+export const gatewayConfig = defineConfig({
+  plugins: ctx => [
+    useHTTPCache({
+      ...ctx, // This was failing
+
+    })
+  ]
+})
+
+```

--- a/packages/plugins/http-cache/src/index.ts
+++ b/packages/plugins/http-cache/src/index.ts
@@ -1,5 +1,5 @@
 import CachePolicy from 'http-cache-semantics';
-import type { MeshPlugin, MeshPluginOptions, YamlConfig } from '@graphql-mesh/types';
+import type { KeyValueCache, MeshPlugin, MeshPluginOptions, YamlConfig } from '@graphql-mesh/types';
 import { getHeadersObj } from '@graphql-mesh/utils';
 import { Response, URLPattern } from '@whatwg-node/fetch';
 
@@ -12,11 +12,18 @@ interface CacheEntry {
   body: string;
 }
 
-export default function useHTTPCache({
+export interface HTTPCachePluginOptions extends YamlConfig.HTTPCachePlugin {
+  cache?: KeyValueCache;
+}
+
+export default function useHTTPCache<TContext>({
   cache,
   matches,
   ignores,
-}: MeshPluginOptions<YamlConfig.HTTPCachePlugin>): MeshPlugin<{}> {
+}: HTTPCachePluginOptions): MeshPlugin<TContext> {
+  if (!cache) {
+    throw new Error('HTTP Cache plugin requires a cache instance');
+  }
   let matchesPatterns: URLPattern[] | undefined;
   if (matches) {
     matchesPatterns = matches.map(match => new URLPattern(match));

--- a/packages/plugins/http-cache/tests/test-gateway-config.ts
+++ b/packages/plugins/http-cache/tests/test-gateway-config.ts
@@ -1,0 +1,10 @@
+import { defineConfig, useHttpCache } from '@graphql-hive/gateway';
+import useHTTPCache from '@graphql-mesh/plugin-http-cache';
+
+export const gatewayConfig = defineConfig({
+  plugins: ctx => [
+    useHTTPCache({
+      ...ctx,
+    }),
+  ],
+});

--- a/packages/plugins/http-cache/tests/test-gateway-config.ts
+++ b/packages/plugins/http-cache/tests/test-gateway-config.ts
@@ -1,9 +1,8 @@
 import { defineConfig, useHttpCache } from '@graphql-hive/gateway';
-import useHTTPCache from '@graphql-mesh/plugin-http-cache';
 
 export const gatewayConfig = defineConfig({
   plugins: ctx => [
-    useHTTPCache({
+    useHttpCache({
       ...ctx,
     }),
   ],


### PR DESCRIPTION
Relax the typings so the plugin can be used as `GatewayPlugin`.

The pointed line was previously failing because `ctx` is `GatewayConfigContext` which has `config` etc as optional,
but the old type of the plugin options was `MeshPluginOptions` which expects `cache`, `pubsub` etc and more things that are not available in `GatewayConfigContext`.

```ts
import { defineConfig, useHttpCache } from '@graphql-hive/gateway';

export const gatewayConfig = defineConfig({
  plugins: ctx => [
    useHttpCache({
      ...ctx, // This was failing
    })
  ]
})

```