### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/website/src/components/examples-sandbox.tsx
+++ b/website/src/components/examples-sandbox.tsx
@@ -97,7 +97,7 @@ export function ExamplesSandbox({ lazy = false, border = false, ...rest }: Examp
 
   const { basePath } = useRouter();
 
-  const iframeSrc = `${basePath}/codesandbox-iframe.html?example=${exampleDir}`;
+  const iframeSrc = `${basePath}/codesandbox-iframe.html?example=${encodeURIComponent(exampleDir)}`;
 
   return (
     <div {...rest} className={cn('w-full', rest.className)}>


### PR DESCRIPTION
Potential fix for [https://github.com/ardatan/graphql-mesh/security/code-scanning/26](https://github.com/ardatan/graphql-mesh/security/code-scanning/26)

To fix the problem, we need to ensure that the `exampleDir` value is properly sanitized before being used to construct the `iframeSrc` URL. This can be achieved by encoding the `exampleDir` value to ensure that any special characters are properly escaped.

The best way to fix this issue without changing existing functionality is to use the `encodeURIComponent` function to encode the `exampleDir` value before including it in the `iframeSrc` URL. This will ensure that any special characters are properly escaped, preventing potential XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
