### PR TITLE
fix: apply schema transforms from inContextSDK

### DIFF
--- a/.changeset/wet-timers-decide.md
+++ b/.changeset/wet-timers-decide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+Fix to invoke `applySchemaTransforms` when creating `inContextSDK`

--- a/e2e/type-merging-with-transforms/__snapshots__/type-merging-with-transforms.test.ts.snap
+++ b/e2e/type-merging-with-transforms/__snapshots__/type-merging-with-transforms.test.ts.snap
@@ -1,0 +1,186 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should compose the appropriate schema 1`] = `
+"schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://the-guild.dev/graphql/mesh/spec/v1.0", import: ["@merge", "@source"]) {
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @merge(subgraph: String, argsExpr: String, keyArg: String, keyField: String, key: [String!], additionalArgs: String) repeatable on FIELD_DEFINITION
+
+directive @source(name: String!, type: String, subgraph: String!) repeatable on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @additionalField on FIELD_DEFINITION
+
+scalar join__FieldSet
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+enum join__Graph {
+  AUTHORS @join__graph(name: "authors", url: "http://localhost:<authors_port>/graphql")
+  BOOKS @join__graph(name: "books", url: "http://localhost:<books_port>/graphql")
+}
+
+scalar TransportOptions @join__type(graph: AUTHORS) @join__type(graph: BOOKS)
+
+type Query @join__type(graph: AUTHORS) @join__type(graph: BOOKS) {
+  author(id: ID!): Author @merge(subgraph: "authors", keyField: "id", keyArg: "id") @merge(subgraph: "books", keyField: "id", keyArg: "id") @source(name: "authorWithBooks", type: "AuthorWithBooks", subgraph: "books")
+  writers(ids: [ID]): [Author] @source(name: "authors", type: "[Author]", subgraph: "authors") @join__field(graph: AUTHORS)
+  book(id: ID!): Book @merge(subgraph: "books", keyField: "id", keyArg: "id") @join__field(graph: BOOKS)
+  books(ids: [ID]): [Book!]! @merge(subgraph: "books", keyField: "id", keyArg: "ids") @join__field(graph: BOOKS)
+}
+
+type Author @source(name: "AuthorWithBooks", subgraph: "books") @join__type(graph: AUTHORS, key: "id") @join__type(graph: BOOKS, key: "id") {
+  id: ID!
+  name: String! @join__field(graph: AUTHORS)
+  books: [Book!]! @join__field(graph: BOOKS)
+}
+
+type Book @join__type(graph: BOOKS, key: "id") {
+  id: ID!
+  title: String!
+  authorId: ID!
+  author: Author @resolveTo(sourceName: "authors", sourceTypeName: "Query", sourceFieldName: "writers", keyField: "authorId", keysArg: "ids") @additionalField
+}
+"
+`;
+
+exports[`should execute Author 1`] = `
+{
+  "data": {
+    "author": {
+      "books": [
+        {
+          "author": {
+            "id": "1",
+            "name": "Jane Doe",
+          },
+          "id": "0",
+          "title": "Lorem Ipsum",
+        },
+      ],
+      "id": "1",
+      "name": "Jane Doe",
+    },
+  },
+}
+`;
+
+exports[`should execute Authors 1`] = `
+{
+  "data": {
+    "writers": [
+      {
+        "books": [
+          {
+            "author": {
+              "id": "0",
+              "name": "John Doe",
+            },
+            "id": "1",
+            "title": "Dolor Sit Amet",
+          },
+        ],
+        "id": "0",
+        "name": "John Doe",
+      },
+      {
+        "books": [
+          {
+            "author": {
+              "id": "1",
+              "name": "Jane Doe",
+            },
+            "id": "0",
+            "title": "Lorem Ipsum",
+          },
+        ],
+        "id": "1",
+        "name": "Jane Doe",
+      },
+    ],
+  },
+}
+`;
+
+exports[`should execute Book 1`] = `
+{
+  "data": {
+    "book": {
+      "author": {
+        "books": [
+          {
+            "id": "1",
+            "title": "Dolor Sit Amet",
+          },
+        ],
+        "id": "0",
+        "name": "John Doe",
+      },
+      "id": "1",
+      "title": "Dolor Sit Amet",
+    },
+  },
+}
+`;
+
+exports[`should execute Books 1`] = `
+{
+  "data": {
+    "books": [
+      {
+        "author": {
+          "books": [
+            {
+              "id": "0",
+              "title": "Lorem Ipsum",
+            },
+          ],
+          "id": "1",
+          "name": "Jane Doe",
+        },
+        "id": "0",
+        "title": "Lorem Ipsum",
+      },
+      {
+        "author": {
+          "books": [
+            {
+              "id": "1",
+              "title": "Dolor Sit Amet",
+            },
+          ],
+          "id": "0",
+          "name": "John Doe",
+        },
+        "id": "1",
+        "title": "Dolor Sit Amet",
+      },
+    ],
+  },
+}
+`;

--- a/e2e/type-merging-with-transforms/mesh.config.ts
+++ b/e2e/type-merging-with-transforms/mesh.config.ts
@@ -1,0 +1,49 @@
+import { Opts } from '@e2e/opts';
+import {
+  createRenameFieldTransform,
+  createRenameTypeTransform,
+  defineConfig,
+  loadGraphQLHTTPSubgraph,
+} from '@graphql-mesh/compose-cli';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('authors', {
+        endpoint: `http://localhost:${opts.getServicePort('authors')}/graphql`,
+      }),
+      transforms: [
+        createRenameFieldTransform(({ fieldName, typeName }) =>
+          typeName === 'Query' && fieldName === 'authors' ? 'writers' : fieldName,
+        ),
+      ],
+    },
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('books', {
+        endpoint: `http://localhost:${opts.getServicePort('books')}/graphql`,
+      }),
+      transforms: [
+        createRenameFieldTransform(({ fieldName, typeName }) =>
+          typeName === 'Query' && fieldName === 'authorWithBooks' ? 'author' : fieldName,
+        ),
+        createRenameTypeTransform(({ typeName }) =>
+          typeName === 'AuthorWithBooks' ? 'Author' : typeName,
+        ),
+      ],
+    },
+  ],
+  additionalTypeDefs: /* GraphQL */ `
+    extend type Book {
+      author: Author
+        @resolveTo(
+          sourceName: "authors"
+          sourceTypeName: "Query"
+          sourceFieldName: "writers"
+          keyField: "authorId"
+          keysArg: "ids"
+        )
+    }
+  `,
+});

--- a/e2e/type-merging-with-transforms/package.json
+++ b/e2e/type-merging-with-transforms/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/type-merging-with-transforms",
+  "private": true,
+  "dependencies": {
+    "@graphql-hive/gateway": "^1.5.8",
+    "graphql": "^16.9.0",
+    "graphql-yoga": "^5.7.0"
+  }
+}

--- a/e2e/type-merging-with-transforms/services/authors.ts
+++ b/e2e/type-merging-with-transforms/services/authors.ts
@@ -1,0 +1,43 @@
+import { createServer } from 'http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const authors = [
+  {
+    id: '0',
+    name: 'John Doe',
+  },
+  {
+    id: '1',
+    name: 'Jane Doe',
+  },
+];
+
+const yoga = createYoga({
+  schema: createSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        author(id: ID!): Author
+        authors(ids: [ID]): [Author]
+      }
+
+      type Author {
+        id: ID!
+        name: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        author: (_, { id }) => authors.find(author => author.id === id),
+        authors: (_, { ids }) =>
+          ids ? ids.map((id: string) => authors.find(author => author.id === id)) : authors,
+      },
+    },
+  }),
+});
+
+const port = Opts(process.argv).getServicePort('authors', true);
+
+createServer(yoga).listen(port, () => {
+  console.log(`Authors service listening on http://localhost:${port}`);
+});

--- a/e2e/type-merging-with-transforms/services/books.ts
+++ b/e2e/type-merging-with-transforms/services/books.ts
@@ -1,0 +1,56 @@
+import { createServer } from 'http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const books = [
+  {
+    id: '0',
+    title: 'Lorem Ipsum',
+    authorId: '1',
+  },
+  {
+    id: '1',
+    title: 'Dolor Sit Amet',
+    authorId: '0',
+  },
+];
+
+const yoga = createYoga({
+  schema: createSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        authorWithBooks(id: ID!): AuthorWithBooks
+        book(id: ID!): Book
+        books(ids: [ID]): [Book!]!
+      }
+
+      type AuthorWithBooks {
+        id: ID!
+        books: [Book!]!
+      }
+
+      type Book {
+        id: ID!
+        title: String!
+        authorId: ID!
+      }
+    `,
+    resolvers: {
+      Query: {
+        authorWithBooks: (_, { id }) => ({ id }),
+        book: (_, { id }) => books.find(book => book.id === id),
+        books: (_, { ids }) =>
+          ids ? ids.map((id: string) => books.find(book => book.id === id)) : books,
+      },
+      AuthorWithBooks: {
+        books: ({ id }) => books.filter(book => book.authorId === id),
+      },
+    },
+  }),
+});
+
+const port = Opts(process.argv).getServicePort('books', true);
+
+createServer(yoga).listen(port, () => {
+  console.log(`Books service listening on http://localhost:${port}`);
+});

--- a/e2e/type-merging-with-transforms/type-merging-with-transforms.test.ts
+++ b/e2e/type-merging-with-transforms/type-merging-with-transforms.test.ts
@@ -1,0 +1,100 @@
+import { createTenv } from '@e2e/tenv';
+
+const { compose, service, serve } = createTenv(__dirname);
+
+it('should compose the appropriate schema', async () => {
+  const { result } = await compose({
+    services: [await service('authors'), await service('books')],
+    maskServicePorts: true,
+  });
+  expect(result).toMatchSnapshot();
+});
+
+const queries = [
+  {
+    name: 'Author',
+    query: /* GraphQL */ `
+      query Author {
+        author(id: 1) {
+          id
+          name
+          books {
+            id
+            title
+            author {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    name: 'Authors',
+    query: /* GraphQL */ `
+      query Authors {
+        writers {
+          id
+          name
+          books {
+            id
+            title
+            author {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    name: 'Book',
+    query: /* GraphQL */ `
+      query Book {
+        book(id: 1) {
+          id
+          title
+          author {
+            id
+            name
+            books {
+              id
+              title
+            }
+          }
+        }
+      }
+    `,
+  },
+  {
+    name: 'Books',
+    query: /* GraphQL */ `
+      query Books {
+        books {
+          id
+          title
+          author {
+            id
+            name
+            books {
+              id
+              title
+            }
+          }
+        }
+      }
+    `,
+  },
+];
+
+it.concurrent.each(queries)('should execute $name', async ({ query }) => {
+  const { output } = await compose({
+    services: [await service('authors'), await service('books')],
+    output: 'graphql',
+  });
+
+  const { execute } = await serve({ supergraph: output });
+  await expect(execute({ query })).resolves.toMatchSnapshot();
+});

--- a/packages/legacy/utils/src/in-context-sdk.ts
+++ b/packages/legacy/utils/src/in-context-sdk.ts
@@ -27,7 +27,7 @@ import type {
   StitchingInfo,
   SubschemaConfig,
 } from '@graphql-tools/delegate';
-import { delegateToSchema } from '@graphql-tools/delegate';
+import { applySchemaTransforms, delegateToSchema } from '@graphql-tools/delegate';
 import {
   buildOperationNodeForField,
   isDocumentNode,
@@ -67,7 +67,8 @@ export function getInContextSDK(
       }
     }
     // If there is a single source, there is no unifiedSchema
-    const transformedSchema = sourceMap?.get(rawSource) || rawSource.schema;
+    const transformedSchema =
+      sourceMap?.get(rawSource) || applySchemaTransforms(rawSource.schema, rawSource);
     const rootTypes: Record<OperationTypeNode, GraphQLObjectType> = {
       query: transformedSchema.getQueryType(),
       mutation: transformedSchema.getMutationType(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3930,6 +3930,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/type-merging-with-transforms@workspace:e2e/type-merging-with-transforms":
+  version: 0.0.0-use.local
+  resolution: "@e2e/type-merging-with-transforms@workspace:e2e/type-merging-with-transforms"
+  dependencies:
+    "@graphql-hive/gateway": "npm:^1.5.8"
+    graphql: "npm:^16.9.0"
+    graphql-yoga: "npm:^5.7.0"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/utils@workspace:e2e/utils":
   version: 0.0.0-use.local
   resolution: "@e2e/utils@workspace:e2e/utils"


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

The error `context[additionalResolver.sourceName][additionalResolver.sourceTypeName][additionalResolver.sourceFieldName] is not a function` occurs when field names are transformed using transforms. This mismatch prevents proper resolution of the schema field types.

To address this issue, the `applySchemaTransforms` function is now invoked when creating inContextSDK. This ensures that the transformed schema field types are correctly applied, resolving the error and enabling seamless functionality.

Fixes #7742

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

- Verified that the error is no longer triggered when using transformed schema fields.
- Confirmed that all other functionalities remain unaffected by this change.

**Test Environment**:

- OS:
- `@graphql-mesh/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
