### PR TITLE
enhance(transport-rest): use the default fetch if no fetch exists in the transport context

### DIFF
--- a/.changeset/seven-crabs-cough.md
+++ b/.changeset/seven-crabs-cough.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/transport-rest': patch
+---
+
+Use `@whatwg-node/fetch` when the transport context doesn't have one

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -9,7 +9,7 @@ import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 import type { Logger, MeshFetch, MeshFetchRequestInit } from '@graphql-mesh/types';
 import { DefaultLogger, getHeadersObj } from '@graphql-mesh/utils';
 import { createGraphQLError, memoize1 } from '@graphql-tools/utils';
-import { Blob, File, FormData, URLSearchParams } from '@whatwg-node/fetch';
+import { Blob, fetch as defaultFetch, File, FormData, URLSearchParams } from '@whatwg-node/fetch';
 import { isFileUpload } from './isFileUpload.js';
 import { getJsonApiFieldsQuery } from './jsonApiFields.js';
 import { resolveDataByUnionInputType } from './resolveDataByUnionInputType.js';
@@ -296,10 +296,7 @@ export function addHTTPRootFieldResolver(
     }
 
     operationLogger.debug(`=> Fetching `, fullPath, `=>`, requestInit);
-    const fetch: typeof globalFetch = context?.fetch || globalFetch;
-    if (!fetch) {
-      return new TypeError(`You should have fetch defined in either the config or the context!`);
-    }
+    const fetch: typeof globalFetch = context?.fetch || globalFetch || defaultFetch;
     // Trick to pass `sourceName` to the `fetch` function for tracing
     const response = await fetch(fullPath, requestInit, context, {
       ...info,


### PR DESCRIPTION
Fixes https://github.com/graphql-hive/gateway/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved fetch function handling in the GraphQL Mesh REST transport to ensure compatibility across different environments
	- Added fallback mechanism for fetch implementation when no context or global fetch is available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->