### PR TITLE
feat(live-query): `pollingInterval`

### DIFF
--- a/.changeset/social-camels-mate.md
+++ b/.changeset/social-camels-mate.md
@@ -1,0 +1,15 @@
+---
+'@graphql-mesh/plugin-live-query': patch
+'@graphql-mesh/types': patch
+---
+
+Support polling in an interval by milliseconds
+
+```yaml
+plugins:
+  - live-query:
+      invalidateByPolling:
+        - pollingInterval: 10000 # Polling interval in milliseconds
+          invalidate:
+            - Query.products
+```

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -2461,10 +2461,18 @@
         "invalidations": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/LiveQueryInvalidation"
+            "description": "Any of: LiveQueryInvalidationByMutation, LiveQueryInvalidationByPolling",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/LiveQueryInvalidationByMutation"
+              },
+              {
+                "$ref": "#/definitions/LiveQueryInvalidationByPolling"
+              }
+            ]
           },
           "additionalItems": false,
-          "description": "Invalidate a query or queries when a specific operation is done without an error"
+          "description": "Invalidate a query or queries when a specific operation is done without an error (Any of: LiveQueryInvalidationByMutation, LiveQueryInvalidationByPolling)"
         },
         "resourceIdentifier": {
           "type": "string",
@@ -2488,10 +2496,10 @@
         }
       }
     },
-    "LiveQueryInvalidation": {
+    "LiveQueryInvalidationByMutation": {
       "additionalProperties": false,
       "type": "object",
-      "title": "LiveQueryInvalidation",
+      "title": "LiveQueryInvalidationByMutation",
       "properties": {
         "field": {
           "type": "string",
@@ -2506,6 +2514,24 @@
         }
       },
       "required": ["field", "invalidate"]
+    },
+    "LiveQueryInvalidationByPolling": {
+      "additionalProperties": false,
+      "type": "object",
+      "title": "LiveQueryInvalidationByPolling",
+      "properties": {
+        "pollingInterval": {
+          "type": "integer"
+        },
+        "invalidate": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "additionalItems": false
+        }
+      },
+      "required": ["pollingInterval", "invalidate"]
     },
     "LiveQueryIndexBy": {
       "additionalProperties": false,

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -2153,9 +2153,9 @@ export interface HTTPDetailsExtensionsConfig {
 }
 export interface LiveQueryConfig {
   /**
-   * Invalidate a query or queries when a specific operation is done without an error
+   * Invalidate a query or queries when a specific operation is done without an error (Any of: LiveQueryInvalidationByMutation, LiveQueryInvalidationByPolling)
    */
-  invalidations?: LiveQueryInvalidation[];
+  invalidations?: (LiveQueryInvalidationByMutation | LiveQueryInvalidationByPolling)[];
   /**
    * Custom strategy for building resources identifiers
    * By default resource identifiers are built by concatenating the Typename with the id separated by a color (`User:1`).
@@ -2184,11 +2184,15 @@ export interface LiveQueryConfig {
    */
   indexBy?: LiveQueryIndexBy[];
 }
-export interface LiveQueryInvalidation {
+export interface LiveQueryInvalidationByMutation {
   /**
    * Path to the operation that could effect it. In a form: Mutation.something. Note that wildcard is not supported in this field.
    */
   field: string;
+  invalidate: string[];
+}
+export interface LiveQueryInvalidationByPolling {
+  pollingInterval: number;
   invalidate: string[];
 }
 export interface LiveQueryIndexBy {

--- a/packages/plugins/live-query/package.json
+++ b/packages/plugins/live-query/package.json
@@ -42,6 +42,7 @@
     "@graphql-mesh/types": "^0.104.13",
     "@graphql-mesh/utils": "^0.104.13",
     "@n1ru4l/in-memory-live-query-store": "^0.10.0",
+    "@whatwg-node/disposablestack": "^0.0.6",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/plugins/live-query/yaml-config.graphql
+++ b/packages/plugins/live-query/yaml-config.graphql
@@ -38,7 +38,9 @@ type LiveQueryConfig {
   indexBy: [LiveQueryIndexBy]
 }
 
-type LiveQueryInvalidation {
+union LiveQueryInvalidation @md = LiveQueryInvalidationByMutation | LiveQueryInvalidationByPolling
+
+type LiveQueryInvalidationByMutation @md {
   """
   Path to the operation that could effect it. In a form: Mutation.something. Note that wildcard is not supported in this field.
   """
@@ -46,7 +48,18 @@ type LiveQueryInvalidation {
   invalidate: [String!]!
 }
 
-type LiveQueryIndexBy {
+type LiveQueryInvalidationByPolling @md {
+  """
+  Polling interval in milliseconds
+  """
+  pollingInterval: Int!
+  """
+  Schema coordinate of the query to be polled
+  """
+  invalidate: [String!]!
+}
+
+type LiveQueryIndexBy @md {
   field: String!
   args: [String]!
 }

--- a/website/src/generated-markdown/LiveQueryIndexBy.generated.md
+++ b/website/src/generated-markdown/LiveQueryIndexBy.generated.md
@@ -1,0 +1,3 @@
+
+* `field` (type: `String`, required)
+* `args` (type: `Array of String`, required)

--- a/website/src/generated-markdown/LiveQueryInvalidationByMutation.generated.md
+++ b/website/src/generated-markdown/LiveQueryInvalidationByMutation.generated.md
@@ -1,0 +1,3 @@
+
+* `field` (type: `String`, required) - Path to the operation that could effect it. In a form: Mutation.something. Note that wildcard is not supported in this field.
+* `invalidate` (type: `Array of String`, required)

--- a/website/src/generated-markdown/LiveQueryInvalidationByPolling.generated.md
+++ b/website/src/generated-markdown/LiveQueryInvalidationByPolling.generated.md
@@ -1,0 +1,3 @@
+
+* `pollingInterval` (type: `Int`, required)
+* `invalidate` (type: `Array of String`, required)

--- a/website/src/pages/docs/plugins/live-queries.mdx
+++ b/website/src/pages/docs/plugins/live-queries.mdx
@@ -92,6 +92,20 @@ invalidations:
       - Query.todo(id:"{args.id}")
 ```
 
+### Polling Based Invalidation
+
+You can also invalidate queries in a polling interval by specifying the schema coordinate of the
+query to be polled.
+
+```yaml filename=".meshrc.yaml"
+plugins:
+  - live-query:
+      invalidateByPolling:
+        - pollingInterval: 10000 # Polling interval in milliseconds
+          invalidate:
+            - Query.products
+```
+
 ### Programmatic Usage
 
 `liveQueryStore` is available in GraphQL Context, so you can access it in resolvers composition

--- a/yarn.lock
+++ b/yarn.lock
@@ -7418,6 +7418,7 @@ __metadata:
     "@graphql-mesh/types": "npm:^0.104.13"
     "@graphql-mesh/utils": "npm:^0.104.13"
     "@n1ru4l/in-memory-live-query-store": "npm:^0.10.0"
+    "@whatwg-node/disposablestack": "npm:^0.0.6"
     graphql: "npm:16.11.0"
     tslib: "npm:^2.4.0"
   peerDependencies:


### PR DESCRIPTION
Support polling in an interval by milliseconds

```yaml
plugins:
  - live-query:
      invalidateByPolling:
        - pollingInterval: 10000 # Polling interval in milliseconds
          invalidate:
            - Query.products
```