### PR TITLE
fix(transform-hive): filter non-existing delegated argument

### DIFF
--- a/.changeset/pink-crews-fix.md
+++ b/.changeset/pink-crews-fix.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transform-hive': patch
+---
+
+Remove non-existing delegated argument from the document while reporting to Hive


### PR DESCRIPTION
In order to prevent Hive Agent to crash, filter non-existing delegated argument while reporting.