### PR TITLE
fix(compose): do not add `@additionalField` if the field already exists from a subgraph

### DIFF
--- a/.changeset/sad-queens-own.md
+++ b/.changeset/sad-queens-own.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/compose-cli': patch
+---
+
+Do not overwrite existing fields with `@additionalField` directive

--- a/e2e/openapi-javascript-wiki/__snapshots__/openapi-javascript-wiki.test.ts.snap
+++ b/e2e/openapi-javascript-wiki/__snapshots__/openapi-javascript-wiki.test.ts.snap
@@ -74,7 +74,7 @@ type Query @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "
   
   Stability: [experimental](https://www.mediawiki.org/wiki/API_versioning#Experimental)
   """
-  feed_availability: availability @httpOperation(subgraph: "Wiki", path: "/feed/availability", operationSpecificHeaders: [["Accept", "application/json; charset=utf-8; profile=\\"https://www.mediawiki.org/wiki/Specs/Availability/1.0.1\\", application/problem+json"]], httpMethod: GET)
+  feed_availability: availability! @httpOperation(subgraph: "Wiki", path: "/feed/availability", operationSpecificHeaders: [["Accept", "application/json; charset=utf-8; profile=\\"https://www.mediawiki.org/wiki/Specs/Availability/1.0.1\\", application/problem+json"]], httpMethod: GET)
   """
   Returns the previously-stored formula via \`/media/math/check/{type}\` for
   the given hash.

--- a/e2e/openapi-javascript-wiki/mesh.config.ts
+++ b/e2e/openapi-javascript-wiki/mesh.config.ts
@@ -16,6 +16,7 @@ export const composeConfig = defineComposeConfig({
   additionalTypeDefs: /* GraphQL */ `
     extend type Query {
       viewsInPastMonth(project: String!): Int!
+      feed_availability: availability!
     }
   `,
 });

--- a/packages/compose-cli/src/getComposedSchemaFromConfig.ts
+++ b/packages/compose-cli/src/getComposedSchemaFromConfig.ts
@@ -218,8 +218,8 @@ export async function getComposedSchemaFromConfig(config: MeshComposeCLIConfig, 
                   ),
                 };
               }
-              const typeInAncestor = ancestors
-                .toReversed()
+              const typeInAncestor = [...ancestors]
+                .reverse()
                 .find(
                   ancestor =>
                     !Array.isArray(ancestor) &&


### PR DESCRIPTION
When there is a field in the subgraph that is extended in additionalTypeDefs, do not add `@additionalField`

Ref GW-196