### PR TITLE
fix(response-cache): respect subgraph cache control TTL value

### DIFF
--- a/.changeset/@graphql-mesh_plugin-response-cache-8334-dependencies.md
+++ b/.changeset/@graphql-mesh_plugin-response-cache-8334-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/plugin-response-cache": patch
+---
+dependencies updates:
+  - Added dependency [`cache-control-parser@^2.0.6` ↗︎](https://www.npmjs.com/package/cache-control-parser/v/2.0.6) (to `dependencies`)

--- a/.changeset/wicked-schools-wink.md
+++ b/.changeset/wicked-schools-wink.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-response-cache': patch
+---
+
+When a subgraph returns cache control headers with a certain TTL, respect that during the calculation of overall TTL in the response cache plugin

--- a/e2e/cache-control/gateway.config.ts
+++ b/e2e/cache-control/gateway.config.ts
@@ -16,11 +16,6 @@ if (process.env.CACHE_PLUGIN === 'HTTP Caching') {
 } else if (process.env.CACHE_PLUGIN === 'Response Caching') {
   config.responseCaching = {
     session: () => null,
-    ttlPerType: {
-      // Just like a default TTL set in Apollo Server,
-      // We do the same thing in response caching plugin to replicate the behavior
-      Comment: 5_000,
-    },
   };
 } else {
   throw new Error(`Unknown caching plugin: ${process.env.CACHE_PLUGIN}`);

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -43,6 +43,7 @@
     "@graphql-mesh/utils": "^0.103.12",
     "@graphql-tools/utils": "^10.6.2",
     "@graphql-yoga/plugin-response-cache": "^3.1.1",
+    "cache-control-parser": "^2.0.6",
     "graphql-yoga": "^5.7.0",
     "tslib": "^2.4.0"
   },

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -197,6 +197,8 @@ export default function useMeshResponseCache(
     }
   }
 
+  // Stored TTL by the context
+  // To be compared with the calculated one later in `onTtl`
   const ttlByContext = new WeakMap<any, number>();
 
   // @ts-expect-error - GatewayPlugin types
@@ -219,6 +221,9 @@ export default function useMeshResponseCache(
     cache: getCacheForResponseCache(options.cache),
     ttlPerType,
     ttlPerSchemaCoordinate,
+    // Checks the TTL stored in the context
+    // Compares it to the calculated one
+    // Then it takes the lowest value
     onTtl({ ttl, context }) {
       const ttlForThisContext = ttlByContext.get(context);
       if (ttlForThisContext != null && ttlForThisContext < ttl) {
@@ -227,6 +232,8 @@ export default function useMeshResponseCache(
       return ttl;
     },
   });
+  // Checks the TTL stored in the context
+  // Takes the lowest value
   function checkTtl(context: GatewayContext, ttl: number) {
     const ttlForThisContext = ttlByContext.get(context);
     if (ttlForThisContext == null || ttl < ttlForThisContext) {
@@ -234,7 +241,7 @@ export default function useMeshResponseCache(
     }
   }
   plugin.onFetch = function ({ executionRequest, context }) {
-    // If it is a subgraph request
+    // Only if it is a subgraph request
     if (executionRequest && context) {
       return function onFetchDone({ response }) {
         const cacheControlHeader = response.headers.get('cache-control');

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -1,5 +1,6 @@
-import type { Plugin } from 'graphql-yoga';
+import CacheControlParser from 'cache-control-parser';
 import { defaultBuildResponseCacheKey } from '@envelop/response-cache';
+import type { GatewayPlugin } from '@graphql-hive/gateway-runtime';
 import { process } from '@graphql-mesh/cross-helpers';
 import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 import type { KeyValueCache, YamlConfig } from '@graphql-mesh/types';
@@ -166,7 +167,7 @@ export type ResponseCacheConfig = Omit<UseResponseCacheParameter, 'cache'> & {
  * Response cache plugin for GraphQL Mesh
  * @param options
  */
-export default function useMeshResponseCache(options: ResponseCacheConfig): Plugin;
+export default function useMeshResponseCache(options: ResponseCacheConfig): GatewayPlugin;
 /**
  * @deprecated Use new configuration format `ResponseCacheConfig`
  * @param options
@@ -175,7 +176,7 @@ export default function useMeshResponseCache(
   options: YamlConfig.ResponseCacheConfig & {
     cache: KeyValueCache;
   },
-): Plugin;
+): GatewayPlugin;
 export default function useMeshResponseCache(
   options:
     | ResponseCacheConfig
@@ -183,20 +184,22 @@ export default function useMeshResponseCache(
     | (YamlConfig.ResponseCacheConfig & {
         cache: KeyValueCache;
       }),
-): Plugin {
+): GatewayPlugin {
   const ttlPerType: Record<string, number> = { ...(options as ResponseCacheConfig).ttlPerType };
   const ttlPerSchemaCoordinate: Record<string, number> = {
     ...(options as ResponseCacheConfig).ttlPerSchemaCoordinate,
   };
 
   const { ttlPerCoordinate } = options as YamlConfig.ResponseCacheConfig;
+  const ttlByContext = new WeakMap<any, number>();
   if (ttlPerCoordinate) {
     for (const ttlConfig of ttlPerCoordinate) {
       ttlPerSchemaCoordinate[ttlConfig.coordinate] = ttlConfig.ttl;
     }
   }
 
-  return useResponseCache({
+  // @ts-expect-error - GatewayPlugin types
+  const plugin: GatewayPlugin = useResponseCache({
     includeExtensionMetadata:
       options.includeExtensionMetadata != null
         ? options.includeExtensionMetadata
@@ -215,5 +218,36 @@ export default function useMeshResponseCache(
     cache: getCacheForResponseCache(options.cache),
     ttlPerType,
     ttlPerSchemaCoordinate,
+    onTtl({ ttl, context }) {
+      const ttlForThisContext = ttlByContext.get(context);
+      if (ttlForThisContext != null && ttlForThisContext < ttl) {
+        return ttlForThisContext;
+      }
+      return ttl;
+    },
   });
+  plugin.onFetch = function ({ executionRequest, context }) {
+    // If it is a subgraph request
+    if (executionRequest && context) {
+      return function onFetchDone({ response }) {
+        function checkTtl(ttl: number) {
+          const ttlForThisContext = ttlByContext.get(context);
+          if (ttlForThisContext == null || ttl < ttlForThisContext) {
+            ttlByContext.set(context, ttl);
+          }
+        }
+        const cacheControlHeader = response.headers.get('cache-control');
+        if (cacheControlHeader != null) {
+          const parsedCacheControl = CacheControlParser.parse(cacheControlHeader);
+          if (parsedCacheControl['max-age']) {
+            checkTtl(parsedCacheControl['max-age'] * 1000);
+          }
+          if (parsedCacheControl['s-maxage']) {
+            checkTtl(parsedCacheControl['s-maxage'] * 1000);
+          }
+        }
+      };
+    }
+  };
+  return plugin;
 }

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -251,12 +251,12 @@ export default function useMeshResponseCache(
         const cacheControlHeader = response.headers.get('cache-control');
         if (cacheControlHeader != null) {
           const parsedCacheControl = CacheControlParser.parse(cacheControlHeader);
-          if (parsedCacheControl['max-age']) {
+          if (parsedCacheControl['max-age'] != null) {
             const maxAgeInSeconds = parsedCacheControl['max-age'];
             const maxAgeInMs = maxAgeInSeconds * 1000;
             checkTtl(context, maxAgeInMs);
           }
-          if (parsedCacheControl['s-maxage']) {
+          if (parsedCacheControl['s-maxage'] != null) {
             const sMaxAgeInSeconds = parsedCacheControl['s-maxage'];
             const sMaxAgeInMs = sMaxAgeInSeconds * 1000;
             checkTtl(context, sMaxAgeInMs);

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -185,25 +185,14 @@ export default function useMeshResponseCache(
         cache: KeyValueCache;
       }),
 ): GatewayPlugin {
-  const ttlPerType: Record<string, number> = {};
-  if ('ttlPerType' in options && options.ttlPerType) {
-    for (const type in options.ttlPerType) {
-      const ttl = options.ttlPerType[type];
-      ttlPerType[type] = ttl;
-    }
-  }
+  const ttlPerType: Record<string, number> = { ...(options as ResponseCacheConfig).ttlPerType };
+  const ttlPerSchemaCoordinate: Record<string, number> = {
+    ...(options as ResponseCacheConfig).ttlPerSchemaCoordinate,
+  };
 
-  const ttlPerSchemaCoordinate: Record<string, number> = {};
-
-  if ('ttlPerSchemaCoordinate' in options && options.ttlPerSchemaCoordinate) {
-    for (const coordinate in options.ttlPerSchemaCoordinate) {
-      const ttl = options.ttlPerSchemaCoordinate[coordinate];
-      ttlPerSchemaCoordinate[coordinate] = ttl;
-    }
-  }
-
-  if ('ttlPerCoordinate' in options && options.ttlPerCoordinate?.length) {
-    for (const ttlConfig of options.ttlPerCoordinate) {
+  const { ttlPerCoordinate } = options as YamlConfig.ResponseCacheConfig;
+  if (ttlPerCoordinate) {
+    for (const ttlConfig of ttlPerCoordinate) {
       ttlPerSchemaCoordinate[ttlConfig.coordinate] = ttlConfig.ttl;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,7 +80,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:3.12.8":
+"@apollo/client@npm:3.12.8, @apollo/client@npm:^3.8.0":
   version: 3.12.8
   resolution: "@apollo/client@npm:3.12.8"
   dependencies:
@@ -113,43 +113,6 @@ __metadata:
     subscriptions-transport-ws:
       optional: true
   checksum: 10c0/3af203769fa82892dd5d4870eea2d8d2845b4197118a274779f483df154410601c45bd008afb017f03ef446902ce4ea9c32454e3525abe782286a65979a1f7d0
-  languageName: node
-  linkType: hard
-
-"@apollo/client@npm:^3.8.0":
-  version: 3.12.7
-  resolution: "@apollo/client@npm:3.12.7"
-  dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.1.1"
-    "@wry/caches": "npm:^1.0.0"
-    "@wry/equality": "npm:^0.5.6"
-    "@wry/trie": "npm:^0.5.0"
-    graphql-tag: "npm:^2.12.6"
-    hoist-non-react-statics: "npm:^3.3.2"
-    optimism: "npm:^0.18.0"
-    prop-types: "npm:^15.7.2"
-    rehackt: "npm:^0.1.0"
-    response-iterator: "npm:^0.2.6"
-    symbol-observable: "npm:^4.0.0"
-    ts-invariant: "npm:^0.10.3"
-    tslib: "npm:^2.3.0"
-    zen-observable-ts: "npm:^1.2.5"
-  peerDependencies:
-    graphql: ^15.0.0 || ^16.0.0
-    graphql-ws: ^5.5.5
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
-    subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-  peerDependenciesMeta:
-    graphql-ws:
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-    subscriptions-transport-ws:
-      optional: true
-  checksum: 10c0/396147eafe9099217da534305be7667a44f89fbb7ef7bb342662fd842fffc6de870744546137a8a7065c1bc458f1201070a74fb7ece0f9f63b6c03907de27cc8
   languageName: node
   linkType: hard
 
@@ -6829,6 +6792,7 @@ __metadata:
     "@graphql-mesh/utils": "npm:^0.103.12"
     "@graphql-tools/utils": "npm:^10.6.2"
     "@graphql-yoga/plugin-response-cache": "npm:^3.1.1"
+    cache-control-parser: "npm:^2.0.6"
     graphql-yoga: "npm:^5.7.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
@@ -8391,7 +8355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-yoga/plugin-apollo-inline-trace@npm:3.10.12":
+"@graphql-yoga/plugin-apollo-inline-trace@npm:3.10.12, @graphql-yoga/plugin-apollo-inline-trace@npm:^3.10.10":
   version: 3.10.12
   resolution: "@graphql-yoga/plugin-apollo-inline-trace@npm:3.10.12"
   dependencies:
@@ -8404,22 +8368,6 @@ __metadata:
     graphql: ^15.2.0 || ^16.0.0
     graphql-yoga: ^5.10.11
   checksum: 10c0/a07953afd6a08101352a8bab075cdbfcdec55c7247c238a880cd803c5e78230a87f23ca0f516c5f94c67ebed81b4cbb6a59a6ccae5a0df32c581e5e91aa8fa28
-  languageName: node
-  linkType: hard
-
-"@graphql-yoga/plugin-apollo-inline-trace@npm:^3.10.10":
-  version: 3.10.10
-  resolution: "@graphql-yoga/plugin-apollo-inline-trace@npm:3.10.10"
-  dependencies:
-    "@apollo/usage-reporting-protobuf": "npm:^4.1.1"
-    "@envelop/on-resolve": "npm:^4.1.1"
-    tslib: "npm:^2.8.1"
-  peerDependencies:
-    "@graphql-tools/utils": ^10.6.1
-    "@whatwg-node/fetch": ^0.10.1
-    graphql: ^15.2.0 || ^16.0.0
-    graphql-yoga: ^5.10.10
-  checksum: 10c0/5171ffd8277d2058529c8910ea79496365854e06fabcf0316dc1237c3512ce2ab556a746732320d1b969bae96eee18ac7a951961358c6f8661fbac2c8e2687af
   languageName: node
   linkType: hard
 
@@ -13899,7 +13847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.22.0":
+"@typescript-eslint/eslint-plugin@npm:8.22.0, @typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.22.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.22.0"
   dependencies:
@@ -13917,27 +13865,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
   checksum: 10c0/eecc23e05287cc99a43855d64c0f0898f690ee14b8c31b60ba92ce9732443f6b0c9695514b276fb2ecd27e64c15d4c38cd28b570779115525b4dfdbba60e81ca
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/eslint-plugin@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.21.0"
-  dependencies:
-    "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.21.0"
-    "@typescript-eslint/type-utils": "npm:8.21.0"
-    "@typescript-eslint/utils": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
-    graphemer: "npm:^1.4.0"
-    ignore: "npm:^5.3.1"
-    natural-compare: "npm:^1.4.0"
-    ts-api-utils: "npm:^2.0.0"
-  peerDependencies:
-    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/4601d21ec35b9fa5cfc1ad0330733ab40d6c6822c7fc15c3584a16f678c9a72e077a1725a950823fe0f499a15f3981795b1ea5d1e7a1be5c7b8296ea9ae6327c
   languageName: node
   linkType: hard
 
@@ -13976,7 +13903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.22.0":
+"@typescript-eslint/parser@npm:8.22.0, @typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.22.0
   resolution: "@typescript-eslint/parser@npm:8.22.0"
   dependencies:
@@ -13989,22 +13916,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
   checksum: 10c0/6575684d4724aa908b0d6a29db5d5054b9277804844ee4179c77371f8b8b84534b9b7e4df0e282c5f39729ae6f0019208a6b83f0ca5d0f06f9da5a06d8ddb4fd
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/parser@npm:8.21.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.21.0"
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/typescript-estree": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
-    debug: "npm:^4.3.4"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/aadebd50ca7aa2d61ad85d890c0d7010f2c293ec4d50a7833ef9674f232f0bc7118faa93a898771fbea50f02d542d687cf3569421b23f72fe6fed6895d5506fc
   languageName: node
   linkType: hard
 
@@ -14035,16 +13946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.21.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
-  checksum: 10c0/ea405e79dc884ea1c76465604db52f9b0941d6cbb0bde6bce1af689ef212f782e214de69d46503c7c47bfc180d763369b7433f1965e3be3c442b417e8c9f8f75
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.22.0":
   version: 8.22.0
   resolution: "@typescript-eslint/scope-manager@npm:8.22.0"
@@ -14072,21 +13973,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/type-utils@npm:8.21.0"
-  dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.21.0"
-    "@typescript-eslint/utils": "npm:8.21.0"
-    debug: "npm:^4.3.4"
-    ts-api-utils: "npm:^2.0.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/617f5dfe83fd9a7c722b27fa4e7f0c84f29baa94f75a4e8e5ccfd5b0a373437f65724e21b9642870fb0960f204b1a7f516a038200a12f8118f21b1bf86315bf3
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/type-utils@npm:8.22.0":
   version: 8.22.0
   resolution: "@typescript-eslint/type-utils@npm:8.22.0"
@@ -14106,13 +13992,6 @@ __metadata:
   version: 5.62.0
   resolution: "@typescript-eslint/types@npm:5.62.0"
   checksum: 10c0/7febd3a7f0701c0b927e094f02e82d8ee2cada2b186fcb938bc2b94ff6fbad88237afc304cbaf33e82797078bbbb1baf91475f6400912f8b64c89be79bfa4ddf
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/types@npm:8.21.0"
-  checksum: 10c0/67dfd300cc614d7b02e94d0dacfb228a7f4c3fd4eede29c43adb9e9fcc16365ae3df8d6165018da3c123dce65545bef03e3e8183f35e9b3a911ffc727e3274c2
   languageName: node
   linkType: hard
 
@@ -14138,24 +14017,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/d7984a3e9d56897b2481940ec803cb8e7ead03df8d9cfd9797350be82ff765dfcf3cfec04e7355e1779e948da8f02bc5e11719d07a596eb1cb995c48a95e38cf
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.21.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/visitor-keys": "npm:8.21.0"
-    debug: "npm:^4.3.4"
-    fast-glob: "npm:^3.3.2"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^2.0.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/0cf5b0382524f4af54fb5ec71ca7e939ec922711f2d77b383740b28dd4b21407b0ab5dded62df6819d01c12c0b354e95667e3c7025a5d27d05b805161ab94855
   languageName: node
   linkType: hard
 
@@ -14195,21 +14056,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/utils@npm:8.21.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.21.0"
-    "@typescript-eslint/types": "npm:8.21.0"
-    "@typescript-eslint/typescript-estree": "npm:8.21.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.8.0"
-  checksum: 10c0/d8347dbe9176417220aa62902cfc1b2007a9246bb7a8cccdf8590120903eb50ca14cb668efaab4646d086277f2367559985b62230e43ebd8b0723d237eeaa2f2
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/utils@npm:8.22.0":
   version: 8.22.0
   resolution: "@typescript-eslint/utils@npm:8.22.0"
@@ -14232,16 +14078,6 @@ __metadata:
     "@typescript-eslint/types": "npm:5.62.0"
     eslint-visitor-keys: "npm:^3.3.0"
   checksum: 10c0/7c3b8e4148e9b94d9b7162a596a1260d7a3efc4e65199693b8025c71c4652b8042501c0bc9f57654c1e2943c26da98c0f77884a746c6ae81389fcb0b513d995d
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.21.0":
-  version: 8.21.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.21.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.21.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/b3f1412f550e35c0d7ae0410db616951116b365167539f9b85710d8bc2b36b322c5e637caee84cc1ae5df8f1d961880250d52ffdef352b31e5bdbef74ba6fea9
   languageName: node
   linkType: hard
 
@@ -16136,6 +15972,13 @@ __metadata:
     tar: "npm:^7.4.3"
     unique-filename: "npm:^4.0.0"
   checksum: 10c0/01f2134e1bd7d3ab68be851df96c8d63b492b1853b67f2eecb2c37bb682d37cb70bb858a16f2f0554d3c0071be6dfe21456a1ff6fa4b7eed996570d6a25ffe9c
+  languageName: node
+  linkType: hard
+
+"cache-control-parser@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "cache-control-parser@npm:2.0.6"
+  checksum: 10c0/b34cd72c4bb8899325dfdb806adf9feb6c0b4a224314831efdc6a4308f45445b69d56b96402bf798caf035a8c79cb170b7309d727bef15c21f47181119611546
   languageName: node
   linkType: hard
 
@@ -31667,7 +31510,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.1, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.8":
+"readable-stream@npm:^2.0.1, readable-stream@npm:^2.2.2":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -32397,15 +32240,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/78ad6edb8309a2bfb720c2c1898f7907a37f858866ce11a5974643af1203a6a6e05b2fa9c53d8064a673a447b83d42569260c306d43628bff5bb101969708355
-  languageName: node
-  linkType: hard
-
-"response-iterator@npm:^0.2.6":
-  version: 0.2.19
-  resolution: "response-iterator@npm:0.2.19"
-  dependencies:
-    readable-stream: "npm:^2.3.8"
-  checksum: 10c0/fee5d23958060f87f74ba11d7d291d4a0e88ea964abed0d3375ac174993666131446c84c20236460cec9fae8173fbed78caa5a6534c717a98ce67255e38fe85e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
~~Blocked by https://github.com/n1ru4l/envelop/pull/2392~~
Fixes https://github.com/graphql-hive/gateway/issues/542

When a subgraph returns cache control headers with a certain TTL, respect that during the calculation of overall TTL in the response cache plugin.

So this removes the extra configuration in the test, TTL is inherited from the subgraph response automatically.

For example, if there is a subgraph using Apollo Server that defines the default TTL without any `@cacheControl` directives. It prevents the response cache plugin to set the TTL infinite(which is the default of the response-cache plugin)