### PR TITLE
fix(response-cache): Check for the presence of a cache instance

### DIFF
--- a/.changeset/clear-dryers-nail.md
+++ b/.changeset/clear-dryers-nail.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/plugin-response-cache': patch
+---
+
+Throw an error at gateway initialization time when no cache is configured, but the response-cache
+plugin is enabled.

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -54,7 +54,12 @@ function getShouldCacheResult(
   };
 }
 
-function getCacheForResponseCache(meshCache: KeyValueCache): UseResponseCacheParameter['cache'] {
+function getCacheForResponseCache(meshCache?: KeyValueCache): UseResponseCacheParameter['cache'] {
+  if (!meshCache) {
+    throw new Error(
+      'Response Cache is enabled, but no cache is configured. Please provide a cache instance through the `cache` option.',
+    );
+  }
   return {
     get(responseId) {
       return meshCache.get(`response-cache:${responseId}`);
@@ -178,7 +183,7 @@ export default function useMeshResponseCache(options: ResponseCacheConfig): Gate
  */
 export default function useMeshResponseCache(
   options: YamlConfig.ResponseCacheConfig & {
-    cache: KeyValueCache;
+    cache?: KeyValueCache;
   },
 ): GatewayPlugin;
 export default function useMeshResponseCache(
@@ -186,7 +191,7 @@ export default function useMeshResponseCache(
     | ResponseCacheConfig
     // TODO: This is for v0 compatibility, remove once v1 is released
     | (YamlConfig.ResponseCacheConfig & {
-        cache: KeyValueCache;
+        cache?: KeyValueCache;
       }),
 ): GatewayPlugin {
   const ttlPerType: Record<string, number> = { ...(options as ResponseCacheConfig).ttlPerType };


### PR DESCRIPTION
Related to GW-295

When used with `createGatewayRuntime`, there is no default `cache` instance created, which leads to a unwelcoming `cannot read 'get' of undefined` at query time.

This PR introduces an error at gateway initialization time, so that the gateway doesn't start if a `cache` instance is not configured.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


