### PR TITLE
Fix multiple gRPC subgraphs in a supergraph

### DIFF
--- a/.changeset/modern-doors-swim.md
+++ b/.changeset/modern-doors-swim.md
@@ -1,0 +1,11 @@
+---
+'@graphql-mesh/grpc': minor
+'@graphql-mesh/transport-grpc': minor
+'@omnigraph/grpc': minor
+---
+
+Handle multiple gRPC services correctly in a supergraph
+
+Previously multiple directives on Query type conflicting, which needs to be fixed on Gateway runtime later, but for now, it should be already in the transport directive. And this change fixes the issue before the gateway runtime fix.
+
+Generated schema will be different so this can be considered a breaking change but it will be no functional change for the existing users.

--- a/e2e/grpc-multiple/__snapshots__/grpc-multiple.test.ts.snap
+++ b/e2e/grpc-multiple/__snapshots__/grpc-multiple.test.ts.snap
@@ -1,0 +1,267 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gRPC Multiple composes 1`] = `
+"
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  
+  
+  
+  
+  
+  @link(
+  url: "https://the-guild.dev/graphql/mesh/spec/v1.0"
+  import: ["@grpcMethod", "@grpcConnectivityState", "@transport", "@extraSchemaDefinitionDirective"]
+)
+{
+  query: Query
+  
+  
+}
+
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(
+    graph: join__Graph
+    requires: join__FieldSet
+    provides: join__FieldSet
+    type: String
+    external: Boolean
+    override: String
+    usedOverridden: Boolean
+  ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(
+    graph: join__Graph!
+    interface: String!
+  ) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(
+    graph: join__Graph!
+    key: join__FieldSet
+    extension: Boolean! = false
+    resolvable: Boolean! = true
+    isInterfaceObject: Boolean! = false
+  ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  scalar join__FieldSet
+
+
+  directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+  ) repeatable on SCHEMA
+
+  scalar link__Import
+
+  enum link__Purpose {
+    """
+    \`SECURITY\` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    \`EXECUTION\` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+
+
+
+
+
+
+
+enum join__Graph {
+  PETS @join__graph(name: "Pets", url: "localhost:<Pets_port>") 
+  STORES @join__graph(name: "Stores", url: "localhost:<Stores_port>") 
+}
+
+directive @grpcMethod(
+  subgraph: String
+  rootJsonName: String
+  objPath: String
+  methodName: String
+  responseStream: Boolean
+) repeatable on FIELD_DEFINITION
+
+directive @grpcConnectivityState(subgraph: String, rootJsonName: String, objPath: String)  repeatable on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, options: TransportOptions)  repeatable on SCHEMA
+
+directive @extraSchemaDefinitionDirective(directives: _DirectiveExtensions)  repeatable on OBJECT
+
+"""
+Request to get all pet stores
+"""
+scalar pets__Empty_Input @join__type(graph: PETS)  @specifiedBy(
+  url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+)
+
+scalar TransportOptions @join__type(graph: PETS)  @join__type(graph: STORES) 
+
+scalar _DirectiveExtensions @join__type(graph: PETS)  @join__type(graph: STORES) 
+
+"""
+Request to get all pet stores
+"""
+scalar petstore__Empty_Input @join__type(graph: STORES)  @specifiedBy(
+  url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+)
+
+type Query @extraSchemaDefinitionDirective(
+  directives: {transport: [{subgraph: "Pets", kind: "grpc", location: "localhost:<Pets_port>", options: {requestTimeout: 200000, roots: [{name: "Root0", rootJson: {options: {syntax: "proto3"}, nested: {pets: {nested: {Pet: {fields: {id: {type: "int32", id: 1, comment: null}, name: {type: "string", id: 2, comment: null}}, comment: "Message for pet store information"}, Empty: {fields: {}, comment: "Request to get all pet stores"}, Pets: {fields: {pets: {rule: "repeated", type: "Pet", id: 1, comment: null}}, comment: "Response with a list of pet stores"}, PetService: {methods: {GetAllPets: {requestType: "Empty", responseType: "Pets", comment: null}}, comment: "Service definition for pet store"}}}}}}]}}]}
+) @extraSchemaDefinitionDirective(
+  directives: {transport: [{subgraph: "Stores", kind: "grpc", location: "localhost:<Stores_port>", options: {requestTimeout: 200000, roots: [{name: "Root0", rootJson: {options: {syntax: "proto3"}, nested: {petstore: {nested: {PetStore: {fields: {id: {type: "int32", id: 1, comment: null}, name: {type: "string", id: 2, comment: null}, location: {type: "int32", id: 3, comment: null}, petsForSale: {rule: "repeated", type: "int32", id: 4, comment: null}}, comment: "Message for pet store information"}, Empty: {fields: {}, comment: "Request to get all pet stores"}, PetStoreList: {fields: {petStores: {rule: "repeated", type: "PetStore", id: 1, comment: null}}, comment: "Response with a list of pet stores"}, PetStoreService: {methods: {GetAllPetStores: {requestType: "Empty", responseType: "PetStoreList", comment: null}, GetPetStorePets: {requestType: "PetStore", responseType: "PetStore", comment: null}}, comment: "Service definition for pet store"}}}}}}]}}]}
+) @join__type(graph: PETS)  @join__type(graph: STORES)  {
+  pets_PetService_GetAllPets(input: pets__Empty_Input) : pets__Pets @grpcMethod(
+    subgraph: "Pets"
+    rootJsonName: "Root0"
+    objPath: "pets.PetService"
+    methodName: "GetAllPets"
+    responseStream: false
+  ) @join__field(graph: PETS) 
+  pets_PetService_connectivityState(tryToConnect: Boolean) : ConnectivityState @grpcConnectivityState(subgraph: "Pets", rootJsonName: "Root0", objPath: "pets.PetService")  @join__field(graph: PETS) 
+  petstore_PetStoreService_GetAllPetStores(input: petstore__Empty_Input) : petstore__PetStoreList @grpcMethod(
+    subgraph: "Stores"
+    rootJsonName: "Root0"
+    objPath: "petstore.PetStoreService"
+    methodName: "GetAllPetStores"
+    responseStream: false
+  ) @join__field(graph: STORES) 
+  petstore_PetStoreService_GetPetStorePets(input: petstore__PetStore_Input) : petstore__PetStore @grpcMethod(
+    subgraph: "Stores"
+    rootJsonName: "Root0"
+    objPath: "petstore.PetStoreService"
+    methodName: "GetPetStorePets"
+    responseStream: false
+  ) @join__field(graph: STORES) 
+  petstore_PetStoreService_connectivityState(tryToConnect: Boolean) : ConnectivityState @grpcConnectivityState(
+    subgraph: "Stores"
+    rootJsonName: "Root0"
+    objPath: "petstore.PetStoreService"
+  ) @join__field(graph: STORES) 
+}
+
+"""
+Response with a list of pet stores
+"""
+type pets__Pets @join__type(graph: PETS)  {
+  pets: [pets__Pet]
+}
+
+"""
+Message for pet store information
+"""
+type pets__Pet @join__type(graph: PETS)  {
+  id: Int
+  name: String
+}
+
+"""
+Response with a list of pet stores
+"""
+type petstore__PetStoreList @join__type(graph: STORES)  {
+  petStores: [petstore__PetStore]
+}
+
+"""
+Message for pet store information
+"""
+type petstore__PetStore @join__type(graph: STORES)  {
+  id: Int
+  name: String
+  location: Int
+  petsForSale: [Int]
+}
+
+enum ConnectivityState @join__type(graph: PETS)  @join__type(graph: STORES)  {
+  IDLE @join__enumValue(graph: PETS)  @join__enumValue(graph: STORES) 
+  CONNECTING @join__enumValue(graph: PETS)  @join__enumValue(graph: STORES) 
+  READY @join__enumValue(graph: PETS)  @join__enumValue(graph: STORES) 
+  TRANSIENT_FAILURE @join__enumValue(graph: PETS)  @join__enumValue(graph: STORES) 
+  SHUTDOWN @join__enumValue(graph: PETS)  @join__enumValue(graph: STORES) 
+}
+
+"""
+Message for pet store information
+"""
+input petstore__PetStore_Input @join__type(graph: STORES)  {
+  id: Int
+  name: String
+  location: Int
+  petsForSale: [Int]
+}
+    
+"
+`;
+
+exports[`gRPC Multiple works: GetAllPetStores 1`] = `
+{
+  "data": {
+    "petstore_PetStoreService_GetAllPetStores": {
+      "petStores": [
+        {
+          "id": 1,
+          "name": "Happy Paws Pet Store",
+        },
+        {
+          "id": 2,
+          "name": "Pet Paradise",
+        },
+        {
+          "id": 3,
+          "name": "Furry Friends",
+        },
+        {
+          "id": 4,
+          "name": "Paws and Claws",
+        },
+        {
+          "id": 5,
+          "name": "The Pet Shop",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`gRPC Multiple works: GetAllPets 1`] = `
+{
+  "data": {
+    "pets_PetService_GetAllPets": {
+      "pets": [
+        {
+          "id": 1,
+          "name": "Pet1",
+        },
+        {
+          "id": 2,
+          "name": "Pet2",
+        },
+        {
+          "id": 3,
+          "name": "Pet3",
+        },
+        {
+          "id": 4,
+          "name": "Pet4",
+        },
+        {
+          "id": 5,
+          "name": "Pet5",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/e2e/grpc-multiple/grpc-multiple.test.ts
+++ b/e2e/grpc-multiple/grpc-multiple.test.ts
@@ -1,0 +1,54 @@
+import { createTenv, type Serve } from '@e2e/tenv';
+
+describe('gRPC Multiple', () => {
+  const { compose, service, serve } = createTenv(__dirname);
+  const queries = {
+    GetAllPets: /* GraphQL */ `
+      query GetAllPets {
+        pets_PetService_GetAllPets {
+          pets {
+            id
+            name
+          }
+        }
+      }
+    `,
+    GetAllPetStores: /* GraphQL */ `
+      query GetAllPetStores {
+        petstore_PetStoreService_GetAllPetStores {
+          petStores {
+            id
+            name
+          }
+        }
+      }
+    `,
+  };
+  let gw: Serve;
+  let supergraph: string;
+  beforeAll(async () => {
+    const { output, result } = await compose({
+      services: [await service('Pets'), await service('Stores')],
+      output: 'graphql',
+    });
+    supergraph = result;
+    gw = await serve({
+      supergraph: output,
+    });
+  });
+  it('composes', async () => {
+    const { result } = await compose({
+      services: [await service('Pets'), await service('Stores')],
+      maskServicePorts: true,
+    });
+    expect(result).toMatchSnapshot();
+  });
+  for (const queryName in queries) {
+    it('works', async () => {
+      const result = await gw.execute({
+        query: queries[queryName],
+      });
+      expect(result).toMatchSnapshot(queryName);
+    });
+  }
+});

--- a/e2e/grpc-multiple/mesh.config.ts
+++ b/e2e/grpc-multiple/mesh.config.ts
@@ -1,0 +1,22 @@
+import { Opts } from '@e2e/opts';
+import { defineConfig } from '@graphql-mesh/compose-cli';
+import { loadGrpcSubgraph } from '@omnigraph/grpc';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGrpcSubgraph('Pets', {
+        endpoint: 'localhost:' + opts.getServicePort('Pets'),
+        source: './services/Pets/pets.proto', // only needed when not running reflection
+      }),
+    },
+    {
+      sourceHandler: loadGrpcSubgraph('Stores', {
+        endpoint: 'localhost:' + opts.getServicePort('Stores'),
+        source: './services/Stores/pet-store.proto', // only needed when not running reflection
+      }),
+    },
+  ],
+});

--- a/e2e/grpc-multiple/package.json
+++ b/e2e/grpc-multiple/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@e2e/grpc-multiple",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@graphql-hive/gateway": "^1.5.8",
+    "@graphql-mesh/compose-cli": "workspace:*",
+    "@grpc/grpc-js": "^1.12.2",
+    "@grpc/proto-loader": "^0.7.13",
+    "@grpc/reflection": "^1.0.4",
+    "@omnigraph/grpc": "workspace:*",
+    "graphql": "16.10.0"
+  }
+}

--- a/e2e/grpc-multiple/services/Pets/index.ts
+++ b/e2e/grpc-multiple/services/Pets/index.ts
@@ -1,0 +1,49 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { join } from 'path';
+import { Opts } from '@e2e/opts';
+import { loadPackageDefinition, Server, ServerCredentials } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+import { ReflectionService } from '@grpc/reflection';
+
+const _dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load the protobuf file
+const PROTO_PATH = join(_dirname, 'pets.proto');
+const packageDefinition = loadSync(PROTO_PATH, {});
+const petsProto: any = loadPackageDefinition(packageDefinition).pets;
+const reflection = new ReflectionService(packageDefinition);
+
+// Static pet store data
+const pets = [
+  { id: 1, name: 'Pet1' },
+  { id: 2, name: 'Pet2' },
+  { id: 3, name: 'Pet3' },
+  { id: 4, name: 'Pet4' },
+  { id: 5, name: 'Pet5' },
+];
+
+// gRPC service methods
+const petService = {
+  GetAllPets: (call, callback) => {
+    callback(null, { pets });
+  },
+};
+
+const opts = Opts(process.argv);
+
+const port = opts.getServicePort('Pets');
+
+// Start the server
+function main() {
+  const server = new Server();
+  server.addService(petsProto.PetService.service, petService);
+  reflection.addToServer(server);
+
+  server.bindAsync('0.0.0.0:' + port, ServerCredentials.createInsecure(), () => {
+    console.log('gRPC Server running with reflection on port ' + port);
+    server.start();
+  });
+}
+
+main();

--- a/e2e/grpc-multiple/services/Pets/pets.proto
+++ b/e2e/grpc-multiple/services/Pets/pets.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package pets;
+
+// Message for pet store information
+message Pet {
+  int32 id = 1;
+  string name = 2;
+}
+
+// Request to get all pet stores
+message Empty {}
+
+// Response with a list of pet stores
+message Pets {
+  repeated Pet pets = 1;
+}
+
+// Service definition for pet store
+service PetService {
+  rpc GetAllPets (Empty) returns (Pets);
+}

--- a/e2e/grpc-multiple/services/Stores/index.ts
+++ b/e2e/grpc-multiple/services/Stores/index.ts
@@ -1,0 +1,86 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { join } from 'path';
+import { Opts } from '@e2e/opts';
+import { loadPackageDefinition, Server, ServerCredentials, status } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+import { ReflectionService } from '@grpc/reflection';
+
+const _dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load the protobuf file
+const PROTO_PATH = join(_dirname, 'pet-store.proto');
+const packageDefinition = loadSync(PROTO_PATH, {});
+const petstoreProto: any = loadPackageDefinition(packageDefinition).petstore;
+const reflection = new ReflectionService(packageDefinition);
+
+// Static pet store data
+const petStores = [
+  {
+    id: 1,
+    location: 1,
+    name: 'Happy Paws Pet Store',
+    petsForSale: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  },
+  {
+    id: 2,
+    location: 1,
+    name: 'Pet Paradise',
+    petsForSale: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+  },
+  {
+    id: 3,
+    location: 2,
+    name: 'Furry Friends',
+    petsForSale: [21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+  },
+  {
+    id: 4,
+    location: 3,
+    name: 'Paws and Claws',
+    petsForSale: [31, 32, 33, 34, 35, 36, 37, 38, 39, 40],
+  },
+  {
+    id: 5,
+    location: 4,
+    name: 'The Pet Shop',
+    petsForSale: [41, 42, 43, 44, 45, 46, 47, 48, 49, 50],
+  },
+];
+
+// gRPC service methods
+const petStoreService = {
+  GetAllPetStores: (call, callback) => {
+    callback(null, { petStores });
+  },
+
+  GetPetStorePets: (call, callback) => {
+    const storeId = call.request.id;
+    const petStore = petStores.find(store => store.id === storeId);
+    if (!petStore) {
+      return callback({
+        code: status.NOT_FOUND,
+        message: 'Pet store not found',
+      });
+    }
+    callback(null, petStore);
+  },
+};
+
+const opts = Opts(process.argv);
+
+const port = opts.getServicePort('Stores');
+
+// Start the server
+function main() {
+  const server = new Server();
+  server.addService(petstoreProto.PetStoreService.service, petStoreService);
+  reflection.addToServer(server);
+
+  server.bindAsync('0.0.0.0:' + port, ServerCredentials.createInsecure(), () => {
+    console.log('gRPC Server running with reflection on port ' + port);
+    server.start();
+  });
+}
+
+main();

--- a/e2e/grpc-multiple/services/Stores/pet-store.proto
+++ b/e2e/grpc-multiple/services/Stores/pet-store.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package petstore;
+
+// Message for pet store information
+message PetStore {
+  int32 id = 1;
+  string name = 2;
+  int32 location = 3;
+  repeated int32 petsForSale = 4;
+}
+
+// Request to get all pet stores
+message Empty {}
+
+// Response with a list of pet stores
+message PetStoreList {
+  repeated PetStore petStores = 1;
+}
+
+// Service definition for pet store
+service PetStoreService {
+  rpc GetAllPetStores (Empty) returns (PetStoreList);
+  rpc GetPetStorePets (PetStore) returns (PetStore);
+}

--- a/packages/legacy/handlers/grpc/src/index.ts
+++ b/packages/legacy/handlers/grpc/src/index.ts
@@ -24,8 +24,10 @@ export default class GrpcHandler implements MeshHandler {
   private pubsub: MeshPubSub;
   private fetchFn: MeshFetch;
   private importFn: ImportFn;
+  private sourceName: string;
 
   constructor({
+    name,
     config,
     baseDir,
     store,
@@ -42,6 +44,7 @@ export default class GrpcHandler implements MeshHandler {
     );
     this.pubsub = pubsub;
     this.importFn = importFn;
+    this.sourceName = name;
   }
 
   private getCachedNonExecutableSchema() {
@@ -65,6 +68,7 @@ export default class GrpcHandler implements MeshHandler {
 
   getMeshSource() {
     const transport = new GrpcTransportHelper(
+      this.sourceName,
       this.baseDir,
       this.logger,
       this.config.endpoint,

--- a/packages/loaders/grpc/src/directives.ts
+++ b/packages/loaders/grpc/src/directives.ts
@@ -60,26 +60,6 @@ export const EnumDirective = new GraphQLDirective({
   },
 });
 
-export const grpcRootJsonDirective = new GraphQLDirective({
-  name: 'grpcRootJson',
-  locations: [DirectiveLocation.OBJECT],
-  args: {
-    subgraph: {
-      type: GraphQLString,
-    },
-    name: {
-      type: GraphQLString,
-    },
-    rootJson: {
-      type: ObjMapScalar,
-    },
-    loadOptions: {
-      type: ObjMapScalar,
-    },
-  },
-  isRepeatable: true,
-});
-
 export const transportDirective = new GraphQLDirective({
   name: 'transport',
   args: {

--- a/packages/loaders/grpc/src/grpcLoaderHelper.ts
+++ b/packages/loaders/grpc/src/grpcLoaderHelper.ts
@@ -31,7 +31,6 @@ import {
   EnumDirective,
   grpcConnectivityStateDirective,
   grpcMethodDirective,
-  grpcRootJsonDirective,
   transportDirective,
 } from './directives.js';
 import { addIncludePathResolver, getTypeName, walkToFindTypePath } from './utils.js';
@@ -90,6 +89,10 @@ export class GrpcLoaderHelper implements AsyncDisposable {
     const descriptorSets = await this.getDescriptorSets(creds);
 
     const directives: Directive[] = [];
+    const roots: {
+      name: string;
+      rootJson: AnyNestedObject;
+    }[] = [];
     for (const { name: rootJsonName, rootJson } of descriptorSets) {
       const rootLogger = this.logger.child(rootJsonName);
 
@@ -102,16 +105,7 @@ export class GrpcLoaderHelper implements AsyncDisposable {
         rootJson,
         rootLogger,
       });
-
-      this.schemaComposer.addDirective(grpcRootJsonDirective);
-      directives.push({
-        name: 'grpcRootJson',
-        args: {
-          subgraph: this.subgraphName,
-          name: rootJsonName,
-          rootJson,
-        },
-      });
+      roots.push({ name: rootJsonName, rootJson });
     }
     this.schemaComposer.Query.setDirectives(directives);
 
@@ -136,6 +130,7 @@ export class GrpcLoaderHelper implements AsyncDisposable {
         credentialsSsl: this.config.credentialsSsl,
         useHTTPS: this.config.useHTTPS,
         metaData: this.config.metaData,
+        roots,
       },
     };
     return schema;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,6 +3671,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/grpc-multiple@workspace:e2e/grpc-multiple":
+  version: 0.0.0-use.local
+  resolution: "@e2e/grpc-multiple@workspace:e2e/grpc-multiple"
+  dependencies:
+    "@graphql-hive/gateway": "npm:^1.5.8"
+    "@graphql-mesh/compose-cli": "workspace:*"
+    "@grpc/grpc-js": "npm:^1.12.2"
+    "@grpc/proto-loader": "npm:^0.7.13"
+    "@grpc/reflection": "npm:^1.0.4"
+    "@omnigraph/grpc": "workspace:*"
+    graphql: "npm:16.10.0"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/grpc@workspace:e2e/grpc-example":
   version: 0.0.0-use.local
   resolution: "@e2e/grpc@workspace:e2e/grpc-example"
@@ -8554,6 +8568,18 @@ __metadata:
   bin:
     proto-loader-gen-types: build/bin/proto-loader-gen-types.js
   checksum: 10c0/8c7d25ddff9587ad8963b7823fc57c253e83e76a4f4f663afb5c90a49f7d58512e8f6f65c0551577545025da1e92172913d61815dfa87eaf2de492d1bfe0e1d1
+  languageName: node
+  linkType: hard
+
+"@grpc/reflection@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@grpc/reflection@npm:1.0.4"
+  dependencies:
+    "@grpc/proto-loader": "npm:^0.7.13"
+    protobufjs: "npm:^7.2.5"
+  peerDependencies:
+    "@grpc/grpc-js": ^1.8.21
+  checksum: 10c0/6e9eff27161d9a2988446d4bef354b038b4be2e638c36d24e1a87390eec3185da69a0cb7d36431f6212f5b9a61076322918f5a8d2082ec6469fd037fcf40157f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Handle multiple gRPC services correctly in a supergraph

Previously multiple directives on Query type conflicting, which needs to be fixed on Gateway runtime later, but for now, it should be already in the transport directive. And this change fixes the issue before the gateway runtime fix.

Generated schema will be different so this can be considered a breaking change but it will be no functional change for the existing users.
