### PR TITLE
enhance(logging): more clear key-value pairs

### DIFF
--- a/.changeset/heavy-swans-act.md
+++ b/.changeset/heavy-swans-act.md
@@ -1,0 +1,16 @@
+---
+'@graphql-mesh/merger-bare': patch
+'@omnigraph/json-schema': patch
+'@graphql-mesh/plugin-http-cache': patch
+'@graphql-mesh/transport-grpc': patch
+'@graphql-mesh/transport-rest': patch
+'@graphql-mesh/runtime': patch
+'@graphql-mesh/config': patch
+'@graphql-mesh/types': patch
+'@graphql-mesh/utils': patch
+'@omnigraph/grpc': patch
+'@graphql-mesh/compose-cli': patch
+'@graphql-mesh/cli': patch
+---
+
+More clear key-value pairs in the logs

--- a/examples/grpc-example/example-queries/MoviesByCast.stream.graphql
+++ b/examples/grpc-example/example-queries/MoviesByCast.stream.graphql
@@ -1,4 +1,4 @@
-query SearchMoviesByCast {
+query SearchMoviesByCastQuery {
   exampleSearchMoviesByCast(input: { castName: "Tom Cruise" }) @stream {
     name
     year

--- a/examples/grpc-example/example-queries/MoviesByCast.subscription.graphql
+++ b/examples/grpc-example/example-queries/MoviesByCast.subscription.graphql
@@ -1,4 +1,4 @@
-subscription SearchMoviesByCast {
+subscription SearchMoviesByCastSubscription {
   exampleSearchMoviesByCast(input: { castName: "Tom Cruise" }) {
     name
     year

--- a/packages/compose-cli/src/getComposedSchemaFromConfig.ts
+++ b/packages/compose-cli/src/getComposedSchemaFromConfig.ts
@@ -39,7 +39,7 @@ export async function getComposedSchemaFromConfig(config: MeshComposeCLIConfig, 
   const subgraphConfigsForComposition: SubgraphConfig[] = await Promise.all(
     config.subgraphs.map(async subgraphCLIConfig => {
       const { name: subgraphName, schema$ } = subgraphCLIConfig.sourceHandler(ctx);
-      const log = logger.child(`[${subgraphName}]`);
+      const log = logger.child({ subgraph: subgraphName });
       log.debug(`Loading subgraph`);
       let subgraphSchema: GraphQLSchema;
       try {

--- a/packages/compose-cli/src/run.ts
+++ b/packages/compose-cli/src/run.ts
@@ -70,7 +70,7 @@ export async function run({
     program = program.allowUnknownOption().allowExcessArguments();
   const opts = program.parse().opts();
 
-  const log = rootLog.child(` ${productName}`);
+  const log = rootLog.child(productName);
 
   let importedConfig: MeshComposeCLIConfig;
   if (!opts.configPath) {

--- a/packages/legacy/cli/src/commands/serve/serve.ts
+++ b/packages/legacy/cli/src/commands/serve/serve.ts
@@ -104,7 +104,7 @@ export async function serveMesh(
     let diedWorkers = 0;
     cluster.on('exit', (worker, code, signal) => {
       if (!mainProcessKilled) {
-        logger.child(`Worker ${worker.id}`).error(`died with ${signal || code}. Restarting...`);
+        logger.child({ worker: worker.id }).error(`died with ${signal || code}. Restarting...`);
         diedWorkers++;
         if (diedWorkers === forkNum) {
           logger.error('All workers died. Exiting...');
@@ -125,7 +125,7 @@ export async function serveMesh(
 
     logger.info(`${cliParams.serveMessage}: ${serverUrl}`);
     registerTerminateHandler(eventName => {
-      const eventLogger = logger.child(`${eventName}  💀`);
+      const eventLogger = logger.child({ terminateEvent: eventName });
       eventLogger.info(`Destroying GraphQL Mesh...`);
       getBuiltMesh()
         .then(mesh => mesh.destroy())
@@ -149,7 +149,7 @@ export async function serveMesh(
     });
 
     registerTerminateHandler(eventName => {
-      const eventLogger = logger.child(`${eventName}  💀`);
+      const eventLogger = logger.child({ terminateEvent: eventName });
       eventLogger.debug(`Stopping HTTP Server`);
       mapMaybePromise(stop(), () => {
         eventLogger.debug(`HTTP Server has been stopped`);

--- a/packages/legacy/cli/src/commands/serve/serve.ts
+++ b/packages/legacy/cli/src/commands/serve/serve.ts
@@ -119,7 +119,9 @@ export async function serveMesh(
     });
   } else {
     if (cluster.isWorker) {
-      logger.addPrefix?.(`Worker ${cluster.worker?.id}`);
+      logger.addPrefix?.({
+        worker: cluster.worker.id,
+      });
     }
     logger.info(`Starting GraphQL Mesh...`);
 

--- a/packages/legacy/cli/src/index.ts
+++ b/packages/legacy/cli/src/index.ts
@@ -43,7 +43,7 @@ export interface GraphQLMeshCLIParams {
 
 export const DEFAULT_CLI_PARAMS: GraphQLMeshCLIParams = {
   commandName: 'mesh',
-  initialLoggerPrefix: '🕸️  Mesh',
+  initialLoggerPrefix: '',
   configName: 'mesh',
   artifactsDir: process.env.MESH_ARTIFACTS_DIRNAME || '.mesh',
   serveMessage: 'Serving GraphQL Mesh',
@@ -303,6 +303,7 @@ export function createBuiltMeshHTTPHandler<TServerContext = {}>(): MeshHTTPHandl
             configName: cliParams.configName,
             additionalPackagePrefixes: cliParams.additionalPackagePrefixes,
             initialLoggerPrefix: cliParams.initialLoggerPrefix,
+            logger,
           });
           logger = meshConfig.logger;
 
@@ -387,6 +388,7 @@ export function createBuiltMeshHTTPHandler<TServerContext = {}>(): MeshHTTPHandl
             generateCode: true,
             initialLoggerPrefix: cliParams.initialLoggerPrefix,
             throwOnInvalidConfig: args.throwOnInvalidConfig,
+            logger,
           });
           logger = meshConfig.logger;
 
@@ -455,6 +457,7 @@ export function createBuiltMeshHTTPHandler<TServerContext = {}>(): MeshHTTPHandl
           configName: cliParams.configName,
           additionalPackagePrefixes: cliParams.additionalPackagePrefixes,
           initialLoggerPrefix: cliParams.initialLoggerPrefix,
+          logger,
         });
         logger = meshConfig.logger;
         const sourceIndex = meshConfig.sources.findIndex(

--- a/packages/legacy/config/src/utils.ts
+++ b/packages/legacy/config/src/utils.ts
@@ -258,7 +258,7 @@ export async function resolveLogger(
   importFn: ImportFn,
   cwd: string,
   additionalPackagePrefixes: string[],
-  initialLoggerPrefix = '🕸️  Mesh',
+  initialLoggerPrefix = '',
 ): Promise<{
   importCode: string;
   code: string;

--- a/packages/legacy/mergers/bare/src/index.ts
+++ b/packages/legacy/mergers/bare/src/index.ts
@@ -22,7 +22,7 @@ export default class BareMerger implements MeshMerger {
     this.options.logger.debug(
       `Switching to Stitching merger due to the transforms and additional resolvers`,
     );
-    this.options.logger = this.options.logger.child('Stitching Proxy');
+    this.options.logger = this.options.logger.child({ proxy: 'stitching' });
     this.stitchingMerger = this.stitchingMerger || new StitchingMerger(this.options);
     return this.stitchingMerger.getUnifiedSchema(mergerCtx);
   }

--- a/packages/legacy/runtime/src/get-mesh.ts
+++ b/packages/legacy/runtime/src/get-mesh.ts
@@ -103,7 +103,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
   const {
     pubsub = new PubSub(),
     cache,
-    logger = new DefaultLogger('🕸️  Mesh'),
+    logger = new DefaultLogger(''),
     additionalEnvelopPlugins = [],
     sources,
     merger,
@@ -163,7 +163,7 @@ export async function getMesh(options: GetMeshOptions): Promise<MeshInstance> {
   await Promise.allSettled(
     sources.map(async (apiSource, index) => {
       const apiName = apiSource.name;
-      const sourceLogger = logger.child(apiName);
+      const sourceLogger = logger.child({ source: apiName });
       sourceLogger.debug(`Generating the schema`);
       try {
         const source = await apiSource.handler.getMeshSource({

--- a/packages/legacy/types/src/index.ts
+++ b/packages/legacy/types/src/index.ts
@@ -223,7 +223,7 @@ export type Logger = {
   error: (...args: any[]) => void;
   debug: (...lazyArgs: LazyLoggerMessage[]) => void;
   child: (name: string | Record<string, string | number>) => Logger;
-  addPrefix?: (prefix: string) => Logger;
+  addPrefix?: (prefix: string | Record<string, string | number>) => Logger;
 };
 
 export type SelectionSetParam = SelectionSetNode | DocumentNode | string | SelectionSetNode;

--- a/packages/legacy/types/src/index.ts
+++ b/packages/legacy/types/src/index.ts
@@ -222,7 +222,7 @@ export type Logger = {
   info: (...args: any[]) => void;
   error: (...args: any[]) => void;
   debug: (...lazyArgs: LazyLoggerMessage[]) => void;
-  child: (name: string) => Logger;
+  child: (name: string | Record<string, string | number>) => Logger;
   addPrefix?: (prefix: string) => Logger;
 };
 

--- a/packages/legacy/utils/src/in-context-sdk.ts
+++ b/packages/legacy/utils/src/in-context-sdk.ts
@@ -49,7 +49,7 @@ export function getInContextSDK(
   const inContextSDK: Record<string, any> = {};
   const sourceMap = unifiedSchema.extensions.sourceMap as Map<RawSourceOutput, GraphQLSchema>;
   for (const rawSource of rawSources) {
-    const rawSourceLogger = logger?.child(`${rawSource.name}`);
+    const rawSourceLogger = logger?.child({ source: rawSource.name });
 
     const rawSourceContext: any = {
       rawSource,
@@ -83,9 +83,9 @@ export function getInContextSDK(
         const rootTypeFieldMap = rootType.getFields();
         for (const fieldName in rootTypeFieldMap) {
           const rootTypeField = rootTypeFieldMap[fieldName];
-          const inContextSdkLogger = rawSourceLogger?.child(
-            `InContextSDK.${rootType.name}.${fieldName}`,
-          );
+          const inContextSdkLogger = rawSourceLogger?.child({
+            inContextSdk: `${rootType.name}.${fieldName}`,
+          });
           const namedReturnType = getNamedType(rootTypeField.type);
           const shouldHaveSelectionSet = !isLeafType(namedReturnType);
           rawSourceContext[rootType.name][fieldName] = ({

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -138,7 +138,7 @@ export class DefaultLogger implements Logger {
     );
   }
 
-  addPrefix(prefix: string | Record<string, string>): Logger {
+  addPrefix(prefix: string | Record<string, string | number>): Logger {
     prefix = stringifyName(prefix);
     if (!this.name?.includes(prefix)) {
       this.name = this.name ? `${this.name} ${prefix}` : prefix;
@@ -152,7 +152,7 @@ export class DefaultLogger implements Logger {
 }
 
 function stringifyName(name: string | Record<string, string | number>) {
-  if (typeof name === 'string') {
+  if (typeof name === 'string' || typeof name === 'number') {
     return `[${name}]`;
   }
   const names: string[] = [];

--- a/packages/legacy/utils/src/logger.ts
+++ b/packages/legacy/utils/src/logger.ts
@@ -75,7 +75,7 @@ export class DefaultLogger implements Logger {
       return noop;
     }
     this.console.log(
-      `[${getTimestamp()}] ${this.prefix}`.trim() /* trim in case prefix is empty */,
+      `[timestamp=${getTimestamp()}] ${this.prefix}`.trim() /* trim in case prefix is empty */,
       ...args,
     );
   }
@@ -85,7 +85,7 @@ export class DefaultLogger implements Logger {
       return noop;
     }
     this.console.warn(
-      `[${getTimestamp()}] WARN  ${this.prefix}${ANSI_CODES.orange}`,
+      `[timestamp=${getTimestamp()}] [level=WARN]  ${this.prefix}${ANSI_CODES.orange}`,
       ...args,
       ANSI_CODES.reset,
     );
@@ -96,7 +96,7 @@ export class DefaultLogger implements Logger {
       return noop;
     }
     this.console.info(
-      `[${getTimestamp()}] INFO  ${this.prefix}${ANSI_CODES.cyan}`,
+      `[timestamp=${getTimestamp()}] [level=INFO]  ${this.prefix}${ANSI_CODES.cyan}`,
       ...args,
       ANSI_CODES.reset,
     );
@@ -107,7 +107,7 @@ export class DefaultLogger implements Logger {
       return noop;
     }
     this.console.error(
-      `[${getTimestamp()}] ERROR ${this.prefix}${ANSI_CODES.red}`,
+      `[timestamp=${getTimestamp()}] [level=ERROR] ${this.prefix}${ANSI_CODES.red}`,
       ...args,
       ANSI_CODES.reset,
     );
@@ -119,27 +119,29 @@ export class DefaultLogger implements Logger {
     }
     const flattenedArgs = handleLazyMessage(lazyArgs);
     this.console.debug(
-      `[${getTimestamp()}] DEBUG ${this.prefix}${ANSI_CODES.magenta}`,
+      `[timestamp=${getTimestamp()}] [level=DEBUG] ${this.prefix}${ANSI_CODES.magenta}`,
       ...flattenedArgs,
       ANSI_CODES.reset,
     );
   }
 
-  child(name: string): Logger {
+  child(name: string | Record<string, string | number>): Logger {
+    name = stringifyName(name);
     if (this.name?.includes(name)) {
       return this;
     }
     return new DefaultLogger(
-      this.name ? `${this.name} - ${name}` : name,
+      this.name ? `${this.name} ${name}` : name,
       this.logLevel,
       undefined,
       this.console,
     );
   }
 
-  addPrefix(prefix: string): Logger {
+  addPrefix(prefix: string | Record<string, string>): Logger {
+    prefix = stringifyName(prefix);
     if (!this.name?.includes(prefix)) {
-      this.name = this.name ? `${this.name} - ${prefix}` : prefix;
+      this.name = this.name ? `${this.name} ${prefix}` : prefix;
     }
     return this;
   }
@@ -147,4 +149,15 @@ export class DefaultLogger implements Logger {
   toJSON() {
     return undefined;
   }
+}
+
+function stringifyName(name: string | Record<string, string | number>) {
+  if (typeof name === 'string') {
+    return `[${name}]`;
+  }
+  const names: string[] = [];
+  for (const [key, value] of Object.entries(name)) {
+    names.push(`${key}=${value}`);
+  }
+  return `[${names.join(', ')}]`;
 }

--- a/packages/legacy/utils/src/wrapFetchWithHooks.ts
+++ b/packages/legacy/utils/src/wrapFetchWithHooks.ts
@@ -49,7 +49,7 @@ export function wrapFetchWithHooks<TContext>(onFetchHooks: OnFetchHook<TContext>
               if (context?.request) {
                 const requestId = requestIdByRequest.get(context.request);
                 if (requestId) {
-                  logger = logger.child(requestId);
+                  logger = logger.child({ requestId });
                 }
               }
               if (info?.executionRequest) {

--- a/packages/loaders/grpc/src/grpcLoaderHelper.ts
+++ b/packages/loaders/grpc/src/grpcLoaderHelper.ts
@@ -94,7 +94,7 @@ export class GrpcLoaderHelper extends DisposableStack {
       rootJson: string;
     }[] = [];
     for (const { name: rootJsonName, rootJson } of descriptorSets) {
-      const rootLogger = this.logger.child(rootJsonName);
+      const rootLogger = this.logger.child({ root: rootJsonName });
 
       this.logger.debug(`Building the schema structure based on the root object`);
       this.visit({
@@ -259,7 +259,7 @@ export class GrpcLoaderHelper extends DisposableStack {
       rootPromises.map(async (root$, i) => {
         const root = await root$;
         const rootName = root.name || `Root${i}`;
-        const rootLogger = this.logger.child(rootName);
+        const rootLogger = this.logger.child({ root: rootName });
         rootLogger.debug(`Resolving entire the root tree`);
         root.resolveAll();
         rootLogger.debug(`Creating artifacts from descriptor set and root`);

--- a/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
+++ b/packages/loaders/json-schema/src/getDereferencedJSONSchemaFromOperations.ts
@@ -31,6 +31,7 @@ export async function getDereferencedJSONSchemaFromOperations({
   const referencedJSONSchema = await getReferencedJSONSchemaFromOperations({
     operations,
     cwd,
+    logger,
     schemaHeaders,
     ignoreErrorResponses,
     fetchFn,

--- a/packages/plugins/http-cache/src/index.ts
+++ b/packages/plugins/http-cache/src/index.ts
@@ -79,7 +79,7 @@ export default function useHTTPCache<TContext extends Record<string, any>>({
     }
     return false;
   }
-  const pluginLogger = logger?.child('HTTP Cache');
+  const pluginLogger = logger?.child({ plugin: 'HTTP Cache' });
   return {
     onYogaInit({ yoga }) {
       if (yoga.fetchAPI.URLPattern) {

--- a/packages/transports/grpc/src/index.ts
+++ b/packages/transports/grpc/src/index.ts
@@ -233,7 +233,7 @@ export class GrpcTransportHelper extends DisposableStack {
     const grpcObjectByRootJsonName = new Map<string, ReturnType<typeof loadPackageDefinition>>();
     for (let { name, rootJson, loadOptions } of roots) {
       rootJson = typeof rootJson === 'string' ? JSON.parse(rootJson) : rootJson;
-      const rootLogger = this.logger.child(name);
+      const rootLogger = this.logger.child({ root: name });
       grpcObjectByRootJsonName.set(name, this.getGrpcObject({ rootJson, loadOptions, rootLogger }));
     }
     const rootTypes = getRootTypes(schema);

--- a/packages/transports/rest/src/directives/httpOperation.ts
+++ b/packages/transports/rest/src/directives/httpOperation.ts
@@ -100,8 +100,10 @@ export function addHTTPRootFieldResolver(
       args.fields = undefined;
     }
     const logger = context?.logger || globalLogger;
-    const operationLogger = logger.child(`${info.parentType.name}.${info.fieldName}`);
-    operationLogger.debug(`=> Resolving`);
+    const operationLogger = logger.child({
+      operation: `${info.parentType.name}.${info.fieldName}`,
+    });
+    operationLogger.debug(`Resolving`);
     const interpolationData = { root, args, context, env: process.env };
     const interpolatedBaseUrl = stringInterpolator.parse(endpoint, interpolationData);
     const interpolatedPath = stringInterpolator.parse(path, interpolationData);

--- a/packages/transports/rest/src/directives/pubsubOperation.ts
+++ b/packages/transports/rest/src/directives/pubsubOperation.ts
@@ -18,7 +18,7 @@ export function processPubSubOperationAnnotations({
 }: ProcessPubSubOperationAnnotationsOpts) {
   field.subscribe = function pubSubSubscribeFn(root, args, context, info) {
     const logger = context?.logger || globalLogger;
-    const operationLogger = logger.child(`${info.parentType.name}.${field.name}`);
+    const operationLogger = logger.child({ operation: `${info.parentType.name}.${field.name}` });
     const pubsub = context?.pubsub || globalPubsub;
     if (!pubsub) {
       return new TypeError(`You should have PubSub defined in either the config or the context!`);
@@ -37,8 +37,8 @@ export function processPubSubOperationAnnotations({
   };
   field.resolve = function pubSubResolver(root, args, context, info) {
     const logger = context?.logger || globalLogger;
-    const operationLogger = logger.child(`${info.parentType.name}.${field.name}`);
-    operationLogger.debug('Received ', root, ' from ', pubsubTopic);
+    const operationLogger = logger.child({ operation: `${info.parentType.name}.${field.name}` });
+    operationLogger.debug('received', { root, pubsubTopic });
     return root;
   };
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c5d31e8-83ba-4f42-a513-341a80d1fd4b)

`Logger` interface changes that exposed to the user in case of custom logging;
- Now `child` method of `Logger` accepts an object.

So in Hive Gateway we can implement our JSON-based logger.

`DefaultLogger` text-based prettified logger implementation for `Logger` interface;
- `DefaultLogger` implementation prints key value pairs as `[key=value]`
- Timestamp is shown as `[timestamp=XXX]`
- Most of child usages are now `key=value` instead of single string such as `[requestId=XXX]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the identifiers for GraphQL movie search operations so that queries and subscriptions are now clearly distinguished.

- **Refactor**
  - Enhanced log output by switching from simple text formatting to structured, object-based messages for improved clarity.
  - Standardized logger configurations across the system to ensure better traceability and readability in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->