### PR TITLE
:bug: Support 204 responses which have content keys with empty values

### DIFF
--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -464,7 +464,13 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
           operationConfig.headers.Accept = methodObj.produces.join(', ');
         }
 
-        if ('content' in responseObj) {
+        /**
+         * In some specifications, 204 responses have content keys with empty values ({}),
+         * but the OAS rule is that 204 reponses should not have content keys.
+         *
+         * Reference: https://swagger.io/docs/specification/v3_0/describing-responses/ ("Empty Response Body" section)
+         */
+        if ('content' in responseObj && Object.keys(responseObj.content).length !== 0) {
           const responseObjForStatusCode: {
             oneOf: JSONSchemaObject[];
           } = {


### PR DESCRIPTION
## Description

In some specifications, 204 responses have content keys with empty values ({}),
but the OAS rule is that 204 reponses should not have content keys.

Fixes #8637

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested locally with 800+ OpenAPI V3 specs. Some of them having only 204 responses, a few of them having empty values as content keys.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
