### PR TITLE
fix(plugin-response-cache): make sessionId templates work with Fetch headers

### DIFF
--- a/.changeset/response-cache-session-headers.md
+++ b/.changeset/response-cache-session-headers.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/plugin-response-cache': patch
+---
+
+Fix `sessionId` / `if` / `cacheKey` templates so Fetch `Headers` on the request are usable (e.g. `{context.headers.test}`), matching Yoga's `(request, context)` callback signature.

--- a/e2e/response-cache-session-headers/gateway.config.ts
+++ b/e2e/response-cache-session-headers/gateway.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@graphql-hive/gateway';
+import useMeshResponseCache from '@graphql-mesh/plugin-response-cache';
+
+export const gatewayConfig = defineConfig({
+  plugins: ctx => [
+    useMeshResponseCache({
+      ...ctx,
+      ttl: 60_000,
+      includeExtensionMetadata: true,
+      // Same shape as #5102 / docs: session keyed by a request header
+      sessionId: '{context.headers.test}',
+    }),
+  ],
+});

--- a/e2e/response-cache-session-headers/mesh.config.ts
+++ b/e2e/response-cache-session-headers/mesh.config.ts
@@ -1,0 +1,14 @@
+import { Opts } from '@e2e/opts';
+import { defineConfig, loadGraphQLHTTPSubgraph } from '@graphql-mesh/compose-cli';
+
+const opts = Opts(process.argv);
+
+export const composeConfig = defineConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('Greeting', {
+        endpoint: `http://localhost:${opts.getServicePort('greeting')}/graphql`,
+      }),
+    },
+  ],
+});

--- a/e2e/response-cache-session-headers/package.json
+++ b/e2e/response-cache-session-headers/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@e2e/response-cache-session-headers",
+  "private": true,
+  "dependencies": {
+    "@graphql-hive/gateway": "^2.11.2",
+    "@graphql-mesh/compose-cli": "^1.6.2",
+    "@graphql-mesh/plugin-response-cache": "^0.105.1",
+    "graphql": "16.14.0",
+    "graphql-yoga": "^5.21.2"
+  }
+}

--- a/e2e/response-cache-session-headers/response-cache-session-headers.test.ts
+++ b/e2e/response-cache-session-headers/response-cache-session-headers.test.ts
@@ -1,0 +1,77 @@
+import { createTenv } from '@e2e/tenv';
+
+const { compose, serve, service } = createTenv(__dirname);
+
+it('does not share response cache entries across different session header values', async () => {
+  const greeting = await service('greeting');
+  const { output } = await compose({
+    services: [greeting],
+    output: 'graphql',
+  });
+  const { execute } = await serve({ supergraph: output });
+
+  const query = /* GraphQL */ `
+    query {
+      greeting
+    }
+  `;
+
+  await expect(
+    execute({
+      query,
+      headers: { test: 'a' },
+    }),
+  ).resolves.toMatchObject({
+    data: { greeting: 'hello' },
+    extensions: {
+      responseCache: {
+        didCache: true,
+        hit: false,
+      },
+    },
+  });
+
+  await expect(
+    execute({
+      query,
+      headers: { test: 'a' },
+    }),
+  ).resolves.toMatchObject({
+    data: { greeting: 'hello' },
+    extensions: {
+      responseCache: {
+        hit: true,
+      },
+    },
+  });
+
+  // Changing the session header must miss (reproduces #5102)
+  await expect(
+    execute({
+      query,
+      headers: { test: 'b' },
+    }),
+  ).resolves.toMatchObject({
+    data: { greeting: 'hello' },
+    extensions: {
+      responseCache: {
+        didCache: true,
+        hit: false,
+      },
+    },
+  });
+
+  await expect(
+    execute({
+      query,
+      headers: { test: 'b' },
+    }),
+  ).resolves.toMatchObject({
+    data: { greeting: 'hello' },
+    extensions: {
+      responseCache: {
+        hit: true,
+      },
+    },
+  });
+});

--- a/e2e/response-cache-session-headers/services/greeting.ts
+++ b/e2e/response-cache-session-headers/services/greeting.ts
@@ -1,0 +1,22 @@
+import { createServer } from 'http';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { Opts } from '@e2e/opts';
+
+const opts = Opts(process.argv);
+
+createServer(
+  createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          greeting: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          greeting: () => 'hello',
+        },
+      },
+    }),
+  }),
+).listen(opts.getServicePort('greeting'));

--- a/examples/response-cache/.meshrc.yml
+++ b/examples/response-cache/.meshrc.yml
@@ -21,6 +21,9 @@ plugins:
         - apply: Query.greeting
   - responseCache:
       ttl: 100
+      # Same shape as https://codesandbox.io/p/sandbox/clever-williams-j8m76t (#5102)
+      sessionId: '{context.headers.test}'
+      cacheKey: '{sessionId}'
       includeExtensionMetadata: true
       ttlPerCoordinate:
         - coordinate: Query.withTTL

--- a/examples/response-cache/package.json
+++ b/examples/response-cache/package.json
@@ -12,6 +12,7 @@
     "@graphql-mesh/cli": "^0.101.2",
     "@graphql-mesh/json-schema": "^0.110.1",
     "@graphql-mesh/plugin-mock": "^0.106.1",
+    "@graphql-mesh/plugin-response-cache": "^0.105.1",
     "graphql": "16.14.0"
   }
 }

--- a/examples/response-cache/tests/response-cache.spec.ts
+++ b/examples/response-cache/tests/response-cache.spec.ts
@@ -40,7 +40,9 @@ describe('Response Cache', () => {
           }
         }
       `;
-      expect(await query(gqlQuery)).toEqual({
+      // Stable session header so entries are shared within this test
+      const headers = { test: 'simple' };
+      expect(await query(gqlQuery, headers)).toEqual({
         data: { greeting: { hello: 'world' } },
         extensions: {
           responseCache: {
@@ -50,7 +52,7 @@ describe('Response Cache', () => {
           },
         },
       });
-      expect(await query(gqlQuery)).toEqual({
+      expect(await query(gqlQuery, headers)).toEqual({
         data: { greeting: { hello: 'world' } },
         extensions: {
           responseCache: {
@@ -68,7 +70,8 @@ describe('Response Cache', () => {
           }
         }
       `;
-      expect(await query(gqlQuery)).toEqual({
+      const headers = { test: 'ttl' };
+      expect(await query(gqlQuery, headers)).toEqual({
         data: { withTTL: { hello: 'world' } },
         extensions: {
           responseCache: {
@@ -78,7 +81,7 @@ describe('Response Cache', () => {
           },
         },
       });
-      expect(await query(gqlQuery)).toEqual({
+      expect(await query(gqlQuery, headers)).toEqual({
         data: { withTTL: { hello: 'world' } },
         extensions: {
           responseCache: {
@@ -88,10 +91,62 @@ describe('Response Cache', () => {
       });
     });
 
-    async function query(graphqlQuery: string): Promise<ExecutionResult> {
+    it('should not share cache across different session header values (#5102)', async () => {
+      const gqlQuery = /* GraphQL */ `
+        query HelloWorld {
+          greeting {
+            hello
+          }
+        }
+      `;
+
+      expect(await query(gqlQuery, { test: 'a' })).toMatchObject({
+        data: { greeting: { hello: 'world' } },
+        extensions: {
+          responseCache: {
+            didCache: true,
+            hit: false,
+          },
+        },
+      });
+
+      expect(await query(gqlQuery, { test: 'a' })).toMatchObject({
+        data: { greeting: { hello: 'world' } },
+        extensions: {
+          responseCache: {
+            hit: true,
+          },
+        },
+      });
+
+      // Changing `test` must miss — reproduces codesandbox clever-williams-j8m76t
+      expect(await query(gqlQuery, { test: 'b' })).toMatchObject({
+        data: { greeting: { hello: 'world' } },
+        extensions: {
+          responseCache: {
+            didCache: true,
+            hit: false,
+          },
+        },
+      });
+
+      expect(await query(gqlQuery, { test: 'b' })).toMatchObject({
+        data: { greeting: { hello: 'world' } },
+        extensions: {
+          responseCache: {
+            hit: true,
+          },
+        },
+      });
+    });
+
+    async function query(
+      graphqlQuery: string,
+      extraHeaders: Record<string, string> = {},
+    ): Promise<ExecutionResult> {
       const response = await meshHttp.fetch('/graphql', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...extraHeaders },
         body: JSON.stringify({ query: graphqlQuery }),
       });
       expect(response.status).toBe(200);

--- a/packages/plugins/response-cache/package.json
+++ b/packages/plugins/response-cache/package.json
@@ -49,6 +49,8 @@
     "tslib": "^2.4.0"
   },
   "devDependencies": {
+    "@graphql-hive/gateway-runtime": "^2.10.7",
+    "@graphql-mesh/fusion-composition": "^0.9.2",
     "graphql": "16.14.0"
   },
   "publishConfig": {

--- a/packages/plugins/response-cache/src/index.ts
+++ b/packages/plugins/response-cache/src/index.ts
@@ -4,10 +4,26 @@ import type { GatewayContext, GatewayPlugin } from '@graphql-hive/gateway-runtim
 import { process } from '@graphql-mesh/cross-helpers';
 import { stringInterpolator } from '@graphql-mesh/string-interpolation';
 import type { KeyValueCache, YamlConfig } from '@graphql-mesh/types';
+import { getHeadersObj } from '@graphql-mesh/utils';
 import { isPromise, mapMaybePromise } from '@graphql-tools/utils';
 import type { UseResponseCacheParameter } from '@graphql-yoga/plugin-response-cache';
 import { useResponseCache } from '@graphql-yoga/plugin-response-cache';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
+
+/**
+ * Yoga calls session/enabled as `(request, context)`.
+ * `request.headers` is a Fetch `Headers` instance which string interpolation cannot read
+ * with `{context.headers.foo}` — convert to a plain/lookup object first.
+ */
+function getContextWithHeaders(request?: Request, context?: Record<string, any>) {
+  const headersSource = context?.headers ?? request?.headers;
+  const headers = headersSource != null ? getHeadersObj(headersSource) : {};
+  return {
+    ...context,
+    headers,
+    request,
+  };
+}
 
 function generateSessionIdFactory(sessionIdDef: string) {
   if (sessionIdDef == null) {
@@ -15,18 +31,18 @@ function generateSessionIdFactory(sessionIdDef: string) {
       return null;
     };
   }
-  return function session(context: any) {
+  return function session(request: Request, context?: Record<string, any>) {
     return stringInterpolator.parse(sessionIdDef, {
-      context,
+      context: getContextWithHeaders(request, context),
       env: process.env,
     });
   };
 }
 
 function generateEnabledFactory(ifDef: string) {
-  return function enabled(context: any) {
+  return function enabled(request: Request, context?: Record<string, any>) {
     // eslint-disable-next-line no-new-func
-    return new Function('context', `return ${ifDef}`)(context);
+    return new Function('context', `return ${ifDef}`)(getContextWithHeaders(request, context));
   };
 }
 
@@ -34,8 +50,14 @@ function getBuildResponseCacheKey(
   cacheKeyDef: string,
 ): UseResponseCacheParameter['buildResponseCacheKey'] {
   return function buildResponseCacheKey(cacheKeyParameters) {
+    const { request, context, ...rest } = cacheKeyParameters;
+    const contextWithHeaders = getContextWithHeaders(request, context as Record<string, any>);
     let cacheKey = stringInterpolator.parse(cacheKeyDef, {
-      ...cacheKeyParameters,
+      ...rest,
+      request,
+      context: contextWithHeaders,
+      // Docs historically used `contextValue` (Envelop naming)
+      contextValue: contextWithHeaders,
       env: process.env,
     });
     if (!cacheKey) {

--- a/packages/plugins/response-cache/tests/session-id-headers.test.ts
+++ b/packages/plugins/response-cache/tests/session-id-headers.test.ts
@@ -1,0 +1,218 @@
+import type { ExecutionResult } from 'graphql';
+import { createSchema, createYoga } from 'graphql-yoga';
+import { createGatewayRuntime, useCustomFetch } from '@graphql-hive/gateway-runtime';
+import { getUnifiedGraphGracefully } from '@graphql-mesh/fusion-composition';
+import type { KeyValueCache } from '@graphql-mesh/types';
+import useMeshResponseCache from '../src/index';
+
+function createMemoryCache(): KeyValueCache {
+  const map = new Map<string, unknown>();
+  return {
+    get(key) {
+      return map.get(key) as any;
+    },
+    set(key, value) {
+      map.set(key, value);
+    },
+    delete(key) {
+      return map.delete(key);
+    },
+    getKeysByPrefix(prefix) {
+      return [...map.keys()].filter(key => key.startsWith(prefix));
+    },
+  };
+}
+
+describe('response-cache sessionId headers', () => {
+  it('uses Fetch Request headers in sessionId so different sessions do not share cache', async () => {
+    const upstreamSchema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          greeting: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          greeting: () => 'hello',
+        },
+      },
+    });
+    await using upstreamServer = createYoga({
+      schema: upstreamSchema,
+    });
+    const cache = createMemoryCache();
+    await using gw = createGatewayRuntime({
+      supergraph: () =>
+        getUnifiedGraphGracefully([
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
+            url: 'http://localhost:4001/graphql',
+          },
+        ]),
+      plugins: ctx => [
+        useCustomFetch(function (url, options) {
+          if (String(url) === 'http://localhost:4001/graphql') {
+            return upstreamServer.fetch(url, options);
+          }
+          return Response.error();
+        }),
+        useMeshResponseCache({
+          ...ctx,
+          cache,
+          ttl: 60_000,
+          includeExtensionMetadata: true,
+          sessionId: '{context.headers.test}',
+        }),
+      ],
+    });
+
+    async function query(testHeader: string) {
+      const res = await gw.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          test: testHeader,
+        },
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              greeting
+            }
+          `,
+        }),
+      });
+      expect(res.status).toBe(200);
+      return (await res.json()) as ExecutionResult;
+    }
+
+    // First request for session "a" — miss, then write
+    await expect(query('a')).resolves.toMatchObject({
+      data: { greeting: 'hello' },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+        },
+      },
+    });
+
+    // Same session — hit
+    await expect(query('a')).resolves.toMatchObject({
+      data: { greeting: 'hello' },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    });
+
+    // Different session "b" — must not hit "a"'s entry (reproduces #5102)
+    await expect(query('b')).resolves.toMatchObject({
+      data: { greeting: 'hello' },
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+        },
+      },
+    });
+
+    // Session "b" again — hit
+    await expect(query('b')).resolves.toMatchObject({
+      data: { greeting: 'hello' },
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    });
+  });
+
+  it('evaluates enabled `if` against Request headers', async () => {
+    const upstreamSchema = createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          greeting: String!
+        }
+      `,
+      resolvers: {
+        Query: {
+          greeting: () => 'hello',
+        },
+      },
+    });
+    await using upstreamServer = createYoga({
+      schema: upstreamSchema,
+    });
+    const cache = createMemoryCache();
+    await using gw = createGatewayRuntime({
+      supergraph: () =>
+        getUnifiedGraphGracefully([
+          {
+            name: 'upstream',
+            schema: upstreamSchema,
+            url: 'http://localhost:4001/graphql',
+          },
+        ]),
+      plugins: ctx => [
+        useCustomFetch(function (url, options) {
+          if (String(url) === 'http://localhost:4001/graphql') {
+            return upstreamServer.fetch(url, options);
+          }
+          return Response.error();
+        }),
+        useMeshResponseCache({
+          ...ctx,
+          cache,
+          ttl: 60_000,
+          includeExtensionMetadata: true,
+          if: 'context.headers["x-cache"] == "1"',
+        }),
+      ],
+    });
+
+    async function query(cacheHeader?: string) {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (cacheHeader != null) {
+        headers['x-cache'] = cacheHeader;
+      }
+      const res = await gw.fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          query: /* GraphQL */ `
+            query {
+              greeting
+            }
+          `,
+        }),
+      });
+      expect(res.status).toBe(200);
+      return (await res.json()) as ExecutionResult;
+    }
+
+    // Caching disabled without header
+    const disabled = await query();
+    expect(disabled.extensions?.responseCache).toBeUndefined();
+
+    // Caching enabled with header
+    await expect(query('1')).resolves.toMatchObject({
+      extensions: {
+        responseCache: {
+          didCache: true,
+          hit: false,
+        },
+      },
+    });
+    await expect(query('1')).resolves.toMatchObject({
+      extensions: {
+        responseCache: {
+          hit: true,
+        },
+      },
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5300,6 +5300,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@e2e/response-cache-session-headers@workspace:e2e/response-cache-session-headers":
+  version: 0.0.0-use.local
+  resolution: "@e2e/response-cache-session-headers@workspace:e2e/response-cache-session-headers"
+  dependencies:
+    "@graphql-hive/gateway": "npm:^2.11.2"
+    "@graphql-mesh/compose-cli": "npm:^1.6.2"
+    "@graphql-mesh/plugin-response-cache": "npm:^0.105.1"
+    graphql: "npm:16.14.0"
+    graphql-yoga: "npm:^5.21.2"
+  languageName: unknown
+  linkType: soft
+
 "@e2e/semantic-conventions@workspace:e2e/semantic-conventions":
   version: 0.0.0-use.local
   resolution: "@e2e/semantic-conventions@workspace:e2e/semantic-conventions"
@@ -8862,7 +8874,9 @@ __metadata:
   dependencies:
     "@envelop/core": "npm:^5.5.1"
     "@envelop/response-cache": "npm:^9.1.1"
+    "@graphql-hive/gateway-runtime": "npm:^2.10.7"
     "@graphql-mesh/cross-helpers": "npm:^0.4.16"
+    "@graphql-mesh/fusion-composition": "npm:^0.9.2"
     "@graphql-mesh/string-interpolation": "npm:^0.5.18"
     "@graphql-mesh/types": "npm:^0.105.1"
     "@graphql-mesh/utils": "npm:^0.105.1"
@@ -27077,6 +27091,7 @@ __metadata:
     "@graphql-mesh/cli": "npm:^0.101.2"
     "@graphql-mesh/json-schema": "npm:^0.110.1"
     "@graphql-mesh/plugin-mock": "npm:^0.106.1"
+    "@graphql-mesh/plugin-response-cache": "npm:^0.105.1"
     graphql: "npm:16.14.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
- Normalize Fetch `Headers` in `sessionId` / `if` / `cacheKey` string templates so values like `{context.headers.test}` work under Yoga’s `(request, context)` callbacks
- Add unit, e2e, and v0 (`examples/response-cache`) coverage for the #5102 codesandbox scenario (different `test` header must not share cache entries)
- Supersedes #5103 (same bugfix, rebased onto current master with tests)

Fixes #5102
Closes #5103

## Test plan
- [x] `yarn jest packages/plugins/response-cache/tests/session-id-headers.test.ts`
- [x] `INTEGRATION_TEST=true yarn jest examples/response-cache/tests/response-cache.spec.ts`
- [ ] CI e2e for `e2e/response-cache-session-headers`