### PR TITLE
fix(openapi): HATEOAS href anonymization

### DIFF
--- a/.changeset/social-pots-obey.md
+++ b/.changeset/social-pots-obey.md
@@ -1,0 +1,5 @@
+---
+'@omnigraph/openapi': patch
+---
+
+Fix the HATEOAS href anonymizationn

--- a/.changeset/social-pots-obey.md
+++ b/.changeset/social-pots-obey.md
@@ -2,4 +2,6 @@
 '@omnigraph/openapi': patch
 ---
 
-Fix the HATEOAS href anonymizationn
+When there are two operations in the OAS;
+`/products/` and `/products/{id}`
+Due to the bug in the logic, they conflict and the HATEOAS linking can choose the first one without any argument.

--- a/e2e/openapi-hateoas/__snapshots__/openapi-hateoas.test.ts.snap
+++ b/e2e/openapi-hateoas/__snapshots__/openapi-hateoas.test.ts.snap
@@ -66,8 +66,8 @@ type Electronics implements Product @join__type(graph: PRODUCTS) @join__implemen
   price: Float
   supplierId: Int
   supplier: Supplier
-  """Get a product by ID"""
-  self: Product @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
+  """Get all the products"""
+  self: ProductList @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
 }
 
 type ProductLinks @join__type(graph: PRODUCTS) {
@@ -85,6 +85,10 @@ type Supplier @join__type(graph: PRODUCTS) @join__type(graph: SUPPLIERS, key: "i
   address: String @join__field(graph: SUPPLIERS)
 }
 
+type ProductList @join__type(graph: PRODUCTS) {
+  items: [Product]
+}
+
 type Clothing implements Product @join__type(graph: PRODUCTS) @join__implements(graph: PRODUCTS, interface: "Product") {
   material: String
   _links: ProductLinks
@@ -94,16 +98,18 @@ type Clothing implements Product @join__type(graph: PRODUCTS) @join__implements(
   price: Float
   supplierId: Int
   supplier: Supplier
-  """Get a product by ID"""
-  self: Product @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
+  """Get all the products"""
+  self: ProductList @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
 }
 
 type Query @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "Products", kind: "rest", location: "http://localhost:<OASService_port>"}]}) @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "Suppliers", kind: "rest", location: "http://localhost:<OASService_port>"}]}) @join__type(graph: PRODUCTS) @join__type(graph: SUPPLIERS) {
+  """Get all the products"""
+  getProducts: ProductList @httpOperation(subgraph: "Products", path: "/products/", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @join__field(graph: PRODUCTS)
   """Get a product by ID"""
   getProductById(
     """The product ID"""
     id: Int!
-  ): Product @httpOperation(subgraph: "Products", path: "/products/{args.id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @linkResolver(subgraph: "Products", linkResolverMap: "{\\"self\\":{\\"linkObjArgs\\":{\\"id\\":\\"{root['id']}\\"},\\"targetTypeName\\":\\"Query\\",\\"targetFieldName\\":\\"getProductById\\"}}") @join__field(graph: PRODUCTS)
+  ): Product @httpOperation(subgraph: "Products", path: "/products/{args.id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @linkResolver(subgraph: "Products", linkResolverMap: "{\\\"self\\\":{\\\"linkObjArgs\\\":{},\\\"targetTypeName\\\":\\\"Query\\\",\\\"targetFieldName\\\":\\\"getProducts\\\"}}") @join__field(graph: PRODUCTS)
   """Get a supplier by ID"""
   getSupplierById(
     """The supplier ID"""
@@ -119,8 +125,8 @@ interface Product @discriminator(subgraph: "Products", field: "_type", mapping: 
   price: Float
   supplierId: Int
   supplier: Supplier @additionalField @resolveTo(sourceTypeName: "Query", sourceFieldName: "getSupplierById", sourceName: "Suppliers", sourceArgs: {id: "{root['supplierId']}"}, requiredSelectionSet: "{ supplierId }")
-  """Get a product by ID"""
-  self: Product @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
+  """Get all the products"""
+  self: ProductList @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
 }
 
 enum HTTPMethod @join__type(graph: PRODUCTS) @join__type(graph: SUPPLIERS) {

--- a/e2e/openapi-hateoas/__snapshots__/openapi-hateoas.test.ts.snap
+++ b/e2e/openapi-hateoas/__snapshots__/openapi-hateoas.test.ts.snap
@@ -66,8 +66,8 @@ type Electronics implements Product @join__type(graph: PRODUCTS) @join__implemen
   price: Float
   supplierId: Int
   supplier: Supplier
-  """Get all the products"""
-  self: ProductList @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
+  """Get a product by ID"""
+  self: Product @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
 }
 
 type ProductLinks @join__type(graph: PRODUCTS) {
@@ -85,10 +85,6 @@ type Supplier @join__type(graph: PRODUCTS) @join__type(graph: SUPPLIERS, key: "i
   address: String @join__field(graph: SUPPLIERS)
 }
 
-type ProductList @join__type(graph: PRODUCTS) {
-  items: [Product]
-}
-
 type Clothing implements Product @join__type(graph: PRODUCTS) @join__implements(graph: PRODUCTS, interface: "Product") {
   material: String
   _links: ProductLinks
@@ -98,8 +94,8 @@ type Clothing implements Product @join__type(graph: PRODUCTS) @join__implements(
   price: Float
   supplierId: Int
   supplier: Supplier
-  """Get all the products"""
-  self: ProductList @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
+  """Get a product by ID"""
+  self: Product @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
 }
 
 type Query @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "Products", kind: "rest", location: "http://localhost:<OASService_port>"}]}) @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "Suppliers", kind: "rest", location: "http://localhost:<OASService_port>"}]}) @join__type(graph: PRODUCTS) @join__type(graph: SUPPLIERS) {
@@ -109,12 +105,16 @@ type Query @extraSchemaDefinitionDirective(directives: {transport: [{subgraph: "
   getProductById(
     """The product ID"""
     id: Int!
-  ): Product @httpOperation(subgraph: "Products", path: "/products/{args.id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @linkResolver(subgraph: "Products", linkResolverMap: "{\\\"self\\\":{\\\"linkObjArgs\\\":{},\\\"targetTypeName\\\":\\\"Query\\\",\\\"targetFieldName\\\":\\\"getProducts\\\"}}") @join__field(graph: PRODUCTS)
+  ): Product @httpOperation(subgraph: "Products", path: "/products/{args.id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @linkResolver(subgraph: "Products", linkResolverMap: "{\\\"self\\\":{\\\"linkObjArgs\\\":{\\\"id\\\":\\\"{root['id']}\\\"},\\\"targetTypeName\\\":\\\"Query\\\",\\\"targetFieldName\\\":\\\"getProductById\\\"}}") @join__field(graph: PRODUCTS)
   """Get a supplier by ID"""
   getSupplierById(
     """The supplier ID"""
     id: Int!
   ): Supplier @httpOperation(subgraph: "Suppliers", path: "/suppliers/{args.id}", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET) @merge(subgraph: "Suppliers", keyField: "id", keyArg: "id") @join__field(graph: SUPPLIERS)
+}
+
+type ProductList @join__type(graph: PRODUCTS) {
+  items: [Product]
 }
 
 interface Product @discriminator(subgraph: "Products", field: "_type", mapping: [["ELECTRONICS", "Electronics"], ["CLOTHING", "Clothing"]]) @join__type(graph: PRODUCTS) {
@@ -125,8 +125,8 @@ interface Product @discriminator(subgraph: "Products", field: "_type", mapping: 
   price: Float
   supplierId: Int
   supplier: Supplier @additionalField @resolveTo(sourceTypeName: "Query", sourceFieldName: "getSupplierById", sourceName: "Suppliers", sourceArgs: {id: "{root['supplierId']}"}, requiredSelectionSet: "{ supplierId }")
-  """Get all the products"""
-  self: ProductList @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
+  """Get a product by ID"""
+  self: Product @oas_link(subgraph: "Products", defaultRootType: "Query", defaultField: "getProductById")
 }
 
 enum HTTPMethod @join__type(graph: PRODUCTS) @join__type(graph: SUPPLIERS) {

--- a/e2e/openapi-hateoas/products.json
+++ b/e2e/openapi-hateoas/products.json
@@ -5,6 +5,24 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/products/": {
+      "get": {
+        "operationId": "getProducts",
+        "summary": "Get all the products",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/products/{id}": {
       "get": {
         "operationId": "getProductById",
@@ -37,6 +55,17 @@
   },
   "components": {
     "schemas": {
+      "ProductList": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Product"
+            }
+          }
+        }
+      },
       "Product": {
         "type": "object",
         "discriminator": {

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -588,7 +588,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
               ]?.find(link => link[hateOasConfig.linkNameIdentifier] === linkName);
               if (xLinkObj) {
                 const xLinkHref = xLinkObj[hateOasConfig.linkPathIdentifier];
-                const cleanXLinkHref = xLinkHref.replace(/{[^}]+}/g, '');
+                const cleanXLinkHref = xLinkHref.replace(/{[^}]+}/g, '{}');
                 const deferred = createDeferred<void>();
                 function findActualOperationAndPath(
                   possibleName: string,
@@ -598,7 +598,7 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
                   let actualOperation: OpenAPIV3.OperationObject;
                   let actualPath: string;
                   for (const path in possibleOasDoc.paths) {
-                    const cleanPath = path.replace(/{[^}]+}/g, '');
+                    const cleanPath = path.replace(/{[^}]+}/g, '{}');
                     if (cleanPath === cleanXLinkHref) {
                       actualPath = path;
                       actualOperation = possibleOasDoc.paths[path][method];


### PR DESCRIPTION
## Description

Fix the HATEOAS link reference anonymization process.

Let's say we have these operations:

- Operation A: `/users/{userId}`
- Operation B: `/users/{id}/contracts/{contractId}`

With A (user) linking through HATEOAS to multiple B (contracts).

There is a double need:

1. To anonymize the argument names (this part was already implemented)
2. Ensure the anonymization process keeps the operationId identifiable (this is the buggy part)

The current HATEOAS href anonymization **removes** arguments, whereas we need to keep track of their presence in order not to target the wrong operations at runtime.

Fixes #8636

**In the first commit, it shows how the issue is reproduces, and the other one fixes it.**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Against a cohesive bundle of 800+ local swaggers.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
