### PR TITLE
Fix for code scanning alert no. 27: Clear-text logging of sensitive information

### DIFF
--- a/.changeset/tiny-fans-drive.md
+++ b/.changeset/tiny-fans-drive.md
@@ -1,0 +1,8 @@
+---
+'@graphql-mesh/string-interpolation': patch
+---
+
+Avoid logging sensitive data directly. Instead, log a generic error message without including the potentially sensitive str variable. This way, it still notifies of errors without risking the exposure of sensitive information.
+
+- Replace the logging statement on line 176 in `packages/string-interpolation/src/interpolator.js` to avoid logging the `str` variable.
+- Ensure that the new logging statement provides enough information to debug the issue without exposing sensitive data.

--- a/packages/string-interpolation/src/interpolator.js
+++ b/packages/string-interpolation/src/interpolator.js
@@ -173,7 +173,7 @@ export class Interpolator {
         str,
       );
     } catch (e) {
-      console.error(`An error occurred while applying modifiers to ${str}`, modifiers, e);
+      console.error(`An error occurred while applying modifiers`, e);
       return str;
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/ardatan/graphql-mesh/security/code-scanning/27](https://github.com/ardatan/graphql-mesh/security/code-scanning/27)

To fix the problem, we should avoid logging sensitive data directly. Instead, we can log a generic error message without including the potentially sensitive `str` variable. This way, we still get notified of errors without risking the exposure of sensitive information.

- Replace the logging statement on line 176 in `packages/string-interpolation/src/interpolator.js` to avoid logging the `str` variable.
- Ensure that the new logging statement provides enough information to debug the issue without exposing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
