### PR TITLE
fix(mysql): Propagate tables and tableNames options to loader

### DIFF
--- a/.changeset/some-spoons-lead.md
+++ b/.changeset/some-spoons-lead.md
@@ -1,0 +1,6 @@
+---
+'@graphql-mesh/mysql': patch
+'@omnigraph/mysql': patch
+---
+
+Fix tables and tableFields config options inside mysql handler and schema loader

--- a/packages/legacy/handlers/mysql/src/index.ts
+++ b/packages/legacy/handlers/mysql/src/index.ts
@@ -64,6 +64,8 @@ export default class MySQLHandler implements MeshHandler {
       }
       return loadGraphQLSchemaFromMySQL(this.name, {
         endpoint: endpointUrl.toString(),
+        tables: this.config.tables,
+        tableFields: this.config.tableFields,
         ssl: {
           rejectUnauthorized: this.config.ssl?.rejectUnauthorized,
           caPath: this.config.ssl?.ca,

--- a/packages/legacy/handlers/mysql/test/handler.spec.ts
+++ b/packages/legacy/handlers/mysql/test/handler.spec.ts
@@ -1,0 +1,72 @@
+import type { GraphQLSchema } from 'graphql';
+import InMemoryLRUCache from '@graphql-mesh/cache-inmemory-lru';
+import MySQLHandler from '@graphql-mesh/mysql';
+import { InMemoryStoreStorageAdapter, MeshStore } from '@graphql-mesh/store';
+import type { YamlConfig } from '@graphql-mesh/types';
+import { loadFromModuleExportExpression } from '@graphql-mesh/utils';
+import { loadGraphQLSchemaFromMySQL, type LoadGraphQLSchemaFromMySQLOpts } from '@omnigraph/mysql';
+
+jest.mock('@graphql-mesh/utils');
+jest.mock('@omnigraph/mysql');
+
+const noOpFunction: any = () => {};
+
+describe('mysql', () => {
+  let store: MeshStore;
+  using cache = new InMemoryLRUCache();
+  beforeEach(() => {
+    store = new MeshStore('.mesh', new InMemoryStoreStorageAdapter(), {
+      readonly: false,
+      validate: false,
+    });
+  });
+
+  it('correctly builds schema from loadGraphQLSchemaFromMySQL after passing configuration', async () => {
+    const graphQLSchemaMock: GraphQLSchema = {
+      description: 'someGraphQLSchemaMock',
+    } as any;
+
+    const configMock: YamlConfig.MySQLHandler = {
+      database: 'testdb',
+      tables: ['testTable'],
+      tableFields: [
+        {
+          table: 'testTable',
+          fields: ['testField'],
+        },
+      ],
+      ssl: {
+        rejectUnauthorized: true,
+        ca: 'someCA',
+      },
+    };
+
+    jest.mocked(loadGraphQLSchemaFromMySQL).mockResolvedValue(graphQLSchemaMock);
+
+    const handler = new MySQLHandler({
+      name: 'test',
+      config: configMock,
+      baseDir: __dirname,
+      cache,
+      pubsub: noOpFunction,
+      store,
+      importFn: noOpFunction,
+      logger: noOpFunction,
+    });
+
+    const expectedOptions: LoadGraphQLSchemaFromMySQLOpts = {
+      endpoint: 'mysqls://localhost:3306/testdb',
+      ssl: {
+        rejectUnauthorized: configMock.ssl!.rejectUnauthorized,
+        caPath: configMock.ssl!.ca,
+      },
+      tables: configMock.tables,
+      tableFields: configMock.tableFields,
+    };
+
+    const { schema } = await handler.getMeshSource();
+
+    expect(schema).toBe(graphQLSchemaMock);
+    expect(loadGraphQLSchemaFromMySQL).toHaveBeenCalledWith('test', expectedOptions);
+  });
+});

--- a/packages/loaders/mysql/src/schema.ts
+++ b/packages/loaders/mysql/src/schema.ts
@@ -36,6 +36,7 @@ export interface LoadGraphQLSchemaFromMySQLOpts {
   endpoint: string;
   ssl?: MySQLSSLOptions;
   tables?: string[];
+  tableFields?: TableFieldConfig[];
 }
 
 export async function loadGraphQLSchemaFromMySQL(
@@ -97,6 +98,7 @@ export async function loadGraphQLSchemaFromMySQL(
         subgraphName,
         tableName,
         tables,
+        tableFieldsConfig: opts.tableFields,
         schemaComposer,
         introspectionConnection,
         autoIncrementedColumns,

--- a/packages/loaders/mysql/tests/__snapshots__/schema.test.ts.snap
+++ b/packages/loaders/mysql/tests/__snapshots__/schema.test.ts.snap
@@ -1,0 +1,944 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when the tableFields option is provided in order to filter some fields out 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+  posts(limit: Int, offset: Int, where: posts_WhereInput, orderBy: posts_OrderByInput): [posts] @mysqlSelect(subgraph: "test", table: "posts")
+  count_posts(where: posts_WhereInput): Int @mysqlCount(subgraph: "test", table: "posts")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  username: String!
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  username: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  username: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+"""Post table"""
+type posts {
+  post_id: Int!
+}
+
+"""Post table"""
+input posts_WhereInput {
+  post_id: String
+}
+
+"""Post table"""
+input posts_OrderByInput {
+  post_id: OrderBy
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+  insert_posts(posts: posts_InsertInput!): posts @mysqlInsert(subgraph: "test", table: "posts", primaryKeys: [])
+  update_posts(posts: posts_UpdateInput!, where: posts_WhereInput): posts @mysqlUpdate(subgraph: "test", table: "posts")
+  delete_posts(where: posts_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "posts")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  username: String!
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  username: String
+}
+
+"""Post table"""
+input posts_InsertInput {
+  post_id: Int!
+}
+
+"""Post table"""
+input posts_UpdateInput {
+  post_id: Int
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when the tables option is provided in order to filter some tables out 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+  posts(limit: Int, offset: Int, where: posts_WhereInput, orderBy: posts_OrderByInput): [posts] @mysqlSelect(subgraph: "test", table: "posts")
+  count_posts(where: posts_WhereInput): Int @mysqlCount(subgraph: "test", table: "posts")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  username: String!
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  username: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  username: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+"""Post table"""
+type posts {
+  post_id: Int!
+  by_user_id: Int!
+}
+
+"""Post table"""
+input posts_WhereInput {
+  post_id: String
+  by_user_id: String
+}
+
+"""Post table"""
+input posts_OrderByInput {
+  post_id: OrderBy
+  by_user_id: OrderBy
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+  insert_posts(posts: posts_InsertInput!): posts @mysqlInsert(subgraph: "test", table: "posts", primaryKeys: ["post_id"])
+  update_posts(posts: posts_UpdateInput!, where: posts_WhereInput): posts @mysqlUpdate(subgraph: "test", table: "posts")
+  delete_posts(where: posts_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "posts")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  username: String!
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  username: String
+}
+
+"""Post table"""
+input posts_InsertInput {
+  post_id: Int!
+  by_user_id: Int!
+}
+
+"""Post table"""
+input posts_UpdateInput {
+  post_id: Int
+  by_user_id: Int
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there are ENUM fields in the mysql definition 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  status: users_status!
+}
+
+enum users_status {
+  active
+  inactive
+  pending
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  status: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  status: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  status: users_status
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  status: users_status
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there are SET fields in the mysql definition 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  """Primary key"""
+  user_id: Int!
+  """User tags"""
+  tags: users_tags
+}
+
+enum users_tags {
+  tag1
+  tag2
+  tag3
+}
+
+"""User table"""
+input users_WhereInput {
+  """Primary key"""
+  user_id: String
+  """User tags"""
+  tags: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  """Primary key"""
+  user_id: OrderBy
+  """User tags"""
+  tags: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  """Primary key"""
+  user_id: Int
+  """User tags"""
+  tags: users_tags
+}
+
+"""User table"""
+input users_UpdateInput {
+  """Primary key"""
+  user_id: Int
+  """User tags"""
+  tags: users_tags
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there are json fields in the mysql definition 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  """Primary key"""
+  user_id: Int!
+  """JSON data field"""
+  data_table_field: JSON
+}
+
+"""
+The \`JSON\` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+"""User table"""
+input users_WhereInput {
+  """Primary key"""
+  user_id: String
+  """JSON data field"""
+  data_table_field: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  """Primary key"""
+  user_id: OrderBy
+  """JSON data field"""
+  data_table_field: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  """Primary key"""
+  user_id: Int
+  """JSON data field"""
+  data_table_field: JSON
+}
+
+"""User table"""
+input users_UpdateInput {
+  """Primary key"""
+  user_id: Int
+  """JSON data field"""
+  data_table_field: JSON
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there are multiple tables and a foreign key relationship 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+  posts(limit: Int, offset: Int, where: posts_WhereInput, orderBy: posts_OrderByInput): [posts] @mysqlSelect(subgraph: "test", table: "posts")
+  count_posts(where: posts_WhereInput): Int @mysqlCount(subgraph: "test", table: "posts")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  username: String!
+  posts(limit: Int, offset: Int, where: posts_WhereInput, orderBy: posts_OrderByInput): [posts] @mysqlSelect(subgraph: "test", table: "posts", columnMap: [["by_user_id", "user_id"]])
+}
+
+"""Post table"""
+type posts {
+  post_id: Int!
+  by_user_id: Int!
+  users(where: users_WhereInput, orderBy: users_OrderByInput, limit: Int, offset: Int): [users] @mysqlSelect(subgraph: "test", table: "users", columnMap: [["user_id", "by_user_id"]]) @mysqlTableForeign(subgraph: "test", columnName: "by_user_id")
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  username: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  username: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+"""Post table"""
+input posts_WhereInput {
+  post_id: String
+  by_user_id: String
+}
+
+"""Post table"""
+input posts_OrderByInput {
+  post_id: OrderBy
+  by_user_id: OrderBy
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+  insert_posts(posts: posts_InsertInput!): posts @mysqlInsert(subgraph: "test", table: "posts", primaryKeys: ["post_id"])
+  update_posts(posts: posts_UpdateInput!, where: posts_WhereInput): posts @mysqlUpdate(subgraph: "test", table: "posts")
+  delete_posts(where: posts_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "posts")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  username: String!
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  username: String
+}
+
+"""Post table"""
+input posts_InsertInput {
+  post_id: Int!
+  by_user_id: Int!
+}
+
+"""Post table"""
+input posts_UpdateInput {
+  post_id: Int
+  by_user_id: Int
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there is a field with a comment 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  """A specific comment for user_id"""
+  user_id: Int!
+  user_name: String!
+}
+
+"""User table"""
+input users_WhereInput {
+  """A specific comment for user_id"""
+  user_id: String
+  user_name: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  """A specific comment for user_id"""
+  user_id: OrderBy
+  user_name: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  """A specific comment for user_id"""
+  user_id: Int!
+  user_name: String
+}
+
+"""User table"""
+input users_UpdateInput {
+  """A specific comment for user_id"""
+  user_id: Int
+  user_name: String
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there is a field with a non-nullable value and a default value 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  user_name: String!
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  user_name: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  user_name: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  user_name: String
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  user_name: String
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there is a field with a nullable value and a default value 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  user_name: String
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  user_name: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  user_name: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  user_name: String
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  user_name: String
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there is a field with a nullable value and no default value 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  user_name: String
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  user_name: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  user_name: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  user_name: String
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  user_name: String
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there is a single basic mysql table 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+}"
+`;
+
+exports[`loadGraphQLSchemaFromMySQL should correctly generate graphql schema from a mysql schema when there is an auto increment field in the mysql definition 1`] = `
+"schema @transport(subgraph: "test", kind: "mysql", location: "mysql://test:test@localhost:3306/testdb") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @transport(subgraph: String, kind: String, location: String) repeatable on SCHEMA
+
+directive @mysqlSelect(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlInsert(subgraph: String, table: String, primaryKeys: [String]) on FIELD_DEFINITION
+
+directive @mysqlUpdate(subgraph: String, table: String, columnMap: [[String]]) on FIELD_DEFINITION
+
+directive @mysqlDelete(subgraph: String, table: String) on FIELD_DEFINITION
+
+directive @mysqlTableForeign(subgraph: String, columnName: String) on FIELD_DEFINITION
+
+directive @mysqlCount(subgraph: String, table: String) on FIELD_DEFINITION
+
+type Query {
+  users(limit: Int, offset: Int, where: users_WhereInput, orderBy: users_OrderByInput): [users] @mysqlSelect(subgraph: "test", table: "users")
+  count_users(where: users_WhereInput): Int @mysqlCount(subgraph: "test", table: "users")
+}
+
+"""User table"""
+type users {
+  user_id: Int!
+  user_sequence_id: Int!
+}
+
+"""User table"""
+input users_WhereInput {
+  user_id: String
+  user_sequence_id: String
+}
+
+"""User table"""
+input users_OrderByInput {
+  user_id: OrderBy
+  user_sequence_id: OrderBy
+}
+
+enum OrderBy {
+  asc
+  desc
+}
+
+type Mutation {
+  insert_users(users: users_InsertInput!): users @mysqlInsert(subgraph: "test", table: "users", primaryKeys: ["user_id"])
+  update_users(users: users_UpdateInput!, where: users_WhereInput): users @mysqlUpdate(subgraph: "test", table: "users")
+  delete_users(where: users_WhereInput): Boolean @mysqlDelete(subgraph: "test", table: "users")
+}
+
+"""User table"""
+input users_InsertInput {
+  user_id: Int!
+  user_sequence_id: Int
+}
+
+"""User table"""
+input users_UpdateInput {
+  user_id: Int
+  user_sequence_id: Int
+}"
+`;

--- a/packages/loaders/mysql/tests/schema.test.ts
+++ b/packages/loaders/mysql/tests/schema.test.ts
@@ -1,0 +1,947 @@
+import { getNamedType, isInputObjectType, isNonNullType, isObjectType } from 'graphql';
+import { upgrade } from 'mysql-utilities';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { loadGraphQLSchemaFromMySQL } from '../src/schema.js';
+
+jest.mock('mysql', () => ({
+  // We start with an empty connection mock, we will override it in the mockDatabaseUpgrade function
+  createConnection: jest.fn(() => ({})),
+}));
+
+// See mockDatabaseUpgrade for the actual mocks
+jest.mock('mysql-utilities');
+
+jest.mock('@graphql-mesh/cross-helpers', () => ({
+  fs: {
+    readFileSync: jest.fn(),
+  },
+  util: {
+    // We do not promisify, the functions passed in are already promise-based for simplicity
+    promisify: jest.fn(fn => fn),
+  },
+}));
+
+// Mock transport-mysql
+jest.mock('@graphql-mesh/transport-mysql', () => ({
+  getConnectionOptsFromEndpointUri: jest.fn(() => ({
+    host: 'localhost',
+    port: 3306,
+    user: 'test',
+    password: 'test',
+    database: 'testdb',
+    protocol: 'mysql:',
+  })),
+}));
+
+const mockDatabaseUpgrade = (
+  options: Partial<{
+    databaseTables: jest.Mock;
+    fields: jest.Mock;
+    foreign: jest.Mock;
+    queryKeyValue: jest.Mock;
+    end: jest.Mock;
+  }>,
+) => {
+  jest.mocked(upgrade).mockImplementationOnce(connection => {
+    connection.databaseTables = options.databaseTables ?? jest.fn();
+    connection.fields = options.fields ?? jest.fn();
+    connection.end = options.end ?? jest.fn();
+
+    // By default there are no foreign keys. Override this method inside the individual tests
+    connection.foreign = options.foreign ?? jest.fn(() => ({}));
+    // By default there are no auto incremented columns. Override this method inside the individual tests
+    connection.queryKeyValue = options.queryKeyValue ?? jest.fn(() => ({}));
+  });
+};
+
+const loaderParamsDefaultMock: Parameters<typeof loadGraphQLSchemaFromMySQL> = [
+  'test',
+  {
+    endpoint: 'mysql://test:test@localhost:3306/testdb',
+  },
+];
+
+describe('loadGraphQLSchemaFromMySQL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('should correctly generate graphql schema from a mysql schema', () => {
+    it('when there is a single basic mysql table', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+          },
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot();
+    });
+
+    it('when there are multiple tables and a foreign key relationship', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+          posts: {
+            TABLE_NAME: 'posts',
+            TABLE_COMMENT: 'Post table',
+          },
+        }),
+        fields: jest
+          .fn()
+          .mockResolvedValueOnce({
+            user_id: {
+              Field: 'user_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Key: 'PRI',
+              Default: null,
+            },
+            username: {
+              Field: 'username',
+              Type: 'varchar(255)',
+              Null: 'NO',
+              Default: null,
+            },
+          })
+          .mockResolvedValueOnce({
+            post_id: {
+              Field: 'post_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Key: 'PRI',
+              Default: null,
+            },
+            by_user_id: {
+              Field: 'by_user_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Default: null,
+            },
+          }),
+        foreign: jest.fn(tableName => {
+          if (tableName === 'posts') {
+            return {
+              fk_user_posts: {
+                COLUMN_NAME: 'by_user_id',
+                REFERENCED_TABLE_NAME: 'users',
+                REFERENCED_COLUMN_NAME: 'user_id',
+              },
+            };
+          } else {
+            return {};
+          }
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot();
+    });
+
+    it('when the tables option is provided in order to filter some tables out', async () => {
+      const filteredOutTableName = 'comments_table_name';
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+          posts: {
+            TABLE_NAME: 'posts',
+            TABLE_COMMENT: 'Post table',
+          },
+          [filteredOutTableName]: {
+            TABLE_NAME: filteredOutTableName,
+            TABLE_COMMENT: 'Comment table',
+          },
+        }),
+        fields: jest
+          .fn()
+          .mockResolvedValueOnce({
+            user_id: {
+              Field: 'user_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Key: 'PRI',
+              Default: null,
+            },
+            username: {
+              Field: 'username',
+              Type: 'varchar(255)',
+              Null: 'NO',
+              Default: null,
+            },
+          })
+          .mockResolvedValueOnce({
+            post_id: {
+              Field: 'post_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Key: 'PRI',
+              Default: null,
+            },
+            by_user_id: {
+              Field: 'by_user_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Default: null,
+            },
+          }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(loaderParamsDefaultMock[0], {
+        ...loaderParamsDefaultMock[1],
+        tables: ['users', 'posts'],
+      });
+
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      expect(createdSchema).toBeDefined();
+      expect(schemaString).not.toContain(filteredOutTableName);
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when the tableFields option is provided in order to filter some fields out', async () => {
+      const filteredOutFieldName = 'by_user_id';
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+          posts: {
+            TABLE_NAME: 'posts',
+            TABLE_COMMENT: 'Post table',
+          },
+        }),
+        fields: jest
+          .fn()
+          .mockResolvedValueOnce({
+            user_id: {
+              Field: 'user_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Key: 'PRI',
+              Default: null,
+            },
+            username: {
+              Field: 'username',
+              Type: 'varchar(255)',
+              Null: 'NO',
+              Default: null,
+            },
+          })
+          .mockResolvedValueOnce({
+            post_id: {
+              Field: 'post_id',
+              Type: 'int(11)',
+              Null: 'NO',
+              Default: null,
+            },
+            [filteredOutFieldName]: {
+              Field: filteredOutFieldName,
+              Type: 'int(11)',
+              Null: 'NO',
+              Default: null,
+            },
+          }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(loaderParamsDefaultMock[0], {
+        ...loaderParamsDefaultMock[1],
+        tableFields: [{ table: 'posts', fields: ['post_id'] }],
+      });
+
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      expect(schemaString).not.toContain(filteredOutFieldName);
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when there are ENUM fields in the mysql definition', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+          },
+          status: {
+            Field: 'status',
+            Type: "enum('active','inactive','pending')",
+            Null: 'NO',
+            Key: '',
+            Default: 'active',
+            Extra: '',
+          },
+        }),
+      });
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      expect(schemaString).toContain('enum users_status');
+      expect(schemaString).toContain('active');
+      expect(schemaString).toContain('inactive');
+      expect(schemaString).toContain('pending');
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when there are SET fields in the mysql definition', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+            Extra: 'auto_increment',
+            Comment: 'Primary key',
+          },
+          tags: {
+            Field: 'tags',
+            Type: "set('tag1','tag2','tag3')",
+            Null: 'YES',
+            Key: '',
+            Default: null,
+            Extra: '',
+            Comment: 'User tags',
+          },
+        }),
+        queryKeyValue: jest.fn().mockResolvedValueOnce({
+          users: 'user_id',
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      expect(schemaString).toContain('enum users_tags');
+      expect(schemaString).toContain('tag1');
+      expect(schemaString).toContain('tag2');
+      expect(schemaString).toContain('tag3');
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when there are json fields in the mysql definition', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+            Extra: 'auto_increment',
+            Comment: 'Primary key',
+          },
+          data_table_field: {
+            Field: 'data_table_field',
+            Type: 'json',
+            Null: 'YES',
+            Default: null,
+            Extra: '',
+            Comment: 'JSON data field',
+          },
+        }),
+        queryKeyValue: jest.fn().mockResolvedValueOnce({
+          users: 'user_id',
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      expect(schemaString).toContain('data_table_field: JSON');
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when there is an auto increment field in the mysql definition', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+          },
+          user_sequence_id: {
+            Field: 'user_sequence_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Default: null,
+            Extra: 'auto_increment',
+          },
+        }),
+        queryKeyValue: jest.fn().mockImplementationOnce(sqlString => {
+          if (sqlString.includes('auto_increment')) {
+            return {
+              users: 'user_sequence_id',
+            };
+          }
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+
+      // AST check: Verify that the users_InsertInput type has the correct field structure
+      const usersInsertInputType = createdSchema.getType('users_InsertInput');
+      expect(usersInsertInputType).toBeDefined();
+      expect(isInputObjectType(usersInsertInputType)).toBe(true);
+
+      if (isInputObjectType(usersInsertInputType)) {
+        const fields = usersInsertInputType.getFields();
+
+        // Check that user_id field exists and is required (non-null)
+        expect(fields.user_id).toBeDefined();
+        expect(isNonNullType(fields.user_id.type)).toBe(true);
+        expect(getNamedType(fields.user_id.type).name).toBe('Int');
+
+        // Check that user_sequence_id field exists and is optional (nullable)
+        expect(fields.user_sequence_id).toBeDefined();
+        expect(isNonNullType(fields.user_sequence_id.type)).toBe(false);
+        expect(getNamedType(fields.user_sequence_id.type).name).toBe('Int');
+      }
+
+      expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot();
+    });
+
+    it('when there is a field with a nullable value and no default value', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'No',
+            Key: 'PRI',
+            Default: null,
+          },
+          user_name: {
+            Field: 'user_name',
+            Type: 'varchar(255)',
+            Null: 'YES',
+            Default: null,
+          },
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      const usersType = createdSchema.getType('users');
+      const usersInsertInputType = createdSchema.getType('users_InsertInput');
+
+      expect(usersType).toBeDefined();
+      expect(isObjectType(usersType)).toBe(true);
+
+      expect(usersInsertInputType).toBeDefined();
+      expect(isInputObjectType(usersInsertInputType)).toBe(true);
+
+      if (isObjectType(usersType)) {
+        const fields = usersType.getFields();
+        expect(fields.user_name).toBeDefined();
+        expect(isNonNullType(fields.user_name.type)).toBe(false);
+        expect(getNamedType(fields.user_name.type).name).toBe('String');
+      }
+      if (isInputObjectType(usersInsertInputType)) {
+        const fields = usersInsertInputType.getFields();
+        expect(fields.user_name).toBeDefined();
+        expect(isNonNullType(fields.user_name.type)).toBe(false);
+        expect(getNamedType(fields.user_name.type).name).toBe('String');
+      }
+
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when there is a field with a nullable value and a default value', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+          },
+          user_name: {
+            Field: 'user_name',
+            Type: 'varchar(255)',
+            Null: 'YES',
+            Default: 'default_guest_user_name',
+          },
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      const usersInsertInputType = createdSchema.getType('users_InsertInput');
+      const usersType = createdSchema.getType('users');
+
+      expect(usersType).toBeDefined();
+      expect(isObjectType(usersType)).toBe(true);
+
+      expect(usersInsertInputType).toBeDefined();
+      expect(isInputObjectType(usersInsertInputType)).toBe(true);
+
+      if (isInputObjectType(usersInsertInputType)) {
+        const fields = usersInsertInputType.getFields();
+        expect(fields.user_name).toBeDefined();
+        expect(isNonNullType(fields.user_name.type)).toBe(false);
+        expect(getNamedType(fields.user_name.type).name).toBe('String');
+      }
+
+      if (isObjectType(usersType)) {
+        const fields = usersType.getFields();
+        expect(fields.user_name).toBeDefined();
+        expect(isNonNullType(fields.user_name.type)).toBe(false);
+        expect(getNamedType(fields.user_name.type).name).toBe('String');
+      }
+
+      expect(schemaString).toMatchSnapshot();
+    });
+
+    it('when there is a field with a non-nullable value and a default value', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+          },
+          user_name: {
+            Field: 'user_name',
+            Type: 'varchar(255)',
+            Null: 'NO',
+            Default: 'default_guest_user_name',
+          },
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const usersInsertInputType = createdSchema.getType('users_InsertInput');
+      expect(usersInsertInputType).toBeDefined();
+      expect(isInputObjectType(usersInsertInputType)).toBe(true);
+
+      const usersType = createdSchema.getType('users');
+
+      expect(usersType).toBeDefined();
+      expect(isObjectType(usersType)).toBe(true);
+
+      expect(usersInsertInputType).toBeDefined();
+      expect(isInputObjectType(usersInsertInputType)).toBe(true);
+
+      if (isInputObjectType(usersInsertInputType)) {
+        const fields = usersInsertInputType.getFields();
+        expect(fields.user_name).toBeDefined();
+        expect(isNonNullType(fields.user_name.type)).toBe(false);
+      }
+
+      if (isObjectType(usersType)) {
+        const fields = usersType.getFields();
+        expect(fields.user_name).toBeDefined();
+        expect(isNonNullType(fields.user_name.type)).toBe(true);
+      }
+
+      expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot();
+    });
+
+    it('when there is a field with a comment', async () => {
+      const userIdComment = 'A specific comment for user_id';
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          user_id: {
+            Field: 'user_id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+            Default: null,
+            Comment: userIdComment,
+          },
+          user_name: {
+            Field: 'user_name',
+            Type: 'varchar(255)',
+            Null: 'NO',
+          },
+        }),
+      });
+
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+      expect(schemaString).toContain(userIdComment);
+      expect(schemaString).toMatchSnapshot();
+    });
+  });
+
+  describe('should correctly map MySQL types to GraphQL types', () => {
+    it('should map MySQL types to GraphQL types correctly', async () => {
+      mockDatabaseUpgrade({
+        databaseTables: jest.fn().mockResolvedValueOnce({
+          users: {
+            TABLE_NAME: 'users',
+            TABLE_COMMENT: 'User table',
+          },
+        }),
+        fields: jest.fn().mockResolvedValueOnce({
+          id: {
+            Field: 'id',
+            Type: 'int(11)',
+            Null: 'NO',
+            Key: 'PRI',
+          },
+          name: {
+            Field: 'name',
+            Type: 'varchar(255)',
+            Null: 'NO',
+          },
+          email: {
+            Field: 'email',
+            Type: 'varchar(255)',
+            Null: 'YES',
+          },
+          age: {
+            Field: 'age',
+            Type: 'tinyint unsigned',
+            Null: 'YES',
+          },
+          balance: {
+            Field: 'balance',
+            Type: 'decimal(10,2)',
+            Null: 'YES',
+          },
+          data: {
+            Field: 'data',
+            Type: 'json',
+            Null: 'YES',
+          },
+          created_at: {
+            Field: 'created_at',
+            Type: 'datetime',
+            Null: 'NO',
+          },
+          updated_at: {
+            Field: 'updated_at',
+            Type: 'timestamp',
+            Null: 'YES',
+          },
+          is_active: {
+            Field: 'is_active',
+            Type: 'boolean',
+            Null: 'NO',
+          },
+          bigint_field: {
+            Field: 'bigint_field',
+            Type: 'bigint',
+            Null: 'YES',
+          },
+          bigint_unsigned_field: {
+            Field: 'bigint_unsigned_field',
+            Type: 'bigint unsigned',
+            Null: 'YES',
+          },
+          binary_field: {
+            Field: 'binary_field',
+            Type: 'binary(255)',
+            Null: 'YES',
+          },
+          bit_field: {
+            Field: 'bit_field',
+            Type: 'bit(1)',
+            Null: 'YES',
+          },
+          blob_field: {
+            Field: 'blob_field',
+            Type: 'blob',
+            Null: 'YES',
+          },
+          bool_field: {
+            Field: 'bool_field',
+            Type: 'bool',
+            Null: 'YES',
+          },
+          char_field: {
+            Field: 'char_field',
+            Type: 'char(10)',
+            Null: 'YES',
+          },
+          date_field: {
+            Field: 'date_field',
+            Type: 'date',
+            Null: 'YES',
+          },
+          dec_field: {
+            Field: 'dec_field',
+            Type: 'dec(10,2)',
+            Null: 'YES',
+          },
+          dec_unsigned_field: {
+            Field: 'dec_unsigned_field',
+            Type: 'dec unsigned',
+            Null: 'YES',
+          },
+          decimal_unsigned_field: {
+            Field: 'decimal_unsigned_field',
+            Type: 'decimal unsigned',
+            Null: 'YES',
+          },
+          double_field: {
+            Field: 'double_field',
+            Type: 'double',
+            Null: 'YES',
+          },
+          double_unsigned_field: {
+            Field: 'double_unsigned_field',
+            Type: 'double unsigned',
+            Null: 'YES',
+          },
+          float_field: {
+            Field: 'float_field',
+            Type: 'float',
+            Null: 'YES',
+          },
+          float_unsigned_field: {
+            Field: 'float_unsigned_field',
+            Type: 'float unsigned',
+            Null: 'YES',
+          },
+          int_unsigned_field: {
+            Field: 'int_unsigned_field',
+            Type: 'int unsigned',
+            Null: 'YES',
+          },
+          integer_field: {
+            Field: 'integer_field',
+            Type: 'integer',
+            Null: 'YES',
+          },
+          integer_unsigned_field: {
+            Field: 'integer_unsigned_field',
+            Type: 'integer unsigned',
+            Null: 'YES',
+          },
+          longblob_field: {
+            Field: 'longblob_field',
+            Type: 'longblob',
+            Null: 'YES',
+          },
+          longtext_field: {
+            Field: 'longtext_field',
+            Type: 'longtext',
+            Null: 'YES',
+          },
+          mediumblob_field: {
+            Field: 'mediumblob_field',
+            Type: 'mediumblob',
+            Null: 'YES',
+          },
+          mediumint_field: {
+            Field: 'mediumint_field',
+            Type: 'mediumint',
+            Null: 'YES',
+          },
+          mediumint_unsigned_field: {
+            Field: 'mediumint_unsigned_field',
+            Type: 'mediumint unsigned',
+            Null: 'YES',
+          },
+          mediumtext_field: {
+            Field: 'mediumtext_field',
+            Type: 'mediumtext',
+            Null: 'YES',
+          },
+          numeric_field: {
+            Field: 'numeric_field',
+            Type: 'numeric(10,2)',
+            Null: 'YES',
+          },
+          numeric_unsigned_field: {
+            Field: 'numeric_unsigned_field',
+            Type: 'numeric unsigned',
+            Null: 'YES',
+          },
+          smallint_field: {
+            Field: 'smallint_field',
+            Type: 'smallint',
+            Null: 'YES',
+          },
+          smallint_unsigned_field: {
+            Field: 'smallint_unsigned_field',
+            Type: 'smallint unsigned',
+            Null: 'YES',
+          },
+          text_field: {
+            Field: 'text_field',
+            Type: 'text',
+            Null: 'YES',
+          },
+          time_field: {
+            Field: 'time_field',
+            Type: 'time',
+            Null: 'YES',
+          },
+          tinyblob_field: {
+            Field: 'tinyblob_field',
+            Type: 'tinyblob',
+            Null: 'YES',
+          },
+          tinyint_field: {
+            Field: 'tinyint_field',
+            Type: 'tinyint',
+            Null: 'YES',
+          },
+          tinyint_unsigned_field: {
+            Field: 'tinyint_unsigned_field',
+            Type: 'tinyint unsigned',
+            Null: 'YES',
+          },
+          tinytext_field: {
+            Field: 'tinytext_field',
+            Type: 'tinytext',
+            Null: 'YES',
+          },
+          varbinary_field: {
+            Field: 'varbinary_field',
+            Type: 'varbinary(255)',
+            Null: 'YES',
+          },
+          year_field: {
+            Field: 'year_field',
+            Type: 'year',
+            Null: 'YES',
+          },
+        }),
+      });
+      const createdSchema = await loadGraphQLSchemaFromMySQL(...loaderParamsDefaultMock);
+
+      expect(createdSchema).toBeDefined();
+      const schemaString = printSchemaWithDirectives(createdSchema);
+
+      expect(schemaString).toContain('id: Int!');
+      expect(schemaString).toContain('name: String!');
+      expect(schemaString).toContain('email: String');
+      expect(schemaString).toContain('age: UnsignedInt');
+      expect(schemaString).toContain('balance: Float');
+      expect(schemaString).toContain('data: JSON');
+      expect(schemaString).toContain('created_at: DateTime!');
+      expect(schemaString).toContain('updated_at: Timestamp');
+      expect(schemaString).toContain('is_active: Boolean!');
+      expect(schemaString).toContain('bigint_field: BigInt');
+      expect(schemaString).toContain('bigint_unsigned_field: BigInt');
+      expect(schemaString).toContain('binary_field: String');
+      expect(schemaString).toContain('bit_field: Int');
+      expect(schemaString).toContain('blob_field: String');
+      expect(schemaString).toContain('bool_field: Boolean');
+      expect(schemaString).toContain('char_field: String');
+      expect(schemaString).toContain('date_field: Date');
+      expect(schemaString).toContain('dec_field: Float');
+      expect(schemaString).toContain('dec_unsigned_field: UnsignedFloat');
+      expect(schemaString).toContain('decimal_unsigned_field: UnsignedFloat');
+      expect(schemaString).toContain('double_field: Float');
+      expect(schemaString).toContain('double_unsigned_field: UnsignedFloat');
+      expect(schemaString).toContain('float_field: Float');
+      expect(schemaString).toContain('float_unsigned_field: UnsignedFloat');
+      expect(schemaString).toContain('int_unsigned_field: UnsignedInt');
+      expect(schemaString).toContain('integer_field: Int');
+      expect(schemaString).toContain('integer_unsigned_field: UnsignedInt');
+      expect(schemaString).toContain('longblob_field: String');
+      expect(schemaString).toContain('longtext_field: String');
+      expect(schemaString).toContain('mediumblob_field: String');
+      expect(schemaString).toContain('mediumint_field: Int');
+      expect(schemaString).toContain('mediumint_unsigned_field: UnsignedInt');
+      expect(schemaString).toContain('mediumtext_field: String');
+      expect(schemaString).toContain('numeric_field: Float');
+      expect(schemaString).toContain('numeric_unsigned_field: UnsignedFloat');
+      expect(schemaString).toContain('smallint_field: Int');
+      expect(schemaString).toContain('smallint_unsigned_field: UnsignedInt');
+      expect(schemaString).toContain('text_field: String');
+      expect(schemaString).toContain('time_field: Time');
+      expect(schemaString).toContain('tinyblob_field: String');
+      expect(schemaString).toContain('tinyint_field: Int');
+      expect(schemaString).toContain('tinyint_unsigned_field: UnsignedInt');
+      expect(schemaString).toContain('tinytext_field: String');
+      expect(schemaString).toContain('varbinary_field: String');
+      expect(schemaString).toContain('year_field: Int');
+    });
+  });
+});


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._
- The change is too small for a separate issue. If I missed something and discussion is worth it I can still create an issue, though

## Description

The `tables` and `tableFields` config options are defined in the MySQLHandler types and partially used inside `loadGraphQLSchemaFromMySQL` from `@omnigraph/mysql`. However,  they were not properly being passed down to the `handleTableName` function in the omnigraph schema. 

Moreover, I also fixed the legacy mysql handler to pass down both `tables` and `tableFieldsConfig`.

Fixes # (issue)
- no official issue reported.
- implicitly fixing/making `tables` and `tableFields` work


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?

The PR adds extensive tests for the new mysql schema loader including tests for the fix. Additionally I have locally tested the solution in a real use case.


## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation -> types already suggest usage of these properties
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, and I have added a
      changeset using `yarn changeset` that bumps the version -> added a dozen of extra tests for my feature for the mysql schema loader in general
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] ~Any dependent changes have been merged and published in downstream modules~ -> I believe we do not need any

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
