### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/website/src/components/examples-sandbox.tsx
+++ b/website/src/components/examples-sandbox.tsx
@@ -63,6 +63,10 @@ export interface ExamplesSandboxProps extends React.HTMLAttributes<HTMLElement> 
   border?: boolean;
 }
 
+function isValidExampleDir(value: string): boolean {
+  return Object.values(EXAMPLES).some(group => Object.values(group).includes(value));
+}
+
 export function ExamplesSandbox({ lazy = false, border = false, ...rest }: ExamplesSandboxProps) {
   const [exampleDir, setExampleDir] = useState('json-schema-example');
   const [isVisible, setIsVisible] = useState(!lazy);
@@ -102,7 +106,10 @@ export function ExamplesSandbox({ lazy = false, border = false, ...rest }: Examp
         <select
           value={exampleDir}
           onChange={e => {
-            setExampleDir(e.target.value);
+            const value = e.target.value;
+            if (isValidExampleDir(value)) {
+              setExampleDir(value);
+            }
           }}
           className="bg-inherit hive-focus w-[200px] cursor-pointer px-3 pr-8 p-2 border-beige-400 dark:border-neutral-800 border rounded-lg hover:bg-beige-100 dark:hover:bg-neutral-900 appearance-none"
         >


### PR DESCRIPTION
Potential fix for [https://github.com/ardatan/graphql-mesh/security/code-scanning/26](https://github.com/ardatan/graphql-mesh/security/code-scanning/26)

To fix the problem, we need to ensure that the value taken from `e.target.value` is sanitized before it is used to construct the `iframeSrc` URL. This can be done by validating the value against the predefined set of examples (`EXAMPLES`). If the value is not found in the predefined set, we should not use it.

- We will create a function to validate the `exampleDir` value.
- We will use this function to sanitize the value before setting it to the state.
- This ensures that only valid example directories are used in constructing the `iframeSrc` URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
