### PR TITLE
fix(utils): infer @resolveTo sourceSelectionSet under encapsulate

### DIFF
--- a/.changeset/resolve-to-encapsulate-result.md
+++ b/.changeset/resolve-to-encapsulate-result.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/utils': patch
+---
+
+Fix `@resolveTo` inferring `sourceSelectionSet` from a `result` path when the source field is missing from the gateway schema. Encapsulate (and similar transforms) keep the real source field as an `@inaccessible` copy such as `_encapsulated_<name>_<field>`, which federation then strips from the supergraph. The client selection set is still wrapped with the `result` path instead of crashing on `sourceField.type`.

--- a/e2e/reproduction-9435/mesh.config.ts
+++ b/e2e/reproduction-9435/mesh.config.ts
@@ -1,0 +1,48 @@
+import { Opts } from '@e2e/opts';
+import {
+  createEncapsulateTransform,
+  defineConfig,
+  loadGraphQLHTTPSubgraph,
+} from '@graphql-mesh/compose-cli';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('Subgraph1', {
+        endpoint: `http://localhost:${opts.getServicePort('Subgraph1')}/graphql`,
+      }),
+      transforms: [
+        createEncapsulateTransform({
+          name: 'Subgraph1',
+          applyTo: { query: true, mutation: true, subscription: true },
+        }),
+      ],
+    },
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('Subgraph2', {
+        endpoint: `http://localhost:${opts.getServicePort('Subgraph2')}/graphql`,
+      }),
+      transforms: [
+        createEncapsulateTransform({
+          name: 'Subgraph2',
+          applyTo: { query: true, mutation: true, subscription: true },
+        }),
+      ],
+    },
+  ],
+  additionalTypeDefs: /* GraphQL */ `
+    extend type TargetType {
+      complexDataItem: SubComplexDataFieldType
+        @resolveTo(
+          requiredSelectionSet: "{ id }"
+          sourceName: "Subgraph1"
+          sourceTypeName: "Query"
+          sourceFieldName: "_encapsulated_Subgraph1_complexData"
+          sourceArgs: { id: "{root.id}" }
+          result: "items[0]"
+        )
+    }
+  `,
+});

--- a/e2e/reproduction-9435/package.json
+++ b/e2e/reproduction-9435/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/reproduction-9435",
+  "private": true,
+  "dependencies": {
+    "@graphql-mesh/compose-cli": "workspace:*",
+    "graphql": "^16.13.2",
+    "graphql-yoga": "^5.21.0"
+  }
+}

--- a/e2e/reproduction-9435/package.json
+++ b/e2e/reproduction-9435/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@e2e/reproduction-9435",
+  "type": "module",
   "private": true,
   "dependencies": {
+    "@graphql-hive/gateway": "^2.11.2",
     "@graphql-mesh/compose-cli": "workspace:*",
-    "graphql": "^16.13.2",
-    "graphql-yoga": "^5.21.0"
+    "graphql": "16.14.0",
+    "graphql-yoga": "^5.21.2"
   }
 }

--- a/e2e/reproduction-9435/reproduciton-9435.test.ts
+++ b/e2e/reproduction-9435/reproduciton-9435.test.ts
@@ -1,0 +1,49 @@
+import { createTenv } from '@e2e/tenv';
+
+it('works', async () => {
+  const { container, compose, service, serve } = createTenv(__dirname);
+  await using Subgraph1 = await service('Subgraph1');
+  await using Subgraph2 = await service('Subgraph2');
+  await using composition = await compose({ output: 'graphql', services: [Subgraph1, Subgraph2] });
+  await using gw = await serve({ supergraph: composition.output });
+  const res = await gw.execute({
+    query: /* GraphQL */ `
+      query {
+        Subgraph2 {
+          targetQuery {
+            targets {
+              id
+              complexDataItem {
+                key
+                value
+              }
+            }
+          }
+        }
+      }
+    `,
+  });
+  expect(res.data).toEqual({
+    Subgraph2: {
+      targetQuery: {
+        targets: [
+          {
+            id: 'nullish',
+            complexDataItem: null,
+          },
+          {
+            id: 'empty',
+            complexDataItem: null,
+          },
+          {
+            id: 'full',
+            complexDataItem: {
+              key: 'full',
+              value: 'This is full data',
+            },
+          },
+        ],
+      },
+    },
+  });
+});

--- a/e2e/reproduction-9435/reproduction-9435.test.ts
+++ b/e2e/reproduction-9435/reproduction-9435.test.ts
@@ -1,7 +1,8 @@
 import { createTenv } from '@e2e/tenv';
 
-it('works', async () => {
-  const { container, compose, service, serve } = createTenv(__dirname);
+const { compose, service, serve } = createTenv(__dirname);
+
+it('infers sourceSelectionSet from @resolveTo result under encapsulate', async () => {
   await using Subgraph1 = await service('Subgraph1');
   await using Subgraph2 = await service('Subgraph2');
   await using composition = await compose({ output: 'graphql', services: [Subgraph1, Subgraph2] });
@@ -23,6 +24,7 @@ it('works', async () => {
       }
     `,
   });
+  expect(res.errors).toBeUndefined();
   expect(res.data).toEqual({
     Subgraph2: {
       targetQuery: {
@@ -38,8 +40,8 @@ it('works', async () => {
           {
             id: 'full',
             complexDataItem: {
-              key: 'full',
-              value: 'This is full data',
+              key: 'key1',
+              value: 'value1',
             },
           },
         ],

--- a/e2e/reproduction-9435/services/Subgraph1.ts
+++ b/e2e/reproduction-9435/services/Subgraph1.ts
@@ -1,0 +1,50 @@
+import { createServer } from 'node:http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const port = Opts(process.argv).getServicePort('Subgraph1');
+
+const variants = {
+  nullish: null,
+  empty: {
+    count: 0,
+    items: [],
+  },
+  full: {
+    count: 3,
+    items: [
+      { key: 'key1', value: 'value1' },
+      { key: 'key2', value: 'value2' },
+      { key: 'key3', value: 'value3' },
+    ],
+  },
+};
+
+createServer(
+  createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type SubComplexDataFieldType {
+          key: String
+          value: String
+        }
+
+        type ComplexDataType {
+          count: Int!
+          items: [SubComplexDataFieldType!]!
+        }
+
+        type Query {
+          complexData(id: String!): ComplexDataType
+        }
+      `,
+      resolvers: {
+        Query: {
+          complexData: (_, { id }: { id: 'nullish' | 'empty' | 'full' }) => variants[id],
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Subgraph1 running on http://localhost:${port}/graphql`);
+});

--- a/e2e/reproduction-9435/services/Subgraph2.ts
+++ b/e2e/reproduction-9435/services/Subgraph2.ts
@@ -1,0 +1,35 @@
+import { createServer } from 'node:http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const port = Opts(process.argv).getServicePort('Subgraph2');
+
+createServer(
+  createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type TargetType {
+          id: String
+        }
+
+        type TargetQuery {
+          targets: [TargetType]
+        }
+
+        type Query {
+          targetQuery: TargetQuery
+        }
+      `,
+      resolvers: {
+        Query: {
+          targetQuery: () => ({}),
+        },
+        TargetQuery: {
+          targets: () => [{ id: 'nullish' }, { id: 'empty' }, { id: 'full' }],
+        },
+      },
+    }),
+  }),
+).listen(port, () => {
+  console.log(`Subgraph2 running on http://localhost:${port}/graphql`);
+});

--- a/packages/legacy/utils/src/resolve-additional-resolvers.ts
+++ b/packages/legacy/utils/src/resolve-additional-resolvers.ts
@@ -150,14 +150,23 @@ function generateSelectionSetFactory(
     // If result path provided without a selectionSet
   } else if (additionalResolver.result) {
     const resultPath = toPath(additionalResolver.result);
-    let abstractResultTypeName: string;
+    let abstractResultTypeName: string | undefined;
 
-    const sourceType = schema.getType(additionalResolver.sourceTypeName) as GraphQLObjectType;
-    const sourceTypeFields = sourceType.getFields();
-    const sourceField = sourceTypeFields[additionalResolver.sourceFieldName];
-    const resultFieldType = getTypeByPath(sourceField.type, resultPath);
+    // `info.schema` is the gateway/supergraph schema. Encapsulate (and similar
+    // transforms) keep the real source field as an @inaccessible copy such as
+    // `_encapsulated_<name>_<field>`, which federation then strips from the
+    // supergraph. Selection-set wrapping from `result` still works without that
+    // field; we only need its type when the projected path is abstract.
+    const sourceType = schema.getType(additionalResolver.sourceTypeName);
+    const sourceField =
+      sourceType && 'getFields' in sourceType
+        ? (sourceType as GraphQLObjectType).getFields()[additionalResolver.sourceFieldName]
+        : undefined;
+    const resultFieldType = sourceField?.type
+      ? getTypeByPath(sourceField.type, resultPath)
+      : undefined;
 
-    if (isAbstractType(resultFieldType)) {
+    if (resultFieldType && isAbstractType(resultFieldType)) {
       if (additionalResolver.resultType) {
         abstractResultTypeName = additionalResolver.resultType;
       } else {
@@ -192,6 +201,7 @@ function generateSelectionSetFactory(
           if (
             isLastResult &&
             abstractResultTypeName &&
+            resultFieldType &&
             abstractResultTypeName !== resultFieldType.name
           ) {
             finalSelectionSet = {

--- a/packages/legacy/utils/src/resolve-additional-resolvers.ts
+++ b/packages/legacy/utils/src/resolve-additional-resolvers.ts
@@ -159,8 +159,8 @@ function generateSelectionSetFactory(
     // field; we only need its type when the projected path is abstract.
     const sourceType = schema.getType(additionalResolver.sourceTypeName);
     const sourceField =
-      sourceType && 'getFields' in sourceType
-        ? (sourceType as GraphQLObjectType).getFields()[additionalResolver.sourceFieldName]
+      sourceType && (isObjectType(sourceType) || isInterfaceType(sourceType))
+        ? sourceType.getFields()[additionalResolver.sourceFieldName]
         : undefined;
     const resultFieldType = sourceField?.type
       ? getTypeByPath(sourceField.type, resultPath)

--- a/packages/legacy/utils/test/resolve-additional-resolvers.spec.ts
+++ b/packages/legacy/utils/test/resolve-additional-resolvers.spec.ts
@@ -665,3 +665,136 @@ describe('key-based (batch) additional resolver with valueKeyField', () => {
     });
   });
 });
+
+// Encapsulate hides the real source field as `_encapsulated_<name>_<field>` with
+// @inaccessible; federation then strips it from the supergraph (`info.schema`).
+// `@resolveTo` with a `result` path must still wrap the client selection set
+// (e.g. `items[0]` → `{ items { ... } }`) without looking that field up.
+describe('@resolveTo result path when the source field is missing from the gateway schema', () => {
+  it('infers sourceSelectionSet from result without crashing', async () => {
+    const variants: Record<
+      string,
+      { count: number; items: { key: string; value: string }[] } | null
+    > = {
+      nullish: null,
+      empty: { count: 0, items: [] },
+      full: {
+        count: 3,
+        items: [
+          { key: 'key1', value: 'value1' },
+          { key: 'key2', value: 'value2' },
+          { key: 'key3', value: 'value3' },
+        ],
+      },
+    };
+
+    const sourceSchema = makeExecutableSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type SubComplexDataFieldType {
+          key: String
+          value: String
+        }
+        type ComplexDataType {
+          count: Int!
+          items: [SubComplexDataFieldType!]!
+        }
+        type Query {
+          _encapsulated_Subgraph1_complexData(id: String!): ComplexDataType
+        }
+      `),
+      resolvers: {
+        Query: {
+          _encapsulated_Subgraph1_complexData: (_: unknown, { id }: { id: string }) => variants[id],
+        },
+      },
+    });
+
+    const parentSchema = makeExecutableSchema({
+      typeDefs: parse(/* GraphQL */ `
+        type TargetType {
+          id: String
+        }
+        type TargetQuery {
+          targets: [TargetType]
+        }
+        type Query {
+          targetQuery: TargetQuery
+        }
+      `),
+      resolvers: {
+        Query: {
+          targetQuery: () => ({}),
+        },
+        TargetQuery: {
+          targets: () => [{ id: 'nullish' }, { id: 'empty' }, { id: 'full' }],
+        },
+      },
+    });
+
+    const sourceRaw: RawSourceOutput = {
+      name: 'Subgraph1',
+      schema: sourceSchema,
+      transforms: [],
+      contextVariables: {},
+      handler: {} as RawSourceOutput['handler'],
+      batch: true,
+      createProxyingResolver: () => undefined as any,
+    };
+    const inContextSDK = getInContextSDK(sourceSchema, [sourceRaw], new DefaultLogger('test'), []);
+
+    const additionalResolvers = resolveAdditionalResolversWithoutImport({
+      targetTypeName: 'TargetType',
+      targetFieldName: 'complexDataItem',
+      requiredSelectionSet: '{ id }',
+      sourceName: 'Subgraph1',
+      sourceTypeName: 'Query',
+      sourceFieldName: '_encapsulated_Subgraph1_complexData',
+      sourceArgs: { id: '{root.id}' },
+      result: 'items[0]',
+    });
+
+    // Supergraph does not expose the inaccessible encapsulated field.
+    const stitched = stitchSchemas({
+      subschemas: [{ schema: parentSchema }] as SubschemaConfig[],
+      typeDefs: parse(/* GraphQL */ `
+        type SubComplexDataFieldType {
+          key: String
+          value: String
+        }
+        extend type TargetType {
+          complexDataItem: SubComplexDataFieldType
+        }
+      `),
+      resolvers: additionalResolvers,
+    });
+
+    const result = (await execute({
+      schema: stitched,
+      document: parse(/* GraphQL */ `
+        {
+          targetQuery {
+            targets {
+              id
+              complexDataItem {
+                key
+                value
+              }
+            }
+          }
+        }
+      `),
+      contextValue: { ...inContextSDK },
+    })) as ExecutionResult;
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      targetQuery: {
+        targets: [
+          { id: 'nullish', complexDataItem: null },
+          { id: 'empty', complexDataItem: null },
+          { id: 'full', complexDataItem: { key: 'key1', value: 'value1' } },
+        ],
+      },
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3847,6 +3847,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/reproduction-9435@workspace:e2e/reproduction-9435":
+  version: 0.0.0-use.local
+  resolution: "@e2e/reproduction-9435@workspace:e2e/reproduction-9435"
+  dependencies:
+    "@graphql-mesh/compose-cli": "workspace:*"
+    graphql: "npm:^16.13.2"
+    graphql-yoga: "npm:^5.21.0"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/semantic-conventions@workspace:e2e/semantic-conventions":
   version: 0.0.0-use.local
   resolution: "@e2e/semantic-conventions@workspace:e2e/semantic-conventions"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5314,6 +5314,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/reproduction-9435@workspace:e2e/reproduction-9435":
+  version: 0.0.0-use.local
+  resolution: "@e2e/reproduction-9435@workspace:e2e/reproduction-9435"
+  dependencies:
+    "@graphql-hive/gateway": "npm:^2.11.2"
+    "@graphql-mesh/compose-cli": "workspace:*"
+    graphql: "npm:16.14.0"
+    graphql-yoga: "npm:^5.21.2"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/resolve-to-value-key-field@workspace:e2e/resolve-to-value-key-field":
   version: 0.0.0-use.local
   resolution: "@e2e/resolve-to-value-key-field@workspace:e2e/resolve-to-value-key-field"
@@ -5333,16 +5344,6 @@ __metadata:
     "@graphql-mesh/plugin-response-cache": "npm:^0.105.1"
     graphql: "npm:16.14.0"
     graphql-yoga: "npm:^5.21.2"
-  languageName: unknown
-  linkType: soft
-
-"@e2e/reproduction-9435@workspace:e2e/reproduction-9435":
-  version: 0.0.0-use.local
-  resolution: "@e2e/reproduction-9435@workspace:e2e/reproduction-9435"
-  dependencies:
-    "@graphql-mesh/compose-cli": "workspace:*"
-    graphql: "npm:^16.13.2"
-    graphql-yoga: "npm:^5.21.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5336,6 +5336,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/reproduction-9435@workspace:e2e/reproduction-9435":
+  version: 0.0.0-use.local
+  resolution: "@e2e/reproduction-9435@workspace:e2e/reproduction-9435"
+  dependencies:
+    "@graphql-mesh/compose-cli": "workspace:*"
+    graphql: "npm:^16.13.2"
+    graphql-yoga: "npm:^5.21.0"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/semantic-conventions@workspace:e2e/semantic-conventions":
   version: 0.0.0-use.local
   resolution: "@e2e/semantic-conventions@workspace:e2e/semantic-conventions"


### PR DESCRIPTION
Fixes #9435

`@resolveTo` with a `result` path (and no explicit `sourceSelectionSet`) looked up the source field on the gateway schema to wrap the client selection set. Encapsulate keeps that field as an `@inaccessible` copy such as `_encapsulated_<name>_<field>`, which federation then strips from the supergraph, so `sourceField` was `undefined` and resolution crashed on `sourceField.type`.

The wrapping from `result` (for example `items[0]` → `{ items { ... } }`) does not need that field unless the projected type is abstract. Inference now proceeds when the source field is missing from `info.schema`.

## Test plan
- [x] Unit test: `@resolveTo` + `result` when the encapsulated source field is not on the gateway schema
- [x] E2E: `e2e/reproduction-9435` (two encapsulated subgraphs, `result: "items[0]"`)