### PR TITLE
Accept and support the new Hive PubSub

### DIFF
--- a/.changeset/cute-ducks-brush.md
+++ b/.changeset/cute-ducks-brush.md
@@ -1,0 +1,13 @@
+---
+'@omnigraph/json-schema': patch
+'@graphql-mesh/cache-inmemory-lru': patch
+'@graphql-mesh/plugin-live-query': patch
+'@graphql-mesh/cache-localforage': patch
+'@graphql-mesh/transport-neo4j': patch
+'@graphql-mesh/transport-rest': patch
+'@omnigraph/neo4j': patch
+'@graphql-mesh/utils': patch
+'@graphql-mesh/cache-redis': patch
+---
+
+Accept and support the new and improved `HivePubSub` from `@graphql-hive/pubsub`

--- a/.changeset/hungry-suns-appear.md
+++ b/.changeset/hungry-suns-appear.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/types': patch
+---
+
+Export the new and improved `HivePubSub` from `@graphql-hive/pubsub` together with a utility to detect and convert it to the legacy `MeshPubSub`

--- a/packages/cache/localforage/src/index.ts
+++ b/packages/cache/localforage/src/index.ts
@@ -1,6 +1,7 @@
 import LocalForage from 'localforage';
 import InMemoryLRUCache from '@graphql-mesh/cache-inmemory-lru';
 import type {
+  HivePubSub,
   KeyValueCache,
   KeyValueCacheSetOptions,
   MeshPubSub,
@@ -9,7 +10,7 @@ import type {
 
 export default class LocalforageCache<V = any> implements KeyValueCache<V> {
   private localforage: LocalForage;
-  constructor(config?: YamlConfig.LocalforageConfig & { pubsub?: MeshPubSub }) {
+  constructor(config?: YamlConfig.LocalforageConfig & { pubsub?: MeshPubSub | HivePubSub }) {
     const driverNames = config?.driver || ['INDEXEDDB', 'WEBSQL', 'LOCALSTORAGE'];
     if (driverNames.every(driverName => !LocalForage.supports(driverName))) {
       return new InMemoryLRUCache({ pubsub: config?.pubsub }) as any;

--- a/packages/legacy/types/package.json
+++ b/packages/legacy/types/package.json
@@ -35,6 +35,7 @@
     "graphql": "*"
   },
   "dependencies": {
+    "@graphql-hive/pubsub": "2.0.0-alpha-86d532fca168f7b6e57de46d3cff2439cc6242b7",
     "@graphql-mesh/store": "^0.104.7",
     "@graphql-tools/batch-delegate": "^9.0.10",
     "@graphql-tools/delegate": "^10.0.28",

--- a/packages/legacy/types/src/index.ts
+++ b/packages/legacy/types/src/index.ts
@@ -2,6 +2,8 @@
 import type { DocumentNode, GraphQLResolveInfo, GraphQLSchema, SelectionSetNode } from 'graphql';
 import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue.js';
 import type { Plugin } from '@envelop/core';
+import type { PubSub as HivePubSub } from '@graphql-hive/pubsub';
+import { MeshPubSub as HiveMeshPubSub } from '@graphql-hive/pubsub/mesh';
 import type { MeshStore } from '@graphql-mesh/store';
 import type { BatchDelegateOptions } from '@graphql-tools/batch-delegate';
 import type {
@@ -82,6 +84,34 @@ export interface MeshPubSub {
   unsubscribe(subId: number): void;
   getEventNames(): Iterable<string>;
   asyncIterator<THook extends HookName>(triggers: THook): AsyncIterable<AllHooks[THook]>;
+}
+
+export type { HivePubSub };
+
+/**
+ * Checks whether the provided {@link pubsub} is a {@link HivePubSub}. It is only
+ * accurate when dealing with `@graphql-hive/pubsub` v2 and above.
+ */
+export function isHivePubSub(pubsub: undefined | MeshPubSub | HivePubSub): pubsub is HivePubSub {
+  // HivePubSub does not have asyncIterator method. this only applies for @graphql-hive/pubsub v2+
+  return !('asyncIterator' in pubsub);
+}
+
+/**
+ * A utility function ensuring the provided {@link pubsub} is always the legacy {@link MeshPubSub}.
+ * It does so by converting a {@link HivePubSub} to a {@link MeshPubSub} if provided, or leaving it
+ * as is if it's already a {@link MeshPubSub}.
+ */
+export function toMeshPubSub(pubsub: undefined): undefined;
+export function toMeshPubSub(pubsub: MeshPubSub): MeshPubSub;
+export function toMeshPubSub(pubsub: HivePubSub): MeshPubSub;
+export function toMeshPubSub(pubsub: HivePubSub | MeshPubSub): MeshPubSub;
+export function toMeshPubSub(pubsub: HivePubSub | MeshPubSub | undefined): MeshPubSub | undefined;
+export function toMeshPubSub(pubsub?: MeshPubSub | HivePubSub | undefined): MeshPubSub | undefined {
+  if (isHivePubSub(pubsub)) {
+    return HiveMeshPubSub.from(pubsub);
+  }
+  return pubsub;
 }
 
 export interface MeshTransformOptions<Config = any> {

--- a/packages/loaders/json-schema/src/types.ts
+++ b/packages/loaders/json-schema/src/types.ts
@@ -3,7 +3,7 @@ import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue.js';
 import type { JSONSchema, JSONSchemaObject } from 'json-machete';
 import type { IStringifyOptions } from 'qs';
 import type { ResolverData } from '@graphql-mesh/string-interpolation';
-import type { Logger, MeshFetch, MeshPubSub } from '@graphql-mesh/types';
+import type { HivePubSub, Logger, MeshFetch, MeshPubSub } from '@graphql-mesh/types';
 import type { BaseLoaderOptions } from '@graphql-tools/utils';
 
 export interface JSONSchemaLoaderOptions extends BaseLoaderOptions {
@@ -14,7 +14,7 @@ export interface JSONSchemaLoaderOptions extends BaseLoaderOptions {
   operations: JSONSchemaOperationConfig[];
   errorMessage?: string;
   logger?: Logger;
-  pubsub?: MeshPubSub;
+  pubsub?: MeshPubSub | HivePubSub;
   fetch?: MeshFetch;
   ignoreErrorResponses?: boolean;
   queryParams?: Record<string, string | number | boolean>;

--- a/packages/loaders/neo4j/src/schema.ts
+++ b/packages/loaders/neo4j/src/schema.ts
@@ -7,7 +7,7 @@ import {
   getDriverFromOpts,
   getExecutableSchemaFromTypeDefsAndDriver,
 } from '@graphql-mesh/transport-neo4j';
-import type { Logger, MeshPubSub } from '@graphql-mesh/types';
+import type { HivePubSub, Logger, MeshPubSub } from '@graphql-mesh/types';
 import { mergeSchemas } from '@graphql-tools/schema';
 import { toGraphQLTypeDefs } from '@neo4j/introspector';
 import { polyfillStrReplaceAll, revertStrReplaceAllPolyfill } from './strReplaceAllPolyfill.js';
@@ -51,7 +51,7 @@ export interface LoadGraphQLSchemaFromNeo4JOpts {
   endpoint: string;
   database?: string;
   auth?: Neo4JAuthOpts;
-  pubsub?: MeshPubSub;
+  pubsub?: MeshPubSub | HivePubSub;
   logger?: Logger;
   driver?: Driver;
 }

--- a/packages/plugins/live-query/src/useInvalidateByResult.ts
+++ b/packages/plugins/live-query/src/useInvalidateByResult.ts
@@ -2,10 +2,16 @@ import { getArgumentValues, getOperationAST, TypeInfo, visit, visitWithTypeInfo 
 import type { Plugin } from '@envelop/core';
 import type { ResolverDataBasedFactory } from '@graphql-mesh/string-interpolation';
 import { getInterpolatedStringFactory } from '@graphql-mesh/string-interpolation';
-import type { Logger, MeshPubSub, YamlConfig } from '@graphql-mesh/types';
+import {
+  toMeshPubSub,
+  type HivePubSub,
+  type Logger,
+  type MeshPubSub,
+  type YamlConfig,
+} from '@graphql-mesh/types';
 
 interface InvalidateByResultParams {
-  pubsub: MeshPubSub;
+  pubsub: MeshPubSub | HivePubSub;
   invalidations: YamlConfig.LiveQueryInvalidation[];
   logger: Logger;
 }
@@ -19,6 +25,7 @@ export function useInvalidateByResult(params: InvalidateByResultParams): Plugin 
     );
     liveQueryInvalidationFactoryMap.set(liveQueryInvalidation.field, factories);
   });
+  const pubsub = toMeshPubSub(params.pubsub);
   return {
     onExecute() {
       return {
@@ -49,7 +56,7 @@ export function useInvalidateByResult(params: InvalidateByResultParams): Plugin 
                       result,
                     }),
                   );
-                  params.pubsub.publish('live-query:invalidate', invalidationPaths);
+                  pubsub.publish('live-query:invalidate', invalidationPaths);
                 }
               },
             }),

--- a/packages/transports/neo4j/src/executor.ts
+++ b/packages/transports/neo4j/src/executor.ts
@@ -3,7 +3,7 @@ import { extendSchema, parse, visit } from 'graphql';
 import { GraphQLBigInt } from 'graphql-scalars';
 import type { Driver } from 'neo4j-driver';
 import type { DisposableExecutor } from '@graphql-mesh/transport-common';
-import type { Logger, MeshPubSub } from '@graphql-mesh/types';
+import { toMeshPubSub, type HivePubSub, type Logger, type MeshPubSub } from '@graphql-mesh/types';
 import { makeAsyncDisposable } from '@graphql-mesh/utils';
 import { createDefaultExecutor } from '@graphql-tools/delegate';
 import {
@@ -23,7 +23,7 @@ type Neo4jFeaturesSettings = any;
 export interface Neo4JExecutorOpts {
   schema: GraphQLSchema;
   driver?: Driver;
-  pubsub?: MeshPubSub;
+  pubsub?: MeshPubSub | HivePubSub;
   logger?: Logger;
 }
 
@@ -120,17 +120,18 @@ export async function getNeo4JExecutor(opts: Neo4JExecutorOpts): Promise<Disposa
 
 interface GetExecutableSchemaFromTypeDefs {
   driver: Driver;
-  pubsub?: MeshPubSub;
+  pubsub?: MeshPubSub | HivePubSub;
   typeDefs?: string | DocumentNode;
 }
 
 export function getExecutableSchemaFromTypeDefsAndDriver({
   driver,
-  pubsub,
+  pubsub: meshOrHivePubSub,
   typeDefs,
 }: GetExecutableSchemaFromTypeDefs) {
   let features: Neo4jFeaturesSettings;
-  if (pubsub) {
+  if (meshOrHivePubSub) {
+    const pubsub = toMeshPubSub(meshOrHivePubSub);
     features = {
       subscriptions: {
         events: getEventEmitterFromPubSub(pubsub),

--- a/packages/transports/rest/src/directives/process.ts
+++ b/packages/transports/rest/src/directives/process.ts
@@ -8,7 +8,7 @@ import {
   isUnionType,
 } from 'graphql';
 import { ObjMapScalar } from '@graphql-mesh/transport-common';
-import type { Logger, MeshFetch, MeshPubSub } from '@graphql-mesh/types';
+import type { HivePubSub, Logger, MeshFetch, MeshPubSub } from '@graphql-mesh/types';
 import { getDefDirectives } from '@graphql-mesh/utils';
 import { getDirective, getDirectiveExtensions } from '@graphql-tools/utils';
 import { processDictionaryDirective } from './dictionary.js';
@@ -26,7 +26,7 @@ import { addExecutionLogicToScalar, processScalarType } from './scalars.js';
 import { processTypeScriptAnnotations } from './typescriptAnnotations.js';
 
 export interface ProcessDirectiveArgs {
-  pubsub?: MeshPubSub;
+  pubsub?: MeshPubSub | HivePubSub;
   logger?: Logger;
   globalFetch?: MeshFetch;
   endpoint?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6698,6 +6698,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-hive/pubsub@npm:2.0.0-alpha-86d532fca168f7b6e57de46d3cff2439cc6242b7":
+  version: 2.0.0-alpha-86d532fca168f7b6e57de46d3cff2439cc6242b7
+  resolution: "@graphql-hive/pubsub@npm:2.0.0-alpha-86d532fca168f7b6e57de46d3cff2439cc6242b7"
+  dependencies:
+    "@repeaterjs/repeater": "npm:^3.0.6"
+    "@whatwg-node/disposablestack": "npm:^0.0.6"
+    "@whatwg-node/promise-helpers": "npm:^1.3.0"
+  peerDependencies:
+    ioredis: ^5
+  peerDependenciesMeta:
+    ioredis:
+      optional: true
+  checksum: 10c0/5d3588f71928bedef0069ec8ba291e9ba8e0d2f206ad4e769193b7f44b7c21dfb91598797a5c094c00a3c462e244bd22280807848df1a7778e0b50c9278b991e
+  languageName: node
+  linkType: hard
+
 "@graphql-hive/pubsub@npm:^1.0.0":
   version: 1.0.0
   resolution: "@graphql-hive/pubsub@npm:1.0.0"
@@ -8287,6 +8303,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphql-mesh/types@workspace:packages/legacy/types"
   dependencies:
+    "@graphql-hive/pubsub": "npm:2.0.0-alpha-86d532fca168f7b6e57de46d3cff2439cc6242b7"
     "@graphql-mesh/store": "npm:^0.104.7"
     "@graphql-tools/batch-delegate": "npm:^9.0.10"
     "@graphql-tools/delegate": "npm:^10.0.28"


### PR DESCRIPTION
Ref GW-448

See https://github.com/graphql-hive/gateway/pull/1395 for more info.

Only components on which the Hive Gateway depends support both the new `HivePubSub` and the legacy `MeshPubSub`. Added two more utilities: `isHivePubSub` and `toMeshPubSub` for easier usage and backwards compatibility.

### TODO

- [ ] Use stable version of `@graphql-hive/pubsub` once it is released