### PR TITLE
fix(openapi): support 204 responses which have content keys with empt…

### DIFF
--- a/.changeset/solid-chefs-lay.md
+++ b/.changeset/solid-chefs-lay.md
@@ -1,0 +1,5 @@
+---
+'@omnigraph/openapi': patch
+---
+
+fix(openapi): support 204 responses which have content keys with empty values

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -464,7 +464,14 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
           operationConfig.headers.Accept = methodObj.produces.join(', ');
         }
 
-        if ('content' in responseObj) {
+        /**
+         * The OAS rule is that 204 responses should not specify a content key.
+         * But in the real world, it happens that some specifications present 204 responses with an
+         * empty content key.
+         *
+         * @see https://swagger.io/docs/specification/v3_0/describing-responses/#empty-response-body
+         */
+        if ('content' in responseObj && Object.keys(responseObj.content).length !== 0) {
           const responseObjForStatusCode: {
             oneOf: JSONSchemaObject[];
           } = {

--- a/packages/loaders/openapi/tests/204-response-with-empty-content.test.ts
+++ b/packages/loaders/openapi/tests/204-response-with-empty-content.test.ts
@@ -1,0 +1,17 @@
+import { GraphQLSchema } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { loadGraphQLSchemaFromOpenAPI } from '../src/loadGraphQLSchemaFromOpenAPI.js';
+
+describe('204 response with empty content', () => {
+  let createdSchema: GraphQLSchema;
+  beforeAll(async () => {
+    createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
+      source: './fixtures/204-response-with-empty-content.json',
+      cwd: __dirname,
+    });
+  });
+
+  it('should generate the schema correctly', () => {
+    expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/openapi/tests/__snapshots__/204-response-with-empty-content.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/204-response-with-empty-content.test.ts.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`204 response with empty content should generate the schema correctly 1`] = `
+"schema @transport(subgraph: "test", kind: "rest", location: "/") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
+
+type Query {
+  dummy: String
+}
+
+type Mutation {
+  """ """
+  myOperation: Void @httpOperation(subgraph: "test", path: "/myoperation", httpMethod: PUT)
+}
+
+"""Represents empty values"""
+scalar Void
+
+enum HTTPMethod {
+  GET
+  HEAD
+  POST
+  PUT
+  DELETE
+  CONNECT
+  OPTIONS
+  TRACE
+  PATCH
+}
+
+scalar ObjMap"
+`;

--- a/packages/loaders/openapi/tests/fixtures/204-response-with-empty-content.json
+++ b/packages/loaders/openapi/tests/fixtures/204-response-with-empty-content.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "My operation",
+    "version": "1.0.0",
+    "description": " ",
+    "contact": {}
+  },
+  "tags": [{ "name": "tag" }],
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/myoperation": {
+      "put": {
+        "operationId": "myOperation",
+        "description": " ",
+        "tags": ["tag"],
+        "responses": {
+          "204": { "description": "", "content": {} }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

The OAS rule is that 204 responses should not specify a content key ([reference](https://swagger.io/docs/specification/v3_0/describing-responses/#empty-response-body)).

But in the real world, it happens that some specifications present 204 responses with an empty content key, just like this:

Fixes #8637

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested locally with 800+ OpenAPI V3 specs. Some of them having only 204 responses, a few of them having empty values as content keys.

A test has been added.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
