### PR TITLE
:bug: Fix linkHref anonymization

### DIFF
--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -588,7 +588,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
               ]?.find(link => link[hateOasConfig.linkNameIdentifier] === linkName);
               if (xLinkObj) {
                 const xLinkHref = xLinkObj[hateOasConfig.linkPathIdentifier];
-                const cleanXLinkHref = xLinkHref.replace(/{[^}]+}/g, '');
+                const cleanXLinkHref = xLinkHref.replace(/{[^}]+}/g, '{}');
                 const deferred = createDeferred<void>();
                 function findActualOperationAndPath(
                   possibleName: string,
@@ -598,7 +598,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
                   let actualOperation: OpenAPIV3.OperationObject;
                   let actualPath: string;
                   for (const path in possibleOasDoc.paths) {
-                    const cleanPath = path.replace(/{[^}]+}/g, '');
+                    const cleanPath = path.replace(/{[^}]+}/g, '{}');
                     if (cleanPath === cleanXLinkHref) {
                       actualPath = path;
                       actualOperation = possibleOasDoc.paths[path][method];


### PR DESCRIPTION
## Description

Fix the HATEOAS link reference anonymization process.

Let's say we have these operations:

- Operation A: `/users/{userId}`
- Operation B: `/users/{id}/contracts/{contractId}`

With A (user) linking through HATEOAS to multiple B (contracts).

There is a double need:

1. To anonymize the argument names (this part was already implemented)
2. Ensure the anonymization process keeps the operationId identifiable (this is the buggy part)

The current HATEOAS href anonymization **removes** arguments, whereas we need to keep track of their presence in order not to target the wrong operations at runtime.

Fixes #8636

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Against a cohesive bundle of 800+ local swaggers.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
