### PR TITLE
Improve Mesh v0 config migration CLI and guide

### DIFF
--- a/.changeset/migrate-config-cli-tests.md
+++ b/.changeset/migrate-config-cli-tests.md
@@ -1,0 +1,5 @@
+---
+'@graphql-mesh/migrate-config-cli': patch
+---
+
+Make v0 config migration testable and document handler/transform mappings. The CLI now fails without writing on unsupported config, supports `--dry-run` and `--force`, and maps more GraphQL/transform options instead of dumping YAML as-is.

--- a/packages/legacy/migrate-config-cli/src/index.ts
+++ b/packages/legacy/migrate-config-cli/src/index.ts
@@ -1,17 +1,74 @@
 // eslint-disable-next-line import/no-nodejs-modules
-import { writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 // eslint-disable-next-line import/no-nodejs-modules
 import { join } from 'node:path';
-import kebabCase from 'lodash.kebabcase';
 import { format } from 'prettier';
 import { findConfig } from '@graphql-mesh/cli';
-import { camelCase } from '@graphql-mesh/compose-cli';
 import { getPackage } from '@graphql-mesh/config';
 import type { YamlConfig } from '@graphql-mesh/types';
 import { defaultImportFn } from '@graphql-mesh/utils';
+import {
+  migrateLegacyConfig,
+  type MigrateLegacyConfigResult,
+  type ResolveLegacyPlugin,
+} from './migrate.js';
 
-export async function run() {
-  const cwd = process.argv[2] || process.cwd();
+export { migrateLegacyConfig } from './migrate.js';
+export type {
+  MigrateLegacyConfigOptions,
+  MigrateLegacyConfigResult,
+  MigrationMessage,
+  ResolveLegacyPlugin,
+} from './migrate.js';
+
+function camelCase(value: string): string {
+  return value.replace(/[-_]+(\w)/g, (_, char: string) => char.toUpperCase());
+}
+
+export const createDefaultPluginResolver =
+  (cwd: string): ResolveLegacyPlugin =>
+  async ({ name }) => {
+    try {
+      const { resolved: possiblePluginFactory, moduleName } = await getPackage<any>({
+        name,
+        type: 'plugin',
+        importFn: defaultImportFn,
+        cwd,
+        additionalPrefixes: ['@envelop/', '@graphql-yoga/plugin-', '@escape.tech/graphql-armor-'],
+      });
+      if (typeof possiblePluginFactory === 'function') {
+        const fnName = camelCase(`use_${name}`);
+        return {
+          moduleName,
+          importName: `default as ${fnName}`,
+          factoryName: fnName,
+        };
+      }
+      const importName = Object.keys(possiblePluginFactory || {}).find(
+        iName =>
+          (iName.toString().startsWith('use') || iName.toString().endsWith('Plugin')) &&
+          typeof possiblePluginFactory[iName] === 'function',
+      );
+      if (!importName) {
+        return undefined;
+      }
+      return {
+        moduleName,
+        importName: importName.toString(),
+        factoryName: importName.toString(),
+      };
+    } catch {
+      return undefined;
+    }
+  };
+
+export async function run(argv = process.argv): Promise<MigrateLegacyConfigResult> {
+  const args = argv.slice(2).filter(arg => arg !== '--');
+  const dryRun = args.includes('--dry-run');
+  const force = args.includes('--force');
+  const positional = args.filter(arg => !arg.startsWith('--'));
+  const cwd = positional[0] || process.cwd();
+
   const {
     config: legacyConfig,
     filepath,
@@ -24,317 +81,66 @@ export async function run() {
     initialLoggerPrefix: 'Mesh Config Migrate',
     dir: cwd,
   });
-  if (isEmpty) {
+  if (isEmpty || !legacyConfig) {
     console.error('No config file found');
-    process.exit(1);
-  }
-  if (!legacyConfig) {
-    console.error('No config found');
-    process.exit(1);
+    process.exitCode = 1;
+    return {
+      code: '',
+      addedPackages: [],
+      removedPackages: [],
+      messages: [{ level: 'error', message: 'No config file found' }],
+      fatal: true,
+    };
   }
   console.log(`Found config at ${filepath}`);
 
-  // Create compose configuration
-  const importMap = new Map<string, Set<string>>();
-  const addedPackages = new Set<string>(['@graphql-hive/gateway', '@graphql-mesh/compose-cli']);
-  const removedPackages = new Set<string>(['@graphql-mesh/cli']);
-
-  // Prepare Compose Configuration
-  const subgraphConfigList = new Set<string>();
-  for (const legacySource of legacyConfig.sources) {
-    const handlerName = Object.keys(legacySource.handler)[0];
-    if (handlerName === 'supergraph') {
-      console.error(
-        `If you use "supergraph" handler, you probably don't need to use Mesh Compose,
-check Hive Gateway's docs to consume a supergraph.`,
-      );
-      process.exit(1);
-    }
-    const handlerConfig = legacySource.handler[handlerName];
-    const handlerInfo = handlerInfoMap[handlerName];
-    if (!handlerInfo) {
-      console.error(
-        `Handler ${handlerName} is not supported currently in Mesh Migrate CLI, please do the migration manually.`,
-      );
-      process.exit(1);
-    }
-    addImport(importMap, handlerInfo.packageName, handlerInfo.importName);
-    removedPackages.add(handlerInfo.oldPackageName);
-    addedPackages.add(handlerInfo.packageName);
-    const subgraphConfigContent = new Set<string>();
-    subgraphConfigContent.add(`
-      sourceHandler: ${handlerInfo.importName}(${JSON.stringify(legacySource.name)},
-        ${JSON.stringify(handlerConfig)}
-      )
-      `);
-    if (legacySource.transforms?.length) {
-      subgraphConfigContent.add(`transforms: [
-          ${legacySource.transforms.map(transform => handleTransformConfiguration(importMap, transform)).join(',\n')}
-        ]`);
-    }
-    subgraphConfigList.add(`{
-      ${Array.from(subgraphConfigContent).join(',\n')}
-      }`);
-  }
-  const subgraphsConfig = `
-    subgraphs: [
-      ${Array.from(subgraphConfigList).join(',\n')}
-    ]
-  `;
-
-  const composeConfigList = new Set<string>();
-  composeConfigList.add(subgraphsConfig);
-  if (legacyConfig.additionalTypeDefs) {
-    composeConfigList.add(
-      `additionalTypeDefs: ${JSON.stringify(legacyConfig.additionalTypeDefs)},`,
-    );
-  }
-  if (legacyConfig.transforms) {
-    console.error(
-      'Root level transforms are not supported in Mesh Compose CLI! Please source level transforms instead!',
-    );
-    process.exit(1);
-  }
-  if (legacyConfig.customFetch) {
-    const [packageName, importName = 'default'] = legacyConfig.customFetch.split('#');
-    addImport(importMap, packageName, `${importName} as customFetch`);
-    composeConfigList.add(`fetch: customFetch,`);
-  }
-
-  addImport(importMap, '@graphql-mesh/compose-cli', 'defineConfig as defineComposeConfig');
-  const configList = new Set<string>();
-  const composeConfig = `
-    export const composeConfig = defineComposeConfig({
-      ${Array.from(composeConfigList).join(',\n')}
-    });
-  `;
-
-  // Serve Configuration
-  const serveConfigList = new Set<string>();
-  const pluginList = new Set<string>();
-  if (legacyConfig.additionalEnvelopPlugins) {
-    const [packageName, importName = 'default'] = legacyConfig.additionalEnvelopPlugins.split('#');
-    addImport(importMap, packageName, `${importName} as additionalEnvelopPlugins`);
-    pluginList.add(`...additionalEnvelopPlugins`);
-  }
-  if (legacyConfig.additionalResolvers) {
-    const additionalResolversNewConfig = new Set<string>();
-    const additionalResolversConfigs = Array.isArray(legacyConfig.additionalResolvers)
-      ? legacyConfig.additionalResolvers
-      : [legacyConfig.additionalResolvers];
-    for (const additionalResolversConfigIndex in additionalResolversConfigs) {
-      const additionalResolversConfig = additionalResolversConfigs[additionalResolversConfigIndex];
-      if (typeof additionalResolversConfig === 'string') {
-        const importNameAlias = `additionalResolvers$${additionalResolversConfigIndex}`;
-        const [packageName, importName = 'default'] = additionalResolversConfig.split('#');
-        addImport(importMap, packageName, `${importName} as ${importNameAlias}`);
-        additionalResolversNewConfig.add(importNameAlias);
-      } else if (typeof additionalResolversConfig === 'object') {
-        additionalResolversNewConfig.add(JSON.stringify(additionalResolversConfig));
-      }
-    }
-    serveConfigList.add(`additionalResolvers: [
-      ${Array.from(additionalResolversNewConfig).join(',\n')}
-    ]`);
-  }
-  if (legacyConfig.cache) {
-    const cacheName = Object.keys(legacyConfig.cache)[0].toString();
-    const packageName = `@graphql-mesh/cache-${kebabCase(cacheName)}`;
-    const cacheConfig = legacyConfig.cache[cacheName];
-    addImport(importMap, packageName, 'default as Cache');
-    serveConfigList.add(`cache: new Cache(${JSON.stringify(cacheConfig)})`);
-  }
-  if (legacyConfig.codegen) {
-    console.warn(
-      'Codegen is not available in Mesh Compose CLI! Please use GraphQL Codegen directly to generate types!',
-    );
-  }
-  if (legacyConfig.customFetch) {
-    const [packageName, importName = 'default'] = legacyConfig.customFetch.split('#');
-    addImport(importMap, packageName, `${importName} as customFetch`);
-    serveConfigList.add(`fetchAPI: { fetch: customFetch }`);
-  }
-  if (legacyConfig.logger) {
-    const [packageName, importName = 'default'] = legacyConfig.logger.split('#');
-    addImport(importMap, packageName, `${importName} as logger`);
-    serveConfigList.add(`logger`);
-  }
-  if (legacyConfig.pubsub) {
-    console.warn(
-      'PubSub configuration cannot be migrated right now. Please check docs for PubSub configuration in Mesh Compose CLI!',
-    );
-  }
-  if (legacyConfig.persistedOperations) {
-    console.warn(
-      'Persisted Operations configuration cannot be migrated right now. Please check docs for Persisted Operations configuration in Mesh Compose CLI!',
-    );
-  }
-  if (legacyConfig.plugins) {
-    for (const legacyPluginConfig of legacyConfig.plugins) {
-      const legacyPluginName = Object.keys(legacyPluginConfig)[0];
-      if (legacyPluginName === 'maskedErrors') {
-        const maskedErrorsConfig = legacyPluginConfig[legacyPluginName];
-        if (typeof maskedErrorsConfig === 'boolean') {
-          serveConfigList.add(`maskedErrors: ${maskedErrorsConfig}`);
-        } else {
-          serveConfigList.add(`maskedErrors: ${JSON.stringify(maskedErrorsConfig)}`);
-        }
-      } else if (legacyPluginName === 'immediateIntrospection') {
-        addImport(importMap, '@envelop/core', 'useImmediateIntrospection');
-        pluginList.add('useImmediateIntrospection()');
-      } else if (legacyPluginName === 'hive') {
-        const { persistedDocuments, ...hiveConfig } = legacyPluginConfig[legacyPluginName];
-        serveConfigList.add(`
-          reporting: ${JSON.stringify({
-            type: 'hive',
-            ...hiveConfig,
-          })}
-        `);
-
-        if (persistedDocuments) {
-          serveConfigList.add(
-            `persistedOperations: ${JSON.stringify({
-              type: 'hive',
-
-              ...persistedDocuments,
-            })}`,
-          );
-        }
-      } else if (legacyPluginName === 'prometheus') {
-        serveConfigList.add(`prometheus: ${JSON.stringify(legacyPluginConfig[legacyPluginName])}`);
-      } else if (legacyPluginName === 'rateLimit') {
-        serveConfigList.add(
-          `rateLimiting: ${JSON.stringify(legacyPluginConfig[legacyPluginName])}`,
-        );
-      } else if (legacyPluginName === 'responseCache') {
-        serveConfigList.add(
-          `responseCaching: ${JSON.stringify(legacyPluginConfig[legacyPluginName])}`,
-        );
-      } else {
-        const { resolved: possiblePluginFactory, moduleName } = await getPackage<any>({
-          name: legacyPluginName.toString(),
-          type: 'plugin',
-          importFn: defaultImportFn,
-          cwd,
-          additionalPrefixes: ['@envelop/', '@graphql-yoga/plugin-', '@escape.tech/graphql-armor-'],
-        });
-        let importName: string;
-        let fnName: string;
-        if (typeof possiblePluginFactory === 'function') {
-          fnName = camelCase(`use_${legacyPluginName}`);
-          importName = `default as ${fnName}`;
-        } else {
-          importName = Object.keys(possiblePluginFactory)
-            .find(
-              iName =>
-                (iName.toString().startsWith('use') || iName.toString().endsWith('Plugin')) &&
-                typeof possiblePluginFactory[iName] === 'function',
-            )
-            .toString();
-          fnName = importName;
-        }
-        addImport(importMap, moduleName, importName);
-        pluginList.add(`${fnName}({
-          ...ctx,
-          ${JSON.stringify(legacyPluginConfig[legacyPluginName]).slice(1, -1)},
-        })`);
-      }
-    }
-  }
-  if (legacyConfig.pollingInterval) {
-    serveConfigList.add(`pollingInterval: ${legacyConfig.pollingInterval}`);
-  }
-  if (legacyConfig.require) {
-    for (const requiredPackage of legacyConfig.require) {
-      configList.add(`import '${requiredPackage}';`);
-    }
-  }
-  if (legacyConfig.sdk) {
-    console.warn(
-      'Mesh no longer generates SDKs. Please use GraphQL Codegen to generate types and SDK!',
-    );
-  }
-  if (legacyConfig.serve) {
-    if (legacyConfig.serve.batchingLimit) {
-      serveConfigList.add(`batching: {
-        limit: ${legacyConfig.serve.batchingLimit}
-      }`);
-    }
-    if (legacyConfig.serve.cors) {
-      serveConfigList.add(`cors: ${JSON.stringify(legacyConfig.serve.cors)}`);
-    }
-    if (legacyConfig.serve.endpoint) {
-      serveConfigList.add(`graphqlEndpoint: ${JSON.stringify(legacyConfig.serve.endpoint)}`);
-    }
-    if (legacyConfig.serve.extraParamNames) {
-      console.warn(
-        'Extra Param Names configuration cannot be migrated right now. Please check docs for Extra Param Names configuration in Mesh Compose CLI!',
-      );
-    }
-    if (legacyConfig.serve.fork) {
-      serveConfigList.add(`fork: ${legacyConfig.serve.fork}`);
-    }
-    if (legacyConfig.serve.healthCheckEndpoint) {
-      serveConfigList.add(
-        `healthCheckEndpoint: ${JSON.stringify(legacyConfig.serve.healthCheckEndpoint)}`,
-      );
-    }
-    if (legacyConfig.serve.hostname) {
-      serveConfigList.add(`host: ${JSON.stringify(legacyConfig.serve.hostname)}`);
-    }
-    if (legacyConfig.serve.playground === false) {
-      serveConfigList.add(`graphiql: false`);
-    }
-    if (legacyConfig.serve.playgroundTitle) {
-      serveConfigList.add(`graphiql: {
-        title: ${JSON.stringify(legacyConfig.serve.playgroundTitle)}
-        }`);
-    }
-    if (legacyConfig.serve.port) {
-      serveConfigList.add(`port: ${legacyConfig.serve.port}`);
-    }
-    if (legacyConfig.serve.sslCredentials) {
-      serveConfigList.add(`sslCredentials: ${JSON.stringify(legacyConfig.serve.sslCredentials)}`);
-    }
-    if (legacyConfig.serve.staticFiles) {
-      addImport(importMap, '@graphql-hive/gateway', 'useStaticFiles');
-      pluginList.add(`useStaticFiles(${JSON.stringify(legacyConfig.serve.staticFiles)})`);
-    }
-  }
-  if (legacyConfig.skipSSLValidation) {
-    configList.add(`process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';`);
-  }
-  serveConfigList.add(`plugins: ctx => ([
-    ${Array.from(pluginList).join(',\n')}
-  ])`);
-  addImport(importMap, '@graphql-hive/gateway', 'defineConfig as defineGatewayConfig');
-  const serveConfig = `
-    export const gatewayConfig = defineGatewayConfig({
-      ${Array.from(serveConfigList).join(',\n')}
-    });
-  `;
-  for (const [packageName, imports] of importMap) {
-    configList.add(`import { ${Array.from(imports).join(', ')} } from '${packageName}';`);
-  }
-  configList.add(composeConfig);
-  configList.add(serveConfig);
-  const newConfigPath = join(cwd, 'mesh.config.ts');
-  let configContent = Array.from(configList).join('\n');
-  configContent = await format(configContent, {
-    parser: 'typescript',
+  const result = await migrateLegacyConfig(legacyConfig, {
+    cwd,
+    resolvePlugin: createDefaultPluginResolver(cwd),
   });
-  writeFileSync(newConfigPath, configContent);
+  result.code = await format(result.code, { parser: 'typescript' });
+
+  for (const message of result.messages) {
+    if (message.level === 'error') {
+      console.error(message.message);
+    } else {
+      console.warn(message.message);
+    }
+  }
+
+  if (result.fatal) {
+    console.error('Migration did not write mesh.config.ts because of the errors above.');
+    process.exitCode = 1;
+    return result;
+  }
+
+  const newConfigPath = join(cwd, 'mesh.config.ts');
+  if (!dryRun) {
+    if (existsSync(newConfigPath) && !force) {
+      console.error(
+        `${newConfigPath} already exists. Pass --force to overwrite, or --dry-run to print the result.`,
+      );
+      process.exitCode = 1;
+      return result;
+    }
+    writeFileSync(newConfigPath, result.code);
+  } else {
+    process.stdout.write(result.code);
+  }
+
   console.log('Migration successful!');
   console.log(' ');
-  console.log(`New config file created at ${newConfigPath}`);
-  console.log(' ');
+  if (!dryRun) {
+    console.log(`New config file created at ${newConfigPath}`);
+    console.log(' ');
+  }
   console.log('Please make sure to install the following packages in package.json:');
-  for (const packageName of addedPackages) {
+  for (const packageName of result.addedPackages) {
     console.log(`- ${packageName}`);
   }
   console.log(' ');
   console.log('Please make sure to remove the following packages in package.json:');
-  for (const packageName of removedPackages) {
+  for (const packageName of result.removedPackages) {
     console.log(`- ${packageName}`);
   }
   console.log(' ');
@@ -342,141 +148,5 @@ check Hive Gateway's docs to consume a supergraph.`,
     `Then run "npx mesh-compose -o supergraph.graphql" to generate the supergraph schema!`,
   );
   console.log(`Finally, run "npx hive-gateway supergraph" to start the gateway server!`);
-}
-
-function addImport(importMap: Map<string, Set<string>>, packageName: string, importName: string) {
-  let set = importMap.get(packageName);
-  if (!set) {
-    set = new Set();
-    importMap.set(packageName, set);
-  }
-  set.add(importName);
-}
-
-const handlerInfoMap = {
-  graphql: {
-    packageName: '@graphql-mesh/compose-cli',
-    oldPackageName: '@graphql-mesh/graphql',
-    importName: 'loadGraphQLHTTPSubgraph',
-  },
-  grpc: {
-    packageName: '@omnigraph/grpc',
-    oldPackageName: '@graphql-mesh/grpc',
-    importName: 'loadGRPCSubgraph',
-  },
-  jsonSchema: {
-    packageName: '@omnigraph/json-schema',
-    oldPackageName: '@graphql-mesh/json-schema',
-    importName: 'loadJSONSchemaSubgraph',
-  },
-  mongoose: {
-    packageName: '@omnigraph/mongoose',
-    oldPackageName: '@graphql-mesh/mongoose',
-    importName: 'loadMongooseSubgraph',
-  },
-  mysql: {
-    packageName: '@omnigraph/mysql',
-    oldPackageName: '@graphql-mesh/mysql',
-    importName: 'loadMySQLSubgraph',
-  },
-  neo4j: {
-    packageName: '@omnigraph/neo4j',
-    oldPackageName: '@graphql-mesh/neo4j',
-    importName: 'loadNeo4jSubgraph',
-  },
-  odata: {
-    packageName: '@omnigraph/odata',
-    oldPackageName: '@graphql-mesh/odata',
-    importName: 'loadODataSubgraph',
-  },
-  postgraphile: {
-    packageName: '@omnigraph/postgresql',
-    oldPackageName: '@graphql-mesh/postgraphile',
-    importName: 'loadPostgreSQLSubgraph',
-  },
-  raml: {
-    packageName: '@omnigraph/raml',
-    oldPackageName: '@graphql-mesh/raml',
-    importName: 'loadRAMLSubgraph',
-  },
-  openapi: {
-    packageName: '@omnigraph/openapi',
-    oldPackageName: '@graphql-mesh/openapi',
-    importName: 'loadOpenAPISubgraph',
-  },
-  soap: {
-    packageName: '@omnigraph/soap',
-    oldPackageName: '@graphql-mesh/soap',
-    importName: 'loadSOAPSubgraph',
-  },
-  thrift: {
-    packageName: '@omnigraph/thrift',
-    oldPackageName: '@graphql-mesh/thrift',
-    importName: 'loadThriftSubgraph',
-  },
-  tuql: {
-    packageName: '@omnigraph/sqlite',
-    oldPackageName: '@graphql-mesh/tuql',
-    importName: 'loadSQLiteSubgraph',
-  },
-};
-
-const transformInfoMap = {
-  cache: {
-    deprecated: 'Cache Transform has been deprecated, please use response caching plugin instead!',
-  },
-  encapsulate: {
-    fnName: 'createEncapsulateTransform',
-  },
-  extend: {
-    deprecated: 'Extend Transform has been deprecated, please use additionalTypeDefs instead!',
-  },
-  federation: {
-    fnName: 'createFederationTransform',
-  },
-  filterSchema: {
-    fnName: 'createFilterTransform',
-  },
-  hoistField: {
-    fnName: 'createHoistFieldTransform',
-  },
-  namingConvention: {
-    fnName: 'createNamingConventionTransform',
-  },
-  prefix: {
-    fnName: 'createPrefixTransform',
-  },
-  rateLimit: {
-    deprecated: 'RateLimit Transform has been deprecated, please use rate limiting plugin instead!',
-  },
-  rename: {
-    fnName: 'createRenameTransform',
-  },
-  replaceField: {
-    deprecated:
-      'ReplaceField Transform has been deprecated, please check other alternatives like Hoist Field Transform!',
-  },
-  resolversComposition: {
-    deprecated:
-      'ResolversComposition Transform has been deprecated, please use alternatives or additionalResolvers instead!',
-  },
-  typeMerging: {
-    deprecated:
-      'TypeMerging Transform has been deprecated, please use Federation Transform instead!',
-  },
-};
-
-function handleTransformConfiguration(
-  importMap: Map<string, Set<string>>,
-  transformConfiguration: YamlConfig.Transform,
-) {
-  const transformName = Object.keys(transformConfiguration)[0];
-  const transformConfig = transformConfiguration[transformName];
-  const transformInfo = transformInfoMap[transformName];
-  if (transformInfo.deprecated) {
-    console.error(transformInfo.deprecated);
-    process.exit(1);
-  }
-  addImport(importMap, '@graphql-mesh/compose-cli', transformInfo.fnName);
-  return `${transformInfo.fnName}(${JSON.stringify(transformConfig)})`;
+  return result;
 }

--- a/packages/legacy/migrate-config-cli/src/index.ts
+++ b/packages/legacy/migrate-config-cli/src/index.ts
@@ -21,6 +21,11 @@ export type {
   ResolveLegacyPlugin,
 } from './migrate.js';
 
+function pluginFactoryName(pluginName: string): string {
+  const cleaned = pluginName.replace(/^@/, '').replace(/[^a-zA-Z0-9]+/g, '_');
+  return camelCase(`use_${cleaned}`);
+}
+
 function camelCase(value: string): string {
   return value.replace(/[-_]+(\w)/g, (_, char: string) => char.toUpperCase());
 }
@@ -37,7 +42,7 @@ export const createDefaultPluginResolver =
         additionalPrefixes: ['@envelop/', '@graphql-yoga/plugin-', '@escape.tech/graphql-armor-'],
       });
       if (typeof possiblePluginFactory === 'function') {
-        const fnName = camelCase(`use_${name}`);
+        const fnName = pluginFactoryName(name);
         return {
           moduleName,
           importName: `default as ${fnName}`,
@@ -57,7 +62,10 @@ export const createDefaultPluginResolver =
         importName: importName.toString(),
         factoryName: importName.toString(),
       };
-    } catch {
+    } catch (error) {
+      console.warn(
+        `Plugin "${name}" could not be loaded: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return undefined;
     }
   };
@@ -81,6 +89,10 @@ export async function run(argv = process.argv): Promise<MigrateLegacyConfigResul
     initialLoggerPrefix: 'Mesh Config Migrate',
     dir: cwd,
   });
+  const log = (...parts: string[]) => {
+    (dryRun ? console.error : console.log)(...parts);
+  };
+
   if (isEmpty || !legacyConfig) {
     console.error('No config file found');
     process.exitCode = 1;
@@ -92,13 +104,19 @@ export async function run(argv = process.argv): Promise<MigrateLegacyConfigResul
       fatal: true,
     };
   }
-  console.log(`Found config at ${filepath}`);
+  log(`Found config at ${filepath}`);
 
   const result = await migrateLegacyConfig(legacyConfig, {
     cwd,
     resolvePlugin: createDefaultPluginResolver(cwd),
   });
-  result.code = await format(result.code, { parser: 'typescript' });
+  try {
+    result.code = await format(result.code, { parser: 'typescript' });
+  } catch (error) {
+    console.warn(
+      `Could not format the generated config: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 
   for (const message of result.messages) {
     if (message.level === 'error') {
@@ -128,25 +146,23 @@ export async function run(argv = process.argv): Promise<MigrateLegacyConfigResul
     process.stdout.write(result.code);
   }
 
-  console.log('Migration successful!');
-  console.log(' ');
+  log('Migration successful!');
+  log(' ');
   if (!dryRun) {
-    console.log(`New config file created at ${newConfigPath}`);
-    console.log(' ');
+    log(`New config file created at ${newConfigPath}`);
+    log(' ');
   }
-  console.log('Please make sure to install the following packages in package.json:');
+  log('Please make sure to install the following packages in package.json:');
   for (const packageName of result.addedPackages) {
-    console.log(`- ${packageName}`);
+    log(`- ${packageName}`);
   }
-  console.log(' ');
-  console.log('Please make sure to remove the following packages in package.json:');
+  log(' ');
+  log('Please make sure to remove the following packages in package.json:');
   for (const packageName of result.removedPackages) {
-    console.log(`- ${packageName}`);
+    log(`- ${packageName}`);
   }
-  console.log(' ');
-  console.log(
-    `Then run "npx mesh-compose -o supergraph.graphql" to generate the supergraph schema!`,
-  );
-  console.log(`Finally, run "npx hive-gateway supergraph" to start the gateway server!`);
+  log(' ');
+  log(`Then run "npx mesh-compose -o supergraph.graphql" to generate the supergraph schema!`);
+  log(`Finally, run "npx hive-gateway supergraph" to start the gateway server!`);
   return result;
 }

--- a/packages/legacy/migrate-config-cli/src/migrate.ts
+++ b/packages/legacy/migrate-config-cli/src/migrate.ts
@@ -1,0 +1,598 @@
+import kebabCase from 'lodash.kebabcase';
+import type { YamlConfig } from '@graphql-mesh/types';
+
+export type MigrationMessage = {
+  level: 'error' | 'warn' | 'info';
+  message: string;
+};
+
+export type ResolvedPluginImport = {
+  moduleName: string;
+  importName: string;
+  factoryName: string;
+};
+
+export type ResolveLegacyPlugin = (args: {
+  name: string;
+  cwd?: string;
+}) => Promise<ResolvedPluginImport | undefined>;
+
+export interface MigrateLegacyConfigOptions {
+  cwd?: string;
+  resolvePlugin?: ResolveLegacyPlugin;
+}
+
+export interface MigrateLegacyConfigResult {
+  code: string;
+  addedPackages: string[];
+  removedPackages: string[];
+  messages: MigrationMessage[];
+  fatal: boolean;
+}
+
+export async function migrateLegacyConfig(
+  legacyConfig: YamlConfig.Config,
+  options: MigrateLegacyConfigOptions = {},
+): Promise<MigrateLegacyConfigResult> {
+  const messages: MigrationMessage[] = [];
+  let fatal = false;
+  const importMap = new Map<string, Set<string>>();
+  const addedPackages = new Set<string>(['@graphql-hive/gateway', '@graphql-mesh/compose-cli']);
+  const removedPackages = new Set<string>(['@graphql-mesh/cli']);
+
+  const subgraphConfigList: string[] = [];
+  for (const legacySource of legacyConfig.sources ?? []) {
+    const handlerName = Object.keys(legacySource.handler)[0];
+    if (handlerName === 'supergraph') {
+      messages.push({
+        level: 'error',
+        message:
+          'The "supergraph" handler does not need Mesh Compose. Serve the supergraph with Hive Gateway instead: https://the-guild.dev/graphql/hive/docs/gateway',
+      });
+      fatal = true;
+      continue;
+    }
+    const handlerInfo = handlerInfoMap[handlerName];
+    if (!handlerInfo) {
+      messages.push({
+        level: 'error',
+        message: `Handler "${handlerName}" is not supported by mesh-migrate-config. See the v0 migration guide for the source-handler mapping, then migrate this source manually.`,
+      });
+      fatal = true;
+      continue;
+    }
+    addImport(importMap, handlerInfo.packageName, handlerInfo.importName);
+    removedPackages.add(handlerInfo.oldPackageName);
+    addedPackages.add(handlerInfo.packageName);
+
+    const mappedHandler = mapHandlerConfig(
+      handlerName,
+      legacySource.handler[handlerName],
+      messages,
+    );
+    if (mappedHandler === undefined) {
+      fatal = true;
+      continue;
+    }
+
+    const subgraphFields: string[] = [
+      `sourceHandler: ${handlerInfo.importName}(${JSON.stringify(legacySource.name)}, ${JSON.stringify(mappedHandler)})`,
+    ];
+    if (legacySource.transforms?.length) {
+      const transformExprs: string[] = [];
+      for (const transform of legacySource.transforms) {
+        const expr = handleTransformConfiguration(importMap, transform, messages);
+        if (expr) {
+          transformExprs.push(expr);
+        } else {
+          fatal = true;
+        }
+      }
+      if (transformExprs.length) {
+        subgraphFields.push(`transforms: [\n${transformExprs.join(',\n')}\n]`);
+      }
+    }
+    subgraphConfigList.push(`{\n${subgraphFields.join(',\n')}\n}`);
+  }
+
+  const composeConfigList: string[] = [];
+  if (subgraphConfigList.length) {
+    composeConfigList.push(`subgraphs: [\n${subgraphConfigList.join(',\n')}\n]`);
+  }
+  if (legacyConfig.additionalTypeDefs) {
+    composeConfigList.push(
+      `additionalTypeDefs: ${JSON.stringify(legacyConfig.additionalTypeDefs)}`,
+    );
+  }
+  if (legacyConfig.transforms?.length) {
+    messages.push({
+      level: 'error',
+      message:
+        'Root-level transforms are not supported in Mesh Compose. Move them onto the relevant source, or replace stitching/type-merging with the Federation transform.',
+    });
+    fatal = true;
+  }
+  if (legacyConfig.customFetch) {
+    const [packageName, importName = 'default'] = String(legacyConfig.customFetch).split('#');
+    addImport(importMap, packageName, `${importName} as customFetch`);
+    composeConfigList.push(`fetch: customFetch`);
+  }
+  if (legacyConfig.merger) {
+    messages.push({
+      level: 'warn',
+      message:
+        'The "merger" option is gone in Mesh v1. Composition uses Federation-compatible supergraphs; see Type Merging / Federation transform in the v1 docs.',
+    });
+  }
+  if (legacyConfig.documents?.length) {
+    messages.push({
+      level: 'warn',
+      message:
+        '"documents" is no longer part of Mesh config. Point GraphQL Codegen or your gateway persisted-documents setup at those files instead.',
+    });
+  }
+
+  addImport(importMap, '@graphql-mesh/compose-cli', 'defineConfig as defineComposeConfig');
+
+  const configList: string[] = [];
+  const composeConfig = `export const composeConfig = defineComposeConfig({
+${composeConfigList.join(',\n')}
+});`;
+
+  const serveConfigList: string[] = [];
+  const pluginList: string[] = [];
+
+  if (legacyConfig.additionalEnvelopPlugins) {
+    const [packageName, importName = 'default'] = legacyConfig.additionalEnvelopPlugins.split('#');
+    addImport(importMap, packageName, `${importName} as additionalEnvelopPlugins`);
+    pluginList.push(`...additionalEnvelopPlugins`);
+  }
+  if (legacyConfig.additionalResolvers) {
+    const additionalResolversNewConfig: string[] = [];
+    const additionalResolversConfigs = Array.isArray(legacyConfig.additionalResolvers)
+      ? legacyConfig.additionalResolvers
+      : [legacyConfig.additionalResolvers];
+    for (const additionalResolversConfigIndex in additionalResolversConfigs) {
+      const additionalResolversConfig = additionalResolversConfigs[additionalResolversConfigIndex];
+      if (typeof additionalResolversConfig === 'string') {
+        const importNameAlias = `additionalResolvers$${additionalResolversConfigIndex}`;
+        const [packageName, importName = 'default'] = additionalResolversConfig.split('#');
+        addImport(importMap, packageName, `${importName} as ${importNameAlias}`);
+        additionalResolversNewConfig.push(importNameAlias);
+      } else if (typeof additionalResolversConfig === 'object') {
+        additionalResolversNewConfig.push(JSON.stringify(additionalResolversConfig));
+      }
+    }
+    serveConfigList.push(`additionalResolvers: [
+${additionalResolversNewConfig.join(',\n')}
+]`);
+  }
+  if (legacyConfig.cache) {
+    const cacheName = Object.keys(legacyConfig.cache)[0].toString();
+    const packageName = `@graphql-mesh/cache-${kebabCase(cacheName)}`;
+    const cacheConfig = legacyConfig.cache[cacheName];
+    addImport(importMap, packageName, 'default as Cache');
+    addedPackages.add(packageName);
+    serveConfigList.push(`cache: new Cache(${JSON.stringify(cacheConfig)})`);
+  }
+  if (legacyConfig.codegen) {
+    messages.push({
+      level: 'warn',
+      message:
+        'Mesh no longer runs GraphQL Code Generator. Configure @graphql-codegen/cli separately if you need types or documents.',
+    });
+  }
+  if (legacyConfig.customFetch) {
+    const [packageName, importName = 'default'] = String(legacyConfig.customFetch).split('#');
+    addImport(importMap, packageName, `${importName} as customFetch`);
+    serveConfigList.push(`fetchAPI: { fetch: customFetch }`);
+  }
+  if (legacyConfig.logger) {
+    const [packageName, importName = 'default'] = legacyConfig.logger.split('#');
+    addImport(importMap, packageName, `${importName} as logger`);
+    serveConfigList.push(`logger`);
+  }
+  if (legacyConfig.pubsub) {
+    messages.push({
+      level: 'warn',
+      message:
+        'PubSub config cannot be migrated automatically. See Hive Gateway pubsub / subscriptions docs.',
+    });
+  }
+  if (legacyConfig.persistedOperations) {
+    messages.push({
+      level: 'warn',
+      message:
+        'Persisted operations cannot be migrated automatically. See https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents',
+    });
+  }
+  if (legacyConfig.plugins) {
+    for (const legacyPluginConfig of legacyConfig.plugins) {
+      const legacyPluginName = Object.keys(legacyPluginConfig)[0];
+      if (legacyPluginName === 'maskedErrors') {
+        const maskedErrorsConfig = legacyPluginConfig[legacyPluginName];
+        if (typeof maskedErrorsConfig === 'boolean') {
+          serveConfigList.push(`maskedErrors: ${maskedErrorsConfig}`);
+        } else {
+          serveConfigList.push(`maskedErrors: ${JSON.stringify(maskedErrorsConfig)}`);
+        }
+      } else if (legacyPluginName === 'immediateIntrospection') {
+        addImport(importMap, '@envelop/core', 'useImmediateIntrospection');
+        addedPackages.add('@envelop/core');
+        pluginList.push('useImmediateIntrospection()');
+      } else if (legacyPluginName === 'hive') {
+        const { persistedDocuments, ...hiveConfig } = legacyPluginConfig[legacyPluginName];
+        serveConfigList.push(
+          `reporting: ${JSON.stringify({
+            type: 'hive',
+            ...hiveConfig,
+          })}`,
+        );
+        if (persistedDocuments) {
+          serveConfigList.push(
+            `persistedDocuments: ${JSON.stringify({
+              type: 'hive',
+              ...persistedDocuments,
+            })}`,
+          );
+        }
+      } else if (legacyPluginName === 'prometheus') {
+        serveConfigList.push(`prometheus: ${JSON.stringify(legacyPluginConfig[legacyPluginName])}`);
+      } else if (legacyPluginName === 'rateLimit') {
+        serveConfigList.push(
+          `rateLimiting: ${JSON.stringify(legacyPluginConfig[legacyPluginName])}`,
+        );
+      } else if (legacyPluginName === 'responseCache') {
+        serveConfigList.push(
+          `responseCaching: ${JSON.stringify(legacyPluginConfig[legacyPluginName])}`,
+        );
+      } else if (options.resolvePlugin) {
+        const resolved = await options.resolvePlugin({
+          name: legacyPluginName.toString(),
+          cwd: options.cwd,
+        });
+        if (!resolved) {
+          messages.push({
+            level: 'warn',
+            message: `Plugin "${legacyPluginName}" could not be resolved. Add it to gatewayConfig.plugins manually.`,
+          });
+          continue;
+        }
+        addImport(importMap, resolved.moduleName, resolved.importName);
+        addedPackages.add(resolved.moduleName);
+        const pluginOpts = JSON.stringify(legacyPluginConfig[legacyPluginName]).slice(1, -1);
+        pluginList.push(`${resolved.factoryName}({
+          ...ctx,
+          ${pluginOpts}
+        })`);
+      } else {
+        messages.push({
+          level: 'warn',
+          message: `Plugin "${legacyPluginName}" is not a built-in gateway option. Map it to a Hive Gateway / Envelop plugin manually.`,
+        });
+      }
+    }
+  }
+  if (legacyConfig.pollingInterval) {
+    serveConfigList.push(`pollingInterval: ${legacyConfig.pollingInterval}`);
+  }
+  if (legacyConfig.require) {
+    for (const requiredPackage of legacyConfig.require) {
+      configList.push(`import '${requiredPackage}';`);
+    }
+  }
+  if (legacyConfig.sdk) {
+    messages.push({
+      level: 'warn',
+      message:
+        'Mesh no longer generates SDKs. Use GraphQL Codegen (e.g. client-preset or graphql-request) instead.',
+    });
+  }
+  if (legacyConfig.serve) {
+    if (legacyConfig.serve.batchingLimit) {
+      serveConfigList.push(`batching: {
+        limit: ${legacyConfig.serve.batchingLimit}
+      }`);
+    }
+    if (legacyConfig.serve.cors) {
+      serveConfigList.push(`cors: ${JSON.stringify(legacyConfig.serve.cors)}`);
+    }
+    if (legacyConfig.serve.endpoint) {
+      serveConfigList.push(`graphqlEndpoint: ${JSON.stringify(legacyConfig.serve.endpoint)}`);
+    }
+    if (legacyConfig.serve.extraParamNames) {
+      messages.push({
+        level: 'warn',
+        message:
+          'serve.extraParamNames cannot be migrated automatically. Configure extra GraphQL request parameters on Hive Gateway if you still need them.',
+      });
+    }
+    if (legacyConfig.serve.fork) {
+      serveConfigList.push(`fork: ${legacyConfig.serve.fork}`);
+    }
+    if (legacyConfig.serve.healthCheckEndpoint) {
+      serveConfigList.push(
+        `healthCheckEndpoint: ${JSON.stringify(legacyConfig.serve.healthCheckEndpoint)}`,
+      );
+    }
+    if (legacyConfig.serve.hostname) {
+      serveConfigList.push(`host: ${JSON.stringify(legacyConfig.serve.hostname)}`);
+    }
+    if (legacyConfig.serve.playground === false && !legacyConfig.serve.playgroundTitle) {
+      serveConfigList.push(`graphiql: false`);
+    }
+    if (legacyConfig.serve.playgroundTitle) {
+      serveConfigList.push(`graphiql: {
+        title: ${JSON.stringify(legacyConfig.serve.playgroundTitle)}
+        }`);
+    }
+    if (legacyConfig.serve.port) {
+      serveConfigList.push(`port: ${legacyConfig.serve.port}`);
+    }
+    if (legacyConfig.serve.sslCredentials) {
+      serveConfigList.push(`sslCredentials: ${JSON.stringify(legacyConfig.serve.sslCredentials)}`);
+    }
+    if (legacyConfig.serve.staticFiles) {
+      addImport(importMap, '@graphql-hive/gateway', 'useStaticFiles');
+      pluginList.push(`useStaticFiles(${JSON.stringify(legacyConfig.serve.staticFiles)})`);
+    }
+    if (legacyConfig.serve.browser != null) {
+      messages.push({
+        level: 'warn',
+        message:
+          'serve.browser (auto-open playground) is not part of Hive Gateway config and was skipped.',
+      });
+    }
+  }
+  if (legacyConfig.skipSSLValidation) {
+    configList.push(`process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';`);
+  }
+  if (pluginList.length) {
+    serveConfigList.push(`plugins: ctx => ([
+${pluginList.join(',\n')}
+])`);
+  }
+  addImport(importMap, '@graphql-hive/gateway', 'defineConfig as defineGatewayConfig');
+  const serveInner = serveConfigList.length ? `\n${serveConfigList.join(',\n')}\n` : '';
+  const serveConfig = `export const gatewayConfig = defineGatewayConfig({${serveInner}});`;
+  for (const [packageName, imports] of importMap) {
+    configList.push(`import { ${Array.from(imports).join(', ')} } from '${packageName}';`);
+  }
+  configList.push(composeConfig);
+  configList.push(serveConfig);
+
+  return {
+    code: configList.join('\n'),
+    addedPackages: Array.from(addedPackages),
+    removedPackages: Array.from(removedPackages),
+    messages,
+    fatal,
+  };
+}
+
+function addImport(importMap: Map<string, Set<string>>, packageName: string, importName: string) {
+  let set = importMap.get(packageName);
+  if (!set) {
+    set = new Set();
+    importMap.set(packageName, set);
+  }
+  set.add(importName);
+}
+
+function mapHandlerConfig(
+  handlerName: string,
+  handlerConfig: any,
+  messages: MigrationMessage[],
+): unknown | undefined {
+  if (handlerName !== 'graphql' || handlerConfig == null || typeof handlerConfig !== 'object') {
+    return handlerConfig;
+  }
+  if ('sources' in handlerConfig) {
+    messages.push({
+      level: 'error',
+      message:
+        'GraphQL handler "sources" (fallback/race/highestValue) is not generated by mesh-migrate-config. Split them into separate subgraphs or keep a single endpoint.',
+    });
+    return undefined;
+  }
+  if (!('endpoint' in handlerConfig) && 'source' in handlerConfig) {
+    const { source, ...rest } = handlerConfig;
+    return { endpoint: source, ...rest };
+  }
+  return handlerConfig;
+}
+
+const handlerInfoMap: Record<
+  string,
+  { packageName: string; oldPackageName: string; importName: string }
+> = {
+  graphql: {
+    packageName: '@graphql-mesh/compose-cli',
+    oldPackageName: '@graphql-mesh/graphql',
+    importName: 'loadGraphQLHTTPSubgraph',
+  },
+  grpc: {
+    packageName: '@omnigraph/grpc',
+    oldPackageName: '@graphql-mesh/grpc',
+    importName: 'loadGRPCSubgraph',
+  },
+  jsonSchema: {
+    packageName: '@omnigraph/json-schema',
+    oldPackageName: '@graphql-mesh/json-schema',
+    importName: 'loadJSONSchemaSubgraph',
+  },
+  mongoose: {
+    packageName: '@omnigraph/mongoose',
+    oldPackageName: '@graphql-mesh/mongoose',
+    importName: 'loadMongooseSubgraph',
+  },
+  mysql: {
+    packageName: '@omnigraph/mysql',
+    oldPackageName: '@graphql-mesh/mysql',
+    importName: 'loadMySQLSubgraph',
+  },
+  neo4j: {
+    packageName: '@omnigraph/neo4j',
+    oldPackageName: '@graphql-mesh/neo4j',
+    importName: 'loadNeo4jSubgraph',
+  },
+  odata: {
+    packageName: '@omnigraph/odata',
+    oldPackageName: '@graphql-mesh/odata',
+    importName: 'loadODataSubgraph',
+  },
+  postgraphile: {
+    packageName: '@omnigraph/postgresql',
+    oldPackageName: '@graphql-mesh/postgraphile',
+    importName: 'loadPostgreSQLSubgraph',
+  },
+  raml: {
+    packageName: '@omnigraph/raml',
+    oldPackageName: '@graphql-mesh/raml',
+    importName: 'loadRAMLSubgraph',
+  },
+  openapi: {
+    packageName: '@omnigraph/openapi',
+    oldPackageName: '@graphql-mesh/openapi',
+    importName: 'loadOpenAPISubgraph',
+  },
+  soap: {
+    packageName: '@omnigraph/soap',
+    oldPackageName: '@graphql-mesh/soap',
+    importName: 'loadSOAPSubgraph',
+  },
+  thrift: {
+    packageName: '@omnigraph/thrift',
+    oldPackageName: '@graphql-mesh/thrift',
+    importName: 'loadThriftSubgraph',
+  },
+  tuql: {
+    packageName: '@omnigraph/sqlite',
+    oldPackageName: '@graphql-mesh/tuql',
+    importName: 'loadSQLiteSubgraph',
+  },
+};
+
+type TransformInfo =
+  { fnName: string; mapConfig?: (config: unknown) => unknown } | { deprecated: string };
+
+const transformInfoMap: Record<string, TransformInfo> = {
+  cache: {
+    deprecated:
+      'Cache Transform has been removed. Use the Hive Gateway response caching plugin (`responseCaching`) instead.',
+  },
+  encapsulate: {
+    fnName: 'createEncapsulateTransform',
+  },
+  extend: {
+    fnName: 'createExtendTransform',
+    mapConfig(config) {
+      if (config && typeof config === 'object' && 'typeDefs' in (config as object)) {
+        return (config as YamlConfig.ExtendTransform).typeDefs;
+      }
+      return config;
+    },
+  },
+  federation: {
+    fnName: 'createFederationTransform',
+  },
+  filterSchema: {
+    fnName: 'createFilterTransform',
+    mapConfig(config) {
+      if (Array.isArray(config)) {
+        return { filters: config };
+      }
+      if (config && typeof config === 'object') {
+        const { mode: _mode, ...rest } = config as Record<string, unknown>;
+        return rest;
+      }
+      return config;
+    },
+  },
+  hoistField: {
+    fnName: 'createHoistFieldTransform',
+    mapConfig(config) {
+      if (Array.isArray(config)) {
+        return { mapping: config };
+      }
+      return config;
+    },
+  },
+  namingConvention: {
+    fnName: 'createNamingConventionTransform',
+  },
+  prefix: {
+    fnName: 'createPrefixTransform',
+  },
+  prune: {
+    fnName: 'createPruneTransform',
+  },
+  rateLimit: {
+    deprecated:
+      'RateLimit Transform has been removed. Use Hive Gateway `rateLimiting` instead of a schema transform.',
+  },
+  rename: {
+    fnName: 'createRenameTransform',
+  },
+  replaceField: {
+    deprecated:
+      'ReplaceField Transform has been removed. Use Hoist Field, Rename, or additionalTypeDefs instead.',
+  },
+  resolversComposition: {
+    deprecated:
+      'ResolversComposition Transform has been removed. Use additionalResolvers on the gateway or a custom plugin.',
+  },
+  typeMerging: {
+    deprecated:
+      'TypeMerging Transform has been removed. Use the Federation transform (`createFederationTransform`) instead.',
+  },
+};
+
+function handleTransformConfiguration(
+  importMap: Map<string, Set<string>>,
+  transformConfiguration: YamlConfig.Transform,
+  messages: MigrationMessage[],
+): string | undefined {
+  const transformName = Object.keys(transformConfiguration)[0];
+  const transformConfig = transformConfiguration[transformName];
+  const transformInfo = transformInfoMap[transformName];
+  if (!transformInfo) {
+    messages.push({
+      level: 'error',
+      message: `Transform "${transformName}" is not recognized by mesh-migrate-config. Migrate it manually.`,
+    });
+    return undefined;
+  }
+  if ('deprecated' in transformInfo) {
+    messages.push({
+      level: 'error',
+      message: transformInfo.deprecated,
+    });
+    return undefined;
+  }
+  addImport(importMap, '@graphql-mesh/compose-cli', transformInfo.fnName);
+  const mapped =
+    'mapConfig' in transformInfo && transformInfo.mapConfig
+      ? transformInfo.mapConfig(transformConfig)
+      : transformConfig;
+  if (
+    transformName === 'extend' &&
+    transformConfig &&
+    typeof transformConfig === 'object' &&
+    'resolvers' in transformConfig &&
+    (transformConfig as YamlConfig.ExtendTransform).resolvers
+  ) {
+    messages.push({
+      level: 'warn',
+      message:
+        'extend.resolvers cannot be applied as a compose transform. Move those resolvers to gatewayConfig.additionalResolvers.',
+    });
+  }
+  if (mapped === undefined || mapped === null) {
+    return `${transformInfo.fnName}()`;
+  }
+  if (transformName === 'extend' && typeof mapped === 'string') {
+    return `${transformInfo.fnName}(${JSON.stringify(mapped)})`;
+  }
+  return `${transformInfo.fnName}(${JSON.stringify(mapped)})`;
+}

--- a/packages/legacy/migrate-config-cli/src/migrate.ts
+++ b/packages/legacy/migrate-config-cli/src/migrate.ts
@@ -42,7 +42,7 @@ export async function migrateLegacyConfig(
 
   const subgraphConfigList: string[] = [];
   for (const legacySource of legacyConfig.sources ?? []) {
-    const handlerName = Object.keys(legacySource.handler)[0];
+    const handlerName = String(Object.keys(legacySource.handler)[0]);
     if (handlerName === 'supergraph') {
       messages.push({
         level: 'error',
@@ -134,7 +134,7 @@ export async function migrateLegacyConfig(
 
   addImport(importMap, '@graphql-mesh/compose-cli', 'defineConfig as defineComposeConfig');
 
-  const configList: string[] = [];
+  const sideEffectStatements: string[] = [];
   const composeConfig = `export const composeConfig = defineComposeConfig({
 ${composeConfigList.join(',\n')}
 });`;
@@ -260,10 +260,13 @@ ${additionalResolversNewConfig.join(',\n')}
         }
         addImport(importMap, resolved.moduleName, resolved.importName);
         addedPackages.add(resolved.moduleName);
-        const pluginOpts = JSON.stringify(legacyPluginConfig[legacyPluginName]).slice(1, -1);
+        const pluginConfig = legacyPluginConfig[legacyPluginName];
+        const pluginOpts =
+          pluginConfig != null && typeof pluginConfig === 'object' && !Array.isArray(pluginConfig)
+            ? `,\n...${JSON.stringify(pluginConfig)}`
+            : '';
         pluginList.push(`${resolved.factoryName}({
-          ...ctx,
-          ${pluginOpts}
+          ...ctx${pluginOpts}
         })`);
       } else {
         messages.push({
@@ -278,7 +281,7 @@ ${additionalResolversNewConfig.join(',\n')}
   }
   if (legacyConfig.require) {
     for (const requiredPackage of legacyConfig.require) {
-      configList.push(`import '${requiredPackage}';`);
+      sideEffectStatements.push(`import '${requiredPackage}';`);
     }
   }
   if (legacyConfig.sdk) {
@@ -345,7 +348,7 @@ ${additionalResolversNewConfig.join(',\n')}
     }
   }
   if (legacyConfig.skipSSLValidation) {
-    configList.push(`process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';`);
+    sideEffectStatements.push(`process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';`);
   }
   if (pluginList.length) {
     serveConfigList.push(`plugins: ctx => ([
@@ -355,11 +358,19 @@ ${pluginList.join(',\n')}
   addImport(importMap, '@graphql-hive/gateway', 'defineConfig as defineGatewayConfig');
   const serveInner = serveConfigList.length ? `\n${serveConfigList.join(',\n')}\n` : '';
   const serveConfig = `export const gatewayConfig = defineGatewayConfig({${serveInner}});`;
+  const namedImports: string[] = [];
   for (const [packageName, imports] of importMap) {
-    configList.push(`import { ${Array.from(imports).join(', ')} } from '${packageName}';`);
+    namedImports.push(`import { ${Array.from(imports).join(', ')} } from '${packageName}';`);
   }
-  configList.push(composeConfig);
-  configList.push(serveConfig);
+  const tlsSideEffects = sideEffectStatements.filter(s => s.startsWith('process.env.'));
+  const requireImports = sideEffectStatements.filter(s => s.startsWith('import '));
+  const configList = [
+    ...requireImports,
+    ...namedImports,
+    ...tlsSideEffects,
+    composeConfig,
+    serveConfig,
+  ];
 
   return {
     code: configList.join('\n'),
@@ -590,9 +601,6 @@ function handleTransformConfiguration(
   }
   if (mapped === undefined || mapped === null) {
     return `${transformInfo.fnName}()`;
-  }
-  if (transformName === 'extend' && typeof mapped === 'string') {
-    return `${transformInfo.fnName}(${JSON.stringify(mapped)})`;
   }
   return `${transformInfo.fnName}(${JSON.stringify(mapped)})`;
 }

--- a/packages/legacy/migrate-config-cli/tests/__snapshots__/migrate.test.ts.snap
+++ b/packages/legacy/migrate-config-cli/tests/__snapshots__/migrate.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`migrateLegacyConfig maps OpenAPI and GraphQL HTTP sources with prefix and filterSchema 1`] = `
+"import { loadOpenAPISubgraph } from '@omnigraph/openapi';
+import { createPrefixTransform, loadGraphQLHTTPSubgraph, createFilterTransform, defineConfig as defineComposeConfig } from '@graphql-mesh/compose-cli';
+import { defineConfig as defineGatewayConfig } from '@graphql-hive/gateway';
+export const composeConfig = defineComposeConfig({
+subgraphs: [
+{
+sourceHandler: loadOpenAPISubgraph("Wiki", {"source":"./wiki.yaml"}),
+transforms: [
+createPrefixTransform({"value":"Wiki_"})
+]
+},
+{
+sourceHandler: loadGraphQLHTTPSubgraph("Countries", {"endpoint":"https://countries.trevorblades.com/"}),
+transforms: [
+createFilterTransform({"filters":["Query.continents"]})
+]
+}
+]
+});
+export const gatewayConfig = defineGatewayConfig({});"
+`;
+
+exports[`migrateLegacyConfig maps hive, responseCache, prometheus, rateLimit and maskedErrors plugins 1`] = `
+"import { loadGraphQLHTTPSubgraph, defineConfig as defineComposeConfig } from '@graphql-mesh/compose-cli';
+import { defineConfig as defineGatewayConfig } from '@graphql-hive/gateway';
+export const composeConfig = defineComposeConfig({
+subgraphs: [
+{
+sourceHandler: loadGraphQLHTTPSubgraph("API", {"endpoint":"https://example.com/graphql"})
+}
+]
+});
+export const gatewayConfig = defineGatewayConfig({
+reporting: {"type":"hive","token":"token"},
+persistedDocuments: {"type":"hive","token":"cdn"},
+responseCaching: {"ttl":1000},
+prometheus: {"skipIntrospection":true},
+rateLimiting: {"max":10,"window":"1s"},
+maskedErrors: true
+});"
+`;

--- a/packages/legacy/migrate-config-cli/tests/__snapshots__/migrate.test.ts.snap
+++ b/packages/legacy/migrate-config-cli/tests/__snapshots__/migrate.test.ts.snap
@@ -35,7 +35,7 @@ sourceHandler: loadGraphQLHTTPSubgraph("API", {"endpoint":"https://example.com/g
 });
 export const gatewayConfig = defineGatewayConfig({
 reporting: {"type":"hive","token":"token"},
-persistedDocuments: {"type":"hive","token":"cdn"},
+persistedDocuments: {"type":"hive","cdn":{"endpoint":"https://cdn.graphql-hive.com","accessToken":"cdn"}},
 responseCaching: {"ttl":1000},
 prometheus: {"skipIntrospection":true},
 rateLimiting: {"max":10,"window":"1s"},

--- a/packages/legacy/migrate-config-cli/tests/migrate.test.ts
+++ b/packages/legacy/migrate-config-cli/tests/migrate.test.ts
@@ -1,0 +1,396 @@
+import type { YamlConfig } from '@graphql-mesh/types';
+import { migrateLegacyConfig } from '../src/migrate';
+
+async function migrate(config: YamlConfig.Config) {
+  return migrateLegacyConfig(config);
+}
+
+describe('migrateLegacyConfig', () => {
+  it('maps OpenAPI and GraphQL HTTP sources with prefix and filterSchema', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'Wiki',
+          handler: {
+            openapi: {
+              source: './wiki.yaml',
+            },
+          },
+          transforms: [
+            {
+              prefix: {
+                value: 'Wiki_',
+              },
+            },
+          ],
+        },
+        {
+          name: 'Countries',
+          handler: {
+            graphql: {
+              endpoint: 'https://countries.trevorblades.com/',
+            },
+          },
+          transforms: [
+            {
+              filterSchema: {
+                mode: 'wrap',
+                filters: ['Query.continents'],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.messages).toEqual([]);
+    expect(result.code).toMatchSnapshot();
+    expect(result.addedPackages).toEqual(
+      expect.arrayContaining([
+        '@graphql-hive/gateway',
+        '@graphql-mesh/compose-cli',
+        '@omnigraph/openapi',
+      ]),
+    );
+    expect(result.removedPackages).toEqual(
+      expect.arrayContaining([
+        '@graphql-mesh/cli',
+        '@graphql-mesh/openapi',
+        '@graphql-mesh/graphql',
+      ]),
+    );
+    expect(result.code).not.toContain('plugins:');
+    expect(result.code).toContain('loadOpenAPISubgraph');
+    expect(result.code).toContain('loadGraphQLHTTPSubgraph');
+    expect(result.code).toContain('createPrefixTransform');
+    expect(result.code).toContain('createFilterTransform');
+    expect(result.code).not.toContain('"mode"');
+  });
+
+  it('maps GraphQL code-first source to endpoint', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'Local',
+          handler: {
+            graphql: {
+              source: './schema.ts',
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain('"endpoint":"./schema.ts"');
+    expect(result.code).not.toContain('"source"');
+  });
+
+  it('fails on GraphQL multiple HTTP sources', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: {
+            graphql: {
+              sources: [{ endpoint: 'https://a' }, { endpoint: 'https://b' }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'error',
+          message: expect.stringContaining('sources'),
+        }),
+      ]),
+    );
+  });
+
+  it('fails on root-level transforms', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      transforms: [{ prefix: { value: 'Root_' } }],
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.messages.some(m => m.message.includes('Root-level transforms'))).toBe(true);
+  });
+
+  it('fails on removed transforms with replacement hints', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+          transforms: [{ typeMerging: { queryFields: [] } as any }],
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.messages[0].message).toContain('createFederationTransform');
+  });
+
+  it('maps hive, responseCache, prometheus, rateLimit and maskedErrors plugins', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      plugins: [
+        {
+          hive: {
+            token: 'token',
+            persistedDocuments: { token: 'cdn' },
+          },
+        },
+        {
+          responseCache: {
+            ttl: 1000,
+          },
+        },
+        {
+          prometheus: {
+            skipIntrospection: true,
+          },
+        },
+        {
+          rateLimit: {
+            max: 10,
+            window: '1s',
+          } as any,
+        },
+        {
+          maskedErrors: true as any,
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain('reporting:');
+    expect(result.code).toContain('"type":"hive"');
+    expect(result.code).toContain('persistedDocuments:');
+    expect(result.code).toContain('responseCaching:');
+    expect(result.code).toContain('prometheus:');
+    expect(result.code).toContain('rateLimiting:');
+    expect(result.code).toContain('maskedErrors: true');
+    expect(result.code).toMatchSnapshot();
+  });
+
+  it('maps serve options onto gatewayConfig', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      serve: {
+        port: 4001,
+        hostname: '0.0.0.0',
+        endpoint: '/gql',
+        cors: { origin: '*' },
+        playground: false,
+        healthCheckEndpoint: '/live',
+        batchingLimit: 5,
+      },
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain('port: 4001');
+    expect(result.code).toContain('host: "0.0.0.0"');
+    expect(result.code).toContain('graphqlEndpoint: "/gql"');
+    expect(result.code).toContain('graphiql: false');
+    expect(result.code).toContain('healthCheckEndpoint: "/live"');
+    expect(result.code).toContain('batching:');
+    expect(result.code).toContain('cors:');
+  });
+
+  it('imports additionalResolvers strings and inlines objects', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      additionalResolvers: [
+        './resolvers.ts',
+        {
+          targetTypeName: 'Query',
+          targetFieldName: 'foo',
+          sourceName: 'API',
+          sourceTypeName: 'Query',
+          sourceFieldName: 'foo',
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain(
+      "import { default as additionalResolvers$0 } from './resolvers.ts'",
+    );
+    expect(result.code).toContain('additionalResolvers$0');
+    expect(result.code).toContain('"targetFieldName":"foo"');
+  });
+
+  it('applies customFetch on compose and gateway', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      customFetch: './fetch.ts',
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain("import { default as customFetch } from './fetch.ts'");
+    expect(result.code).toContain('fetch: customFetch');
+    expect(result.code).toContain('fetchAPI: { fetch: customFetch }');
+  });
+
+  it('warns on codegen and sdk but still writes config', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      codegen: {},
+      sdk: {},
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.messages.filter(m => m.level === 'warn').map(m => m.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Code Generator'),
+        expect.stringContaining('SDKs'),
+      ]),
+    );
+  });
+
+  it('fails on unknown handlers', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: {
+            unknown: {},
+          } as any,
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.messages[0].message).toContain('unknown');
+  });
+
+  it('fails on supergraph handler', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'Super',
+          handler: {
+            supergraph: {
+              source: './supergraph.graphql',
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(true);
+    expect(result.messages[0].message).toContain('Hive Gateway');
+  });
+
+  it('maps extend typeDefs to createExtendTransform', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+          transforms: [
+            {
+              extend: {
+                typeDefs: 'extend type Query { ping: String }',
+                resolvers: './extend-resolvers.ts',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain('createExtendTransform("extend type Query { ping: String }")');
+    expect(result.messages.some(m => m.message.includes('extend.resolvers'))).toBe(true);
+  });
+
+  it('maps hoistField arrays to mapping option', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+          transforms: [
+            {
+              hoistField: [
+                {
+                  typeName: 'Query',
+                  pathConfig: ['user', 'address'],
+                  newFieldName: 'userAddress',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain('createHoistFieldTransform');
+    expect(result.code).toContain('"mapping"');
+  });
+
+  it('resolves unknown plugins via resolvePlugin', async () => {
+    const result = await migrateLegacyConfig(
+      {
+        sources: [
+          {
+            name: 'API',
+            handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+          },
+        ],
+        plugins: [{ mock: { mocks: true } as any }],
+      },
+      {
+        resolvePlugin: async () => ({
+          moduleName: '@graphql-mesh/plugin-mock',
+          importName: 'useMock',
+          factoryName: 'useMock',
+        }),
+      },
+    );
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain("from '@graphql-mesh/plugin-mock'");
+    expect(result.code).toContain('useMock({');
+    expect(result.code).toContain('...ctx');
+  });
+});

--- a/packages/legacy/migrate-config-cli/tests/migrate.test.ts
+++ b/packages/legacy/migrate-config-cli/tests/migrate.test.ts
@@ -392,5 +392,51 @@ describe('migrateLegacyConfig', () => {
     expect(result.code).toContain("from '@graphql-mesh/plugin-mock'");
     expect(result.code).toContain('useMock({');
     expect(result.code).toContain('...ctx');
+    expect(result.code).toContain('...{"mocks":true}');
+  });
+
+  it('does not slice non-object plugin config', async () => {
+    const result = await migrateLegacyConfig(
+      {
+        sources: [
+          {
+            name: 'API',
+            handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+          },
+        ],
+        plugins: [{ mock: true as any }],
+      },
+      {
+        resolvePlugin: async () => ({
+          moduleName: '@graphql-mesh/plugin-mock',
+          importName: 'useMock',
+          factoryName: 'useMock',
+        }),
+      },
+    );
+
+    expect(result.fatal).toBe(false);
+    expect(result.code).toContain('useMock({\n          ...ctx\n        })');
+    expect(result.code).not.toContain('ru');
+  });
+
+  it('emits named imports before skipSSLValidation assignment', async () => {
+    const result = await migrate({
+      sources: [
+        {
+          name: 'API',
+          handler: { graphql: { endpoint: 'https://example.com/graphql' } },
+        },
+      ],
+      require: ['dotenv/config'],
+      skipSSLValidation: true,
+    });
+
+    const tlsIndex = result.code.indexOf("process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'");
+    const namedImportIndex = result.code.indexOf('defineConfig as defineComposeConfig');
+    const requireIndex = result.code.indexOf("import 'dotenv/config'");
+    expect(requireIndex).toBeGreaterThanOrEqual(0);
+    expect(namedImportIndex).toBeGreaterThan(requireIndex);
+    expect(tlsIndex).toBeGreaterThan(namedImportIndex);
   });
 });

--- a/packages/legacy/migrate-config-cli/tests/migrate.test.ts
+++ b/packages/legacy/migrate-config-cli/tests/migrate.test.ts
@@ -154,7 +154,12 @@ describe('migrateLegacyConfig', () => {
         {
           hive: {
             token: 'token',
-            persistedDocuments: { token: 'cdn' },
+            persistedDocuments: {
+              cdn: {
+                endpoint: 'https://cdn.graphql-hive.com',
+                accessToken: 'cdn',
+              },
+            },
           },
         },
         {

--- a/website/src/content/v1/_meta.ts
+++ b/website/src/content/v1/_meta.ts
@@ -11,6 +11,6 @@ export default {
   auth: 'Authentication',
   'subscriptions-webhooks': 'Subscriptions & Webhooks',
   'consume-in-other-gateways': 'Consume in Other Gateways',
-  'local-execution': 'Local Execution',
+  'local-execution': 'Local Execution & SDK',
   'migration-from-v0': 'Migration from Mesh v0',
 };

--- a/website/src/content/v1/getting-started.mdx
+++ b/website/src/content/v1/getting-started.mdx
@@ -261,4 +261,9 @@ Learn more;
     title="Serve the generated API with other gateways"
     href="/v1/consume-in-other-gateways"
   />
+  <Cards.Card
+    arrow
+    title="Type-safe SDK (Compose + Codegen + Hive Gateway)"
+    href="/v1/local-execution"
+  />
 </Cards>

--- a/website/src/content/v1/getting-started.mdx
+++ b/website/src/content/v1/getting-started.mdx
@@ -266,4 +266,9 @@ Learn more;
     title="Type-safe SDK (Compose + Codegen + Hive Gateway)"
     href="/v1/local-execution"
   />
+  <Cards.Card
+    arrow
+    title="In-context SDK for additionalResolvers"
+    href="/v1/schema-extensions#in-context-sdk-typed-additionalresolvers"
+  />
 </Cards>

--- a/website/src/content/v1/local-execution.mdx
+++ b/website/src/content/v1/local-execution.mdx
@@ -69,7 +69,7 @@ const exampleDocument = parse(/* GraphQL */ `
 
 const result = await executor({
   document: exampleDocument,
-  variables: { someArg: 'SOME_VALUE' }
+  variables: { someVar: 'SOME_VALUE' }
 })
 ```
 

--- a/website/src/content/v1/local-execution.mdx
+++ b/website/src/content/v1/local-execution.mdx
@@ -74,4 +74,8 @@ const result = await sdk.myQuery({
 console.log(result) // { data: { foo: { bar: 'SOME_VALUE' } } }
 ```
 
-{/* TODO: Add a full example with codegen */}
+A full Mesh Compose + Codegen + `createGatewayRuntime` + `runtime.sdkRequester` example (queries,
+mutations, subscriptions) lives in the
+[Hive Gateway `e2e/typed-sdk`](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk)
+fixture. If you are migrating from Mesh v0 `getMeshSDK()`, see
+[Type-safe SDK](/v1/migration-from-v0#type-safe-sdk).

--- a/website/src/content/v1/local-execution.mdx
+++ b/website/src/content/v1/local-execution.mdx
@@ -12,9 +12,11 @@ composes a supergraph with Mesh Compose, generates `getSdk` with GraphQL Codegen
 / mutations / subscriptions through `createGatewayRuntime` + `runtime.sdkRequester`.
 
 <Callout>
-  Coming from Mesh v0 `getMeshSDK()` / `.mesh`? See [Type-safe SDK in the v0 migration
-  guide](/v1/migration-from-v0#type-safe-sdk). Mesh Compose no longer writes an SDK; Hive Gateway +
-  Codegen do.
+  Mesh v0 `.mesh` contained **two** SDKs. Operation-style `getMeshSDK()` → this page + [typed-sdk
+  example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk). Resolver
+  `context.Source.Query.field` →
+  [`@graphql-mesh/incontext-sdk-codegen`](/v1/schema-extensions#in-context-sdk-typed-additionalresolvers).
+  Full v0 mapping: [Type-safe SDKs](/v1/migration-from-v0#type-safe-sdks).
 </Callout>
 
 ## Supergraph as a file
@@ -136,6 +138,29 @@ const sdk = getSdk(sdkRequester)
 const result = await sdk.myQuery({ someVar: 'SOME_VALUE' })
 ```
 
+## In-context SDK (for `additionalResolvers`)
+
+If you used v0 `MeshContext` inside resolvers (`context.Wiki.Query.…`), that is **not** `getSdk`.
+Generate types with
+[`@graphql-mesh/incontext-sdk-codegen`](https://github.com/ardatan/graphql-mesh/tree/master/packages/incontext-sdk-codegen)
+from the supergraph. Mesh example:
+[`e2e/openapi-javascript-wiki`](https://github.com/ardatan/graphql-mesh/tree/master/e2e/openapi-javascript-wiki).
+
+```ts filename="codegen.ts"
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+export default {
+  schema: './supergraph.graphql',
+  generates: {
+    './types/incontext-sdk.ts': {
+      plugins: ['@graphql-mesh/incontext-sdk-codegen']
+    }
+  }
+} satisfies CodegenConfig
+```
+
+See [In-context SDK](/v1/schema-extensions#in-context-sdk-typed-additionalresolvers).
+
 <Cards>
   <Cards.Card
     arrow
@@ -144,7 +169,8 @@ const result = await sdk.myQuery({ someVar: 'SOME_VALUE' })
   />
   <Cards.Card
     arrow
-    title="Migrate from Mesh v0 getMeshSDK()"
-    href="/v1/migration-from-v0#type-safe-sdk"
+    title="In-context SDK (additionalResolvers)"
+    href="/v1/schema-extensions#in-context-sdk-typed-additionalresolvers"
   />
+  <Cards.Card arrow title="Migrate from Mesh v0 SDKs" href="/v1/migration-from-v0#type-safe-sdks" />
 </Cards>

--- a/website/src/content/v1/local-execution.mdx
+++ b/website/src/content/v1/local-execution.mdx
@@ -1,10 +1,29 @@
+import { Callout, Cards } from '@theguild/components'
+
 # Local Execution
 
-You can use GraphQL Mesh as a completely type-safe SDK in your existing TypeScript project, or for
-programmatically executing queries.
+You can use GraphQL Mesh Compose + Hive Gateway as a type-safe SDK in an existing TypeScript
+project, or execute operations programmatically without standing up an HTTP server.
 
-First, we recommend to output your supergraph as a code file so that you can import it inside your
-code.
+The runnable example is
+[Hive Gateway `examples/typed-sdk`](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)
+([open in CodeSandbox](https://githubbox.com/graphql-hive/gateway/tree/main/examples/typed-sdk)). It
+composes a supergraph with Mesh Compose, generates `getSdk` with GraphQL Codegen, and calls queries
+/ mutations / subscriptions through `createGatewayRuntime` + `runtime.sdkRequester`.
+
+<Callout>
+  Coming from Mesh v0 `getMeshSDK()` / `.mesh`? See [Type-safe SDK in the v0 migration
+  guide](/v1/migration-from-v0#type-safe-sdk). Mesh Compose no longer writes an SDK; Hive Gateway +
+  Codegen do.
+</Callout>
+
+## Supergraph as a file
+
+Compose to SDL (what the example uses) or to a JS module if you want to `import` the schema:
+
+```sh
+npx mesh-compose -o supergraph.graphql
+```
 
 ```ts filename="mesh.config.ts"
 import { defineConfig } from '@graphql-mesh/compose-cli'
@@ -15,9 +34,20 @@ export const composeConfig = defineConfig({
 })
 ```
 
+In the example, `package.json` runs compose then Codegen:
+
+```json
+{
+  "scripts": {
+    "codegen": "npm run compose && graphql-codegen",
+    "compose": "mesh-compose -o supergraph.graphql"
+  }
+}
+```
+
 ## Executing queries programmatically
 
-Mesh's execute function could be used to directly carry out a query:
+Use Hive Gateway’s executor against the composed supergraph (this replaces v0 `.mesh` `execute`):
 
 ```ts
 import { parse } from 'graphql'
@@ -35,47 +65,86 @@ const exampleDocument = parse(/* GraphQL */ `
   }
 `)
 
-const exampleVariables = {
-  someArg: 'SOME_VALUE'
-}
-
 const result = await executor({
   document: exampleDocument,
-  variables: exampleVariables
+  variables: { someArg: 'SOME_VALUE' }
 })
-
-console.log(result) // { data: { foo: { bar: 'SOME_VALUE' } } }
 ```
 
-## Generating fully type safe SDK
+## Generating a fully type-safe SDK
 
-You can use GraphQL Code Generator to generate a fully type-safe SDK for your GraphQL operations.
+v0 generated this inside `.mesh`. v1 uses the same Codegen plugin Mesh used internally
+([`typescript-generic-sdk`](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-generic-sdk)),
+with the **supergraph** as `schema` and your operations as `documents`.
 
-[Configure GraphQL Code Generator](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-generic-sdk)
+```ts filename="codegen.ts"
+import type { CodegenConfig } from '@graphql-codegen/cli'
 
-Then use `getSdkRequesterForUnifiedGraph` to get a function that you can use to execute your
-operations.
+export default {
+  schema: './supergraph.graphql',
+  documents: 'sdk/operations.graphql',
+  generates: {
+    'sdk/generated.ts': {
+      plugins: ['typescript-operations', 'typescript-generic-sdk']
+    }
+  }
+} satisfies CodegenConfig
+```
+
+### With `createGatewayRuntime` (example)
+
+This is what
+[`examples/typed-sdk/example.ts`](https://github.com/graphql-hive/gateway/blob/main/examples/typed-sdk/example.ts)
+does: start an in-process gateway, pass `runtime.sdkRequester` into `getSdk`.
+
+```ts
+import { readFileSync } from 'node:fs'
+import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { getSdk } from './sdk/generated'
+
+await using runtime = createGatewayRuntime({
+  supergraph: readFileSync('./supergraph.graphql', 'utf-8')
+})
+
+const sdk = getSdk(runtime.sdkRequester)
+
+const todos = await sdk.Todos()
+await sdk.AddTodo({ text: 'Write tests' })
+
+const iterable = sdk.TodoAdded()
+const iterator = iterable[Symbol.asyncIterator]()
+```
+
+Run the example locally (from its README): download `example.tar.gz`, `npm i`, `npm run codegen`,
+start the subgraph, compose, then `npm run gateway` — or run `example.ts` for the SDK path. Full
+steps:
+[examples/typed-sdk README](https://github.com/graphql-hive/gateway/blob/main/examples/typed-sdk/README.md).
+
+### With `getSdkRequesterForUnifiedGraph`
+
+If you already import a JS supergraph and do not need `createGatewayRuntime`:
 
 ```ts
 import { getSdkRequesterForUnifiedGraph } from '@graphql-hive/gateway'
-// Assuming you have generated your SDK with GraphQL Code Generator in `generated/sdk.ts`
-import { getSdk } from './generated/sdk'
+import { getSdk } from './sdk/generated'
 
 const sdkRequester = getSdkRequesterForUnifiedGraph({
   getUnifiedGraph: () => import('./supergraph.js').then(m => m.default)
 })
 
 const sdk = getSdk(sdkRequester)
-
-const result = await sdk.myQuery({
-  someVar: 'SOME_VALUE'
-})
-
-console.log(result) // { data: { foo: { bar: 'SOME_VALUE' } } }
+const result = await sdk.myQuery({ someVar: 'SOME_VALUE' })
 ```
 
-A full Mesh Compose + Codegen + `createGatewayRuntime` + `runtime.sdkRequester` example (queries,
-mutations, subscriptions) lives in the
-[Hive Gateway `e2e/typed-sdk`](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk)
-fixture. If you are migrating from Mesh v0 `getMeshSDK()`, see
-[Type-safe SDK](/v1/migration-from-v0#type-safe-sdk).
+<Cards>
+  <Cards.Card
+    arrow
+    title="Hive Gateway typed-sdk example"
+    href="https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk"
+  />
+  <Cards.Card
+    arrow
+    title="Migrate from Mesh v0 getMeshSDK()"
+    href="/v1/migration-from-v0#type-safe-sdk"
+  />
+</Cards>

--- a/website/src/content/v1/migration-from-v0.mdx
+++ b/website/src/content/v1/migration-from-v0.mdx
@@ -28,8 +28,10 @@ If you are migrating from GraphQL Mesh v0, you should be aware of the following 
   now you should take a look at
   [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
   deploy your gateway.
-- GraphQL Mesh no longer runs [GraphQL Code Generator](https://graphql-codegen.com) internally. You
-  should use it separately if you need to generate types or documents.
+- GraphQL Mesh no longer runs [GraphQL Code Generator](https://graphql-codegen.com) internally, and
+  it no longer writes a typed SDK into `.mesh`. You still get a type-safe SDK: generate it with
+  Codegen, then execute through Hive Gateway (`sdkRequester`). See [Type-safe SDK](#type-safe-sdk)
+  below.
 - GraphQL Mesh no longer generates a Persisted Operations store. You should setup your gateway based
   on your needs. [See here](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) for
   more information.
@@ -38,19 +40,19 @@ GraphQL Mesh is now only responsible of generating a GraphQL SDL file `supergrap
 `subgraph.graphql` that you can use with Hive Gateway. It is not responsible for serving the
 generated artifacts.
 
-| Topic                | v0                                                                 | v1                                                                                                      |
-| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                       |
-| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)             |
-| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                      |
-| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                  |
-| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                |
-| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                       |
-| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                           |
-| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)               |
-| Codegen / SDK        | `codegen`, `sdk`, `documents` inside Mesh                          | GraphQL Codegen on your side                                                                            |
-| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) |
-| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                        |
+| Topic                | v0                                                                 | v1                                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                                                                 |
+| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)                                                       |
+| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                                                                |
+| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                                                            |
+| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                                                          |
+| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                                                                 |
+| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                                                                     |
+| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)                                                         |
+| Codegen / SDK        | `documents` + `sdk` → `.mesh` `getMeshSDK()`                       | Codegen `typescript-generic-sdk` + Hive Gateway `sdkRequester` ([typed-sdk e2e](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk)) |
+| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents)                                           |
+| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                                                                  |
 
 ```mermaid
 flowchart LR
@@ -280,7 +282,7 @@ v1, anything that **builds SDL** is compose; anything that **runs requests** is 
 | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `sources`, source `transforms`, `additionalTypeDefs`, `customFetch` used while introspecting | `composeConfig` (`fetch` on compose)                                                            |
 | `serve.*`, `plugins`, `cache`, `additionalResolvers`, `logger`, runtime `customFetch`        | `gatewayConfig` (`fetchAPI.fetch`)                                                              |
-| `codegen`, `sdk`, `documents`                                                                | GraphQL Codegen / your client — Mesh does not run these                                         |
+| `codegen`, `sdk`, `documents`                                                                | GraphQL Codegen on the **supergraph** + Hive Gateway typed SDK (not Mesh CLI)                   |
 | `merger`                                                                                     | No replacement key; composition is Federation-style (migrator warns)                            |
 | `pubsub`                                                                                     | Hive Gateway subscriptions — [docs](/v1/subscriptions-webhooks)                                 |
 | `persistedOperations`                                                                        | [Hive persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) |
@@ -318,18 +320,82 @@ v1, anything that **builds SDL** is compose; anything that **runs requests** is 
 v0 `cache:` (Redis, Localforage, …) becomes `gatewayConfig.cache: new Cache(...)` with
 `@graphql-mesh/cache-*`. That is **not** the old Cache **transform**.
 
+## Type-safe SDK
+
+v0 Mesh **was** an SDK generator. `documents` + `sdk` in `.meshrc` plus `mesh build` wrote
+`getMeshSDK()` into `.mesh`. v1 Mesh Compose does **not** do that. The same pattern lives on Hive
+Gateway: Codegen emits `getSdk`, the gateway supplies the requester.
+
+| v0                                                   | v1                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `documents: ['./src/**/*.graphql']`                  | Codegen `documents` (e.g. `sdk/operations.graphql`)                             |
+| `sdk: { generateOperations: { selectionSetDepth } }` | You own the `.graphql` operations; Codegen does not invent them from Mesh       |
+| `mesh build` → `.mesh` SDK                           | `graphql-codegen` against `supergraph.graphql`                                  |
+| `import { getMeshSDK } from './.mesh'`               | `import { getSdk } from './sdk/generated'`                                      |
+| `getMeshSDK()`                                       | `getSdk(runtime.sdkRequester)` or `getSdk(getSdkRequesterForUnifiedGraph(...))` |
+
+v0:
+
+```ts
+import { getMeshSDK } from './.mesh'
+
+const sdk = getMeshSDK()
+const { getSomething } = await sdk.myQuery({ someVar: 'foo' })
+```
+
+v1 (same idea as the
+[Hive Gateway typed-sdk e2e](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk)):
+
+```ts filename="codegen.ts"
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+export default {
+  schema: './supergraph.graphql',
+  documents: 'sdk/operations.graphql',
+  generates: {
+    'sdk/generated.ts': {
+      plugins: ['typescript-operations', 'typescript-generic-sdk']
+    }
+  }
+} satisfies CodegenConfig
+```
+
+```ts
+import { readFileSync } from 'node:fs'
+import { createGatewayRuntime } from '@graphql-hive/gateway'
+import { getSdk } from './sdk/generated'
+
+await using runtime = createGatewayRuntime({
+  supergraph: readFileSync('./supergraph.graphql', 'utf-8')
+})
+
+const sdk = getSdk(runtime.sdkRequester)
+const todos = await sdk.Todos()
+```
+
+That e2e also shows mutations and subscriptions on the same `getSdk` (`sdk.AddTodo(...)`,
+`sdk.TodoAdded()` as an async iterable).
+
+If you only need in-process execution without `createGatewayRuntime`, use
+`getSdkRequesterForUnifiedGraph` as in [Local Execution](/v1/local-execution). Compose the
+supergraph first (`mesh-compose -o supergraph.graphql`); Codegen’s `schema` must point at that file
+(or `supergraph.js`), not at `.mesh`.
+
+The migrator **warns** on `sdk` / `codegen` / `documents` and does not generate `codegen.ts`. Copy
+your v0 `documents` into Codegen yourself.
+
 ## Using Artifacts
 
 GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTTPHandler`. v0
 deployment used those from `.mesh` after `mesh build`. v1 deployment uses an SDL file plus Hive
 Gateway.
 
-| v0 artifact                                 | v1                                                                                                                 |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                |
-| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment) |
-| Generated SDK from `sdk:`                   | GraphQL Codegen client-preset (or similar) against the supergraph                                                  |
-| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                           |
+| v0 artifact                                 | v1                                                                                                                              |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                             |
+| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment)              |
+| Generated SDK from `sdk:` / `getMeshSDK()`  | Codegen generic SDK + `runtime.sdkRequester` — [typed-sdk e2e](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk) |
+| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                                        |
 
 After a successful config migration:
 
@@ -342,5 +408,5 @@ Read more about
 [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
 setup your gateway with the new artifacts.
 
-If you need local execution, refer to the local execution guide [here](/v1/local-execution). More
-compose background: [Getting Started](/v1/getting-started).
+If you need local execution or a typed SDK, see [Local Execution](/v1/local-execution) and
+[Type-safe SDK](#type-safe-sdk). Compose background: [Getting Started](/v1/getting-started).

--- a/website/src/content/v1/migration-from-v0.mdx
+++ b/website/src/content/v1/migration-from-v0.mdx
@@ -40,19 +40,19 @@ GraphQL Mesh is now only responsible of generating a GraphQL SDL file `supergrap
 `subgraph.graphql` that you can use with Hive Gateway. It is not responsible for serving the
 generated artifacts.
 
-| Topic                | v0                                                                 | v1                                                                                                                                                |
-| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                                                                 |
-| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)                                                       |
-| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                                                                |
-| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                                                            |
-| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                                                          |
-| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                                                                 |
-| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                                                                     |
-| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)                                                         |
-| Codegen / SDK        | `documents` + `sdk` → `.mesh` `getMeshSDK()`                       | Codegen `typescript-generic-sdk` + Hive Gateway `sdkRequester` ([typed-sdk e2e](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk)) |
-| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents)                                           |
-| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                                                                  |
+| Topic                | v0                                                                 | v1                                                                                                                                |
+| -------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                                                 |
+| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)                                       |
+| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                                                |
+| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                                            |
+| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                                          |
+| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                                                 |
+| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                                                     |
+| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)                                         |
+| Codegen / SDK        | `documents` + `sdk` → `.mesh` `getMeshSDK()`                       | Codegen + Hive Gateway `sdkRequester` ([typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)) |
+| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents)                           |
+| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                                                  |
 
 ```mermaid
 flowchart LR
@@ -323,8 +323,9 @@ v0 `cache:` (Redis, Localforage, …) becomes `gatewayConfig.cache: new Cache(..
 ## Type-safe SDK
 
 v0 Mesh **was** an SDK generator. `documents` + `sdk` in `.meshrc` plus `mesh build` wrote
-`getMeshSDK()` into `.mesh`. v1 Mesh Compose does **not** do that. The same pattern lives on Hive
-Gateway: Codegen emits `getSdk`, the gateway supplies the requester.
+`getMeshSDK()` into `.mesh`. v1 Mesh Compose does **not** do that. The same pattern is the
+[Hive Gateway typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk):
+Codegen emits `getSdk`, Hive Gateway supplies `sdkRequester`.
 
 | v0                                                   | v1                                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -343,8 +344,9 @@ const sdk = getMeshSDK()
 const { getSomething } = await sdk.myQuery({ someVar: 'foo' })
 ```
 
-v1 (same idea as the
-[Hive Gateway typed-sdk e2e](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk)):
+v1 — same stack as the
+[Hive Gateway typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)
+([CodeSandbox](https://githubbox.com/graphql-hive/gateway/tree/main/examples/typed-sdk)):
 
 ```ts filename="codegen.ts"
 import type { CodegenConfig } from '@graphql-codegen/cli'
@@ -373,8 +375,9 @@ const sdk = getSdk(runtime.sdkRequester)
 const todos = await sdk.Todos()
 ```
 
-That e2e also shows mutations and subscriptions on the same `getSdk` (`sdk.AddTodo(...)`,
-`sdk.TodoAdded()` as an async iterable).
+The example also runs mutations and subscriptions on the same `getSdk` (`sdk.AddTodo(...)`,
+`sdk.TodoAdded()` as an async iterable). See
+[`example.ts`](https://github.com/graphql-hive/gateway/blob/main/examples/typed-sdk/example.ts).
 
 If you only need in-process execution without `createGatewayRuntime`, use
 `getSdkRequesterForUnifiedGraph` as in [Local Execution](/v1/local-execution). Compose the
@@ -390,12 +393,12 @@ GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTT
 deployment used those from `.mesh` after `mesh build`. v1 deployment uses an SDL file plus Hive
 Gateway.
 
-| v0 artifact                                 | v1                                                                                                                              |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                             |
-| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment)              |
-| Generated SDK from `sdk:` / `getMeshSDK()`  | Codegen generic SDK + `runtime.sdkRequester` — [typed-sdk e2e](https://github.com/graphql-hive/gateway/tree/main/e2e/typed-sdk) |
-| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                                        |
+| v0 artifact                                 | v1                                                                                                                                       |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                                      |
+| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment)                       |
+| Generated SDK from `sdk:` / `getMeshSDK()`  | Codegen generic SDK + `runtime.sdkRequester` — [typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk) |
+| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                                                 |
 
 After a successful config migration:
 
@@ -408,5 +411,7 @@ Read more about
 [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
 setup your gateway with the new artifacts.
 
-If you need local execution or a typed SDK, see [Local Execution](/v1/local-execution) and
-[Type-safe SDK](#type-safe-sdk). Compose background: [Getting Started](/v1/getting-started).
+If you need local execution or a typed SDK, see [Local Execution & SDK](/v1/local-execution) and
+[Type-safe SDK](#type-safe-sdk), or clone
+[examples/typed-sdk](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk). Compose
+background: [Getting Started](/v1/getting-started).

--- a/website/src/content/v1/migration-from-v0.mdx
+++ b/website/src/content/v1/migration-from-v0.mdx
@@ -4,6 +4,17 @@ import { Callout } from '@theguild/components'
 
 <Callout>This feature is still work-in-progress. Please report any issues you encounter.</Callout>
 
+This page is for people coming from Mesh **v0** (`.meshrc.yml`, `@graphql-mesh/cli`, `.mesh`
+artifacts). Mesh **v1** is a different product shape: **Compose** builds a Supergraph SDL, **Hive
+Gateway** serves it. The sections below keep the original v0 concepts and show what they became.
+
+<Callout>
+  Please make sure all of your `@graphql-mesh/` packages are up-to-date on v0 first. Otherwise, the
+  migration script may not parse your config as expected.
+</Callout>
+
+## What changed (v0 vs v1)
+
 If you are migrating from GraphQL Mesh v0, you should be aware of the following changes:
 
 - GraphQL Mesh no longer comes with a built-in gateway. You should setup Hive Gateway to serve the
@@ -27,21 +38,127 @@ GraphQL Mesh is now only responsible of generating a GraphQL SDL file `supergrap
 `subgraph.graphql` that you can use with Hive Gateway. It is not responsible for serving the
 generated artifacts.
 
-For in-process execution (instead of a standalone gateway process), see
-[Local Execution](/v1/local-execution).
+| Topic                | v0                                                                 | v1                                                                                                      |
+| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                       |
+| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)             |
+| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                      |
+| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                  |
+| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                |
+| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                       |
+| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                           |
+| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)               |
+| Codegen / SDK        | `codegen`, `sdk`, `documents` inside Mesh                          | GraphQL Codegen on your side                                                                            |
+| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) |
+| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                        |
 
-<Callout>
-  Please make sure all of your `@graphql-mesh/` packages are up-to-date. Otherwise, the migration
-  script may not work as expected.
-</Callout>
+```mermaid
+flowchart LR
+  subgraph v0["Mesh v0"]
+    S0[Sources] --> C0[".meshrc.yml"]
+    C0 --> CLI0["mesh build / mesh start"]
+    CLI0 --> ART[".mesh JS + HTTP handler"]
+    ART --> Client0[Clients]
+  end
+```
+
+```mermaid
+flowchart LR
+  subgraph v1["Mesh v1"]
+    S1[Sources] --> C1["mesh.config.ts composeConfig"]
+    C1 --> COMPOSE["mesh-compose"]
+    COMPOSE --> SDL["supergraph.graphql"]
+    SDL --> GW["Hive Gateway"]
+    GW --> Client1[Clients]
+  end
+```
+
+## Mental model: sources vs subgraphs
+
+v0 called each upstream a **source** (handler + optional transforms), then merged them into a
+**unified schema**. v1 calls each upstream a **subgraph**. Compose loads it with a `sourceHandler`,
+applies transforms on that subgraph, then composes a **supergraph**.
+
+| v0                                  | v1                                                                                             |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `sources[].name`                    | First argument of `loadOpenAPISubgraph('Wiki', …)` / `loadGraphQLHTTPSubgraph('Countries', …)` |
+| `sources[].handler.openapi`         | `sourceHandler: loadOpenAPISubgraph(...)`                                                      |
+| `sources[].transforms`              | `subgraphs[].transforms: [createPrefixTransform(...)]`                                         |
+| Root `transforms:` (unified schema) | **Not supported** — move onto a subgraph or use Federation                                     |
+| `additionalTypeDefs`                | `composeConfig.additionalTypeDefs` (often with `@resolveTo`)                                   |
+| `additionalResolvers`               | `gatewayConfig.additionalResolvers` (runtime, not compose)                                     |
 
 ## Configuration Format
 
-Before, Mesh used a configuration file in `.meshrc.yml`, `.meshrc.yaml`, `.meshrc.json`, or
-`.meshrc.js` format. Now Mesh supports a configuration file in `mesh.config.ts` or `mesh.config.js`
-format, with `composeConfig` (SDL generation) and `gatewayConfig` (Hive Gateway).
+Before, Mesh used `.meshrc.yml` (or yaml/json/js). Now Mesh uses `mesh.config.ts` / `mesh.config.js`
+with two exports:
 
-Install `@graphql-mesh/migrate-config-cli` to migrate your configuration file from v0 to v1.
+- `composeConfig` — what **Mesh Compose** reads (`mesh-compose`)
+- `gatewayConfig` — what **Hive Gateway** reads (`hive-gateway`)
+
+The same file can hold both so one project still has a single config, but the jobs are split.
+
+### Example: same gateway, two configs
+
+v0 `.meshrc.yml`:
+
+```yaml filename=".meshrc.yml"
+sources:
+  - name: Wiki
+    handler:
+      openapi:
+        source: ./wiki.yaml
+    transforms:
+      - prefix:
+          value: Wiki_
+  - name: Countries
+    handler:
+      graphql:
+        endpoint: https://countries.trevorblades.com
+serve:
+  port: 4000
+  cors:
+    origin: '*'
+plugins:
+  - responseCache:
+      ttl: 1000
+```
+
+v1 `mesh.config.ts` (what the migrator aims to produce):
+
+```ts filename="mesh.config.ts"
+import {
+  createPrefixTransform,
+  defineConfig as defineComposeConfig,
+  loadGraphQLHTTPSubgraph
+} from '@graphql-mesh/compose-cli'
+import { defineConfig as defineGatewayConfig } from '@graphql-hive/gateway'
+import { loadOpenAPISubgraph } from '@omnigraph/openapi'
+
+export const composeConfig = defineComposeConfig({
+  subgraphs: [
+    {
+      sourceHandler: loadOpenAPISubgraph('Wiki', { source: './wiki.yaml' }),
+      transforms: [createPrefixTransform({ value: 'Wiki_' })]
+    },
+    {
+      sourceHandler: loadGraphQLHTTPSubgraph('Countries', {
+        endpoint: 'https://countries.trevorblades.com'
+      })
+    }
+  ]
+})
+
+export const gatewayConfig = defineGatewayConfig({
+  port: 4000,
+  cors: { origin: '*' },
+  responseCaching: { ttl: 1000 }
+})
+```
+
+### Run the migrator
+
+Install `@graphql-mesh/migrate-config-cli` to generate `mesh.config.ts` from your v0 file.
 
 ```sh npm2yarn
 npm install @graphql-mesh/migrate-config-cli
@@ -74,98 +191,145 @@ to those warnings and errors.
   Please report anything it gets wrong.
 </Callout>
 
+## CLI and daily workflow
+
+| Goal                                     | v0                           | v1                                                                                                   |
+| ---------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Dev server (rebuild schema from sources) | `mesh dev`                   | `mesh-compose -o supergraph.graphql` then `hive-gateway supergraph` (re-compose when sources change) |
+| Production schema artifacts              | `mesh build` → `.mesh/`      | `mesh-compose -o supergraph.graphql`                                                                 |
+| Production HTTP server                   | `mesh start` (loads `.mesh`) | `hive-gateway supergraph` (loads SDL)                                                                |
+| Validate                                 | `mesh validate`              | Compose + Gateway config / Hive schema checks                                                        |
+| Serve a single source                    | `mesh serve-source`          | Compose one subgraph, or point Hive Gateway at that subgraph SDL                                     |
+
+v0 `package.json` often looked like `"dev": "mesh dev"`, `"build": "mesh build"`,
+`"start": "mesh start"`. v1 splits that into compose (CI / build) and gateway (runtime).
+
 ## Package Changes
 
 Instead of `@graphql-mesh/cli`, you should now use `@graphql-mesh/compose-cli` and
 `@graphql-hive/gateway`.
-
-For example with `npm`:
 
 ```sh npm2yarn
 npm uninstall @graphql-mesh/cli
 npm install @graphql-mesh/compose-cli @graphql-hive/gateway
 ```
 
-Source handler packages are also changed: `@omnigraph/*` instead of `@graphql-mesh/*` for most
-handlers. The CLI prints the exact add/remove list for your config. Mapping:
+Source handler packages moved from `@graphql-mesh/<handler>` to `@omnigraph/*` (GraphQL HTTP stays
+on compose-cli). The migrator prints the exact add/remove list for **your** config.
 
-| v0 `handler`   | v0 package                   | v1 loader                                                | v1 package                  |
-| -------------- | ---------------------------- | -------------------------------------------------------- | --------------------------- |
-| `graphql`      | `@graphql-mesh/graphql`      | `loadGraphQLHTTPSubgraph`                                | `@graphql-mesh/compose-cli` |
-| `openapi`      | `@graphql-mesh/openapi`      | `loadOpenAPISubgraph`                                    | `@omnigraph/openapi`        |
-| `jsonSchema`   | `@graphql-mesh/json-schema`  | `loadJSONSchemaSubgraph`                                 | `@omnigraph/json-schema`    |
-| `grpc`         | `@graphql-mesh/grpc`         | `loadGRPCSubgraph`                                       | `@omnigraph/grpc`           |
-| `soap`         | `@graphql-mesh/soap`         | `loadSOAPSubgraph`                                       | `@omnigraph/soap`           |
-| `raml`         | `@graphql-mesh/raml`         | `loadRAMLSubgraph`                                       | `@omnigraph/raml`           |
-| `mysql`        | `@graphql-mesh/mysql`        | `loadMySQLSubgraph`                                      | `@omnigraph/mysql`          |
-| `postgraphile` | `@graphql-mesh/postgraphile` | `loadPostgreSQLSubgraph`                                 | `@omnigraph/postgresql`     |
-| `mongoose`     | `@graphql-mesh/mongoose`     | `loadMongooseSubgraph`                                   | `@omnigraph/mongoose`       |
-| `neo4j`        | `@graphql-mesh/neo4j`        | `loadNeo4jSubgraph`                                      | `@omnigraph/neo4j`          |
-| `odata`        | `@graphql-mesh/odata`        | `loadODataSubgraph`                                      | `@omnigraph/odata`          |
-| `thrift`       | `@graphql-mesh/thrift`       | `loadThriftSubgraph`                                     | `@omnigraph/thrift`         |
-| `tuql`         | `@graphql-mesh/tuql`         | `loadSQLiteSubgraph`                                     | `@omnigraph/sqlite`         |
-| `supergraph`   | —                            | **Do not compose.** Pass the supergraph to Hive Gateway. | `@graphql-hive/gateway`     |
+| v0 `handler`   | v0 package                                      | v1 loader                                          | v1 package                  |
+| -------------- | ----------------------------------------------- | -------------------------------------------------- | --------------------------- |
+| `graphql`      | `@graphql-mesh/graphql`                         | `loadGraphQLHTTPSubgraph`                          | `@graphql-mesh/compose-cli` |
+| `openapi`      | `@graphql-mesh/openapi`                         | `loadOpenAPISubgraph`                              | `@omnigraph/openapi`        |
+| `jsonSchema`   | `@graphql-mesh/json-schema`                     | `loadJSONSchemaSubgraph`                           | `@omnigraph/json-schema`    |
+| `grpc`         | `@graphql-mesh/grpc`                            | `loadGRPCSubgraph`                                 | `@omnigraph/grpc`           |
+| `soap`         | `@graphql-mesh/soap`                            | `loadSOAPSubgraph`                                 | `@omnigraph/soap`           |
+| `raml`         | `@graphql-mesh/raml`                            | `loadRAMLSubgraph`                                 | `@omnigraph/raml`           |
+| `mysql`        | `@graphql-mesh/mysql`                           | `loadMySQLSubgraph`                                | `@omnigraph/mysql`          |
+| `postgraphile` | `@graphql-mesh/postgraphile`                    | `loadPostgreSQLSubgraph`                           | `@omnigraph/postgresql`     |
+| `mongoose`     | `@graphql-mesh/mongoose`                        | `loadMongooseSubgraph`                             | `@omnigraph/mongoose`       |
+| `neo4j`        | `@graphql-mesh/neo4j`                           | `loadNeo4jSubgraph`                                | `@omnigraph/neo4j`          |
+| `odata`        | `@graphql-mesh/odata`                           | `loadODataSubgraph`                                | `@omnigraph/odata`          |
+| `thrift`       | `@graphql-mesh/thrift`                          | `loadThriftSubgraph`                               | `@omnigraph/thrift`         |
+| `tuql`         | `@graphql-mesh/tuql`                            | `loadSQLiteSubgraph`                               | `@omnigraph/sqlite`         |
+| `supergraph`   | consume an existing supergraph as a Mesh source | **Do not compose.** Give that SDL to Hive Gateway. | `@graphql-hive/gateway`     |
 
-GraphQL handler notes for the migrator:
+GraphQL handler differences the migrator knows about:
 
-- HTTP `{ endpoint }` is copied as-is.
-- Code-first `{ source: './schema.ts' }` becomes `{ endpoint: './schema.ts' }` for
-  `loadGraphQLHTTPSubgraph`.
-- `sources` + `fallback` / `race` / `highestValue` is **not** auto-migrated. Split into subgraphs or
-  keep a single endpoint.
+- v0 HTTP `{ endpoint }` → v1 `loadGraphQLHTTPSubgraph(name, { endpoint })` (copied as-is).
+- v0 code-first `{ source: './schema.ts' }` → v1 `{ endpoint: './schema.ts' }` (the v1 loader uses
+  `endpoint` for URL **or** a local schema file).
+- v0 `sources` + `fallback` / `race` / `highestValue` is **not** auto-migrated. In v0 that was one
+  handler with several HTTP backends. In v1, split them into subgraphs or keep a single endpoint.
 
 See [Source Handlers](/v1/source-handlers).
 
 ## Transforms
 
-Source-level transforms become `create*Transform` from `@graphql-mesh/compose-cli`. As above, there
-is no `bare` mode; `mode: wrap` is dropped because wrap is the only mode.
+v0 transforms could run in `bare` mode (mutate the schema in place) or `wrap` mode (schema
+wrapping). v1 only wraps, and emits Federation-compatible directives, so the result must be served
+by Hive Gateway (or another Federation-aware gateway). `mode: wrap` in YAML is dropped; it is
+implied.
 
-Root-level `transforms:` on the mesh config is **not** supported. Move them onto a source, or
-replace stitching with [Federation](/v1/transforms/federation).
+v0 allowed **root-level** `transforms:` on the unified schema. v1 does **not**. Move them onto the
+relevant source, or replace stitching with [Federation](/v1/transforms/federation).
 
-| v0 transform           | v1                                | Notes                                                       |
-| ---------------------- | --------------------------------- | ----------------------------------------------------------- |
-| `prefix`               | `createPrefixTransform`           | [docs](/v1/transforms/prefix)                               |
-| `rename`               | `createRenameTransform`           | [docs](/v1/transforms/rename)                               |
-| `filterSchema`         | `createFilterTransform`           | Arrays become `{ filters: [...] }`                          |
-| `encapsulate`          | `createEncapsulateTransform`      | [docs](/v1/transforms/encapsulate)                          |
-| `namingConvention`     | `createNamingConventionTransform` | [docs](/v1/transforms/naming-convention)                    |
-| `hoistField`           | `createHoistFieldTransform`       | Arrays become `{ mapping: [...] }`                          |
-| `prune`                | `createPruneTransform`            | [docs](/v1/transforms/prune)                                |
-| `federation`           | `createFederationTransform`       | [docs](/v1/transforms/federation)                           |
-| `extend`               | `createExtendTransform(typeDefs)` | `extend.resolvers` → `gatewayConfig.additionalResolvers`    |
-| `typeMerging`          | **manual**                        | Use Federation transform / [type merging](/v1/type-merging) |
-| `cache`                | **manual**                        | [Response caching](/v1/response-caching) on the gateway     |
-| `rateLimit`            | **manual**                        | [Rate limit](/v1/rate-limit) on the gateway                 |
-| `replaceField`         | **manual**                        | Hoist / rename / `additionalTypeDefs`                       |
-| `resolversComposition` | **manual**                        | `additionalResolvers` or a gateway plugin                   |
+| v0 transform           | v1                                | What is different                                                                    |
+| ---------------------- | --------------------------------- | ------------------------------------------------------------------------------------ |
+| `prefix`               | `createPrefixTransform`           | Same idea; [docs](/v1/transforms/prefix)                                             |
+| `rename`               | `createRenameTransform`           | [docs](/v1/transforms/rename)                                                        |
+| `filterSchema`         | `createFilterTransform`           | Drop `mode`. A YAML list of globs becomes `{ filters: [...] }`                       |
+| `encapsulate`          | `createEncapsulateTransform`      | [docs](/v1/transforms/encapsulate)                                                   |
+| `namingConvention`     | `createNamingConventionTransform` | [docs](/v1/transforms/naming-convention)                                             |
+| `hoistField`           | `createHoistFieldTransform`       | v0 array → `{ mapping: [...] }`                                                      |
+| `prune`                | `createPruneTransform`            | [docs](/v1/transforms/prune)                                                         |
+| `federation`           | `createFederationTransform`       | How you declare keys / `@merge` in v1                                                |
+| `extend`               | `createExtendTransform(typeDefs)` | `typeDefs` stay in compose; `extend.resolvers` → `gatewayConfig.additionalResolvers` |
+| `typeMerging`          | **manual**                        | Stitching-style merge → Federation / [type merging](/v1/type-merging)                |
+| `cache`                | **manual**                        | Was a transform; now a **gateway** plugin — [response caching](/v1/response-caching) |
+| `rateLimit`            | **manual**                        | Was a transform; now gateway / `@rateLimit` — [rate limit](/v1/rate-limit)           |
+| `replaceField`         | **manual**                        | Use hoist, rename, or `additionalTypeDefs`                                           |
+| `resolversComposition` | **manual**                        | `additionalResolvers` or a gateway plugin                                            |
 
-## What goes on compose vs gateway
+## Serve, plugins, and runtime (compose vs gateway)
 
-| v0                                                                                      | v1                                                                                              |
-| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `sources`, source `transforms`, `additionalTypeDefs`, `customFetch` (compose fetch)     | `composeConfig`                                                                                 |
-| `serve.*`, `plugins`, `cache`, `additionalResolvers`, `logger`, `customFetch` (runtime) | `gatewayConfig`                                                                                 |
-| `codegen`, `sdk`, `documents`                                                           | GraphQL Codegen / your client, not Mesh                                                         |
-| `merger`                                                                                | Federation composition (warning only)                                                           |
-| `pubsub`                                                                                | Hive Gateway subscriptions — [docs](/v1/subscriptions-webhooks)                                 |
-| `persistedOperations`                                                                   | [Hive persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) |
-| `serve.extraParamNames`, `serve.browser`                                                | not migrated                                                                                    |
+In v0, `serve`, `plugins`, `cache`, and `customFetch` lived next to `sources` in one YAML file. In
+v1, anything that **builds SDL** is compose; anything that **runs requests** is Hive Gateway.
 
-Serve field mapping: `port` → `port`, `hostname` → `host`, `endpoint` → `graphqlEndpoint`,
-`playground: false` → `graphiql: false`, `playgroundTitle` → `graphiql.title`, `cors`,
-`healthCheckEndpoint`, `batchingLimit` → `batching.limit`, `sslCredentials`, `fork`.
+| v0                                                                                           | v1                                                                                              |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `sources`, source `transforms`, `additionalTypeDefs`, `customFetch` used while introspecting | `composeConfig` (`fetch` on compose)                                                            |
+| `serve.*`, `plugins`, `cache`, `additionalResolvers`, `logger`, runtime `customFetch`        | `gatewayConfig` (`fetchAPI.fetch`)                                                              |
+| `codegen`, `sdk`, `documents`                                                                | GraphQL Codegen / your client — Mesh does not run these                                         |
+| `merger`                                                                                     | No replacement key; composition is Federation-style (migrator warns)                            |
+| `pubsub`                                                                                     | Hive Gateway subscriptions — [docs](/v1/subscriptions-webhooks)                                 |
+| `persistedOperations`                                                                        | [Hive persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) |
+| `serve.extraParamNames`, `serve.browser`                                                     | not migrated                                                                                    |
 
-Built-in plugin mapping: `hive` → `reporting` (+ `persistedDocuments` when present), `responseCache`
-→ `responseCaching`, `rateLimit` → `rateLimiting`, `prometheus` → `prometheus`, `maskedErrors` →
-`maskedErrors`, `immediateIntrospection` → `useImmediateIntrospection()`. Other plugins are resolved
-from `@envelop/*` / `@graphql-yoga/plugin-*` when possible.
+### `serve` field names
+
+| v0 `serve`                                    | v1 `gatewayConfig`           |
+| --------------------------------------------- | ---------------------------- |
+| `port`                                        | `port`                       |
+| `hostname`                                    | `host`                       |
+| `endpoint` (GraphQL path, default `/graphql`) | `graphqlEndpoint`            |
+| `playground: false`                           | `graphiql: false`            |
+| `playgroundTitle`                             | `graphiql: { title }`        |
+| `cors`                                        | `cors`                       |
+| `healthCheckEndpoint`                         | `healthCheckEndpoint`        |
+| `batchingLimit`                               | `batching: { limit }`        |
+| `sslCredentials`                              | `sslCredentials`             |
+| `fork`                                        | `fork`                       |
+| `staticFiles`                                 | `useStaticFiles(...)` plugin |
+| `browser`                                     | skipped (dev-only auto-open) |
+
+### Plugins
+
+| v0 `plugins`                         | v1                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------- |
+| `hive`                               | `reporting: { type: 'hive', ... }` and `persistedDocuments` when set      |
+| `responseCache`                      | `responseCaching`                                                         |
+| `rateLimit`                          | `rateLimiting`                                                            |
+| `prometheus`                         | `prometheus`                                                              |
+| `maskedErrors`                       | `maskedErrors`                                                            |
+| `immediateIntrospection`             | `useImmediateIntrospection()` in `plugins`                                |
+| other Envelop / Yoga / Armor plugins | resolved when possible; otherwise add to `gatewayConfig.plugins` yourself |
+
+v0 `cache:` (Redis, Localforage, …) becomes `gatewayConfig.cache: new Cache(...)` with
+`@graphql-mesh/cache-*`. That is **not** the old Cache **transform**.
 
 ## Using Artifacts
 
-GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTTPHandler` functions.
-Instead, it generates a GraphQL SDL file that you can use with Hive Gateway.
+GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTTPHandler`. v0
+deployment used those from `.mesh` after `mesh build`. v1 deployment uses an SDL file plus Hive
+Gateway.
+
+| v0 artifact                                 | v1                                                                                                                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                |
+| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment) |
+| Generated SDK from `sdk:`                   | GraphQL Codegen client-preset (or similar) against the supergraph                                                  |
+| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                           |
 
 After a successful config migration:
 
@@ -178,4 +342,5 @@ Read more about
 [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
 setup your gateway with the new artifacts.
 
-If you need local execution, refer to the local execution guide [here](/v1/local-execution).
+If you need local execution, refer to the local execution guide [here](/v1/local-execution). More
+compose background: [Getting Started](/v1/getting-started).

--- a/website/src/content/v1/migration-from-v0.mdx
+++ b/website/src/content/v1/migration-from-v0.mdx
@@ -1,81 +1,146 @@
 import { Callout } from '@theguild/components'
 
-# Migration from GraphQL Mesh v0 (Experimental - Beta)
-
-<Callout>This feature is still work-in-progress. Please report any issues you encounter.</Callout>
-
-If you are migrating from GraphQL Mesh v0, you should be aware of the following changes:
-
-- GraphQL Mesh no longer comes with a built-in gateway. You should setup Hive Gateway to serve the
-  generated artifacts.
-- GraphQL Mesh no longer generates an executable JavaScript code in `.mesh` folder, but instead it
-  builds a GraphQL SDL (Supergraph or Subgraph) that you can use with Hive Gateway.
-- GraphQL Mesh Transforms no longer have `bare` mode. There is only `wrap` mode now, and all the
-  transforms are using Federation-compatible directives. Any transformed subgraph should be served
-  using Hive Gateway.
-- If you deploy GraphQL Mesh v0 by using the http handler provided in the artifacts under `.mesh`,
-  now you should take a look at
-  [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
-  deploy your gateway.
-- GraphQL Mesh no longer [GraphQL Code Generator](https://graphql-codegen.com) internally. You
-  should use it separately if you need to generate types or documents.
-- GraphQL Mesh no longer generates Persisted Operations store. You should setup your gateway based
-  on your needs. [See here](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) for
-  more information.
-
-GraphQL Mesh is now only responsible of generating a GraphQL SDL file `supergraph.graphql` or
-`subgraph.graphql` that you can use with Hive Gateway, it is not responsible for serving the
-generated artifacts.
+# Migration from GraphQL Mesh v0 (Experimental)
 
 <Callout>
-  Please make sure all of your `@graphql-mesh/` packages are up-to-date. Otherwise, the migration
-  script may not work as expected!
+  The config migrator is still experimental. Run it, then review `mesh.config.ts` and the warnings
+  it prints. Please report anything it gets wrong.
 </Callout>
 
-## Configuration Format
+Mesh v1 is **compose + serve**, not a single runtime that writes `.mesh` artifacts.
 
-Before Mesh used to support a configuration file in `.meshrc.yml` or `.meshrc.json` format. Now Mesh
-only supports a configuration file in `mesh.config.js` or `mesh.config.ts` format.
+- **Compose** (`@graphql-mesh/compose-cli`) builds a Supergraph/Subgraph SDL (`supergraph.graphql`).
+- **Serve** ([Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway)) executes that SDL.
+  Transforms are Federation-compatible wrap transforms; transformed subgraphs must be served by Hive
+  Gateway (or another Federation-aware gateway).
+- Mesh no longer generates executable JS in `.mesh`, does not run GraphQL Code Generator internally,
+  and does not write a persisted-operations store.
 
-Please install `@graphql-mesh/migrate-config-cli` package to migrate your configuration file from v0
-to v1.
+If you used `createBuiltMeshHTTPHandler` from `.mesh`, follow
+[Hive Gateway deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment). For
+in-process execution see [Local Execution](/v1/local-execution).
+
+<Callout>
+  Update every `@graphql-mesh/*` package on v0 first. The migrator reads the current YAML/JSON
+  schema; old handler option names may not parse.
+</Callout>
+
+## 1. Migrate `.meshrc` with the CLI
+
+v0: `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`.  
+v1: `mesh.config.ts` (or `mesh.config.js`) with `composeConfig` and `gatewayConfig`.
 
 ```sh npm2yarn
 npm install @graphql-mesh/migrate-config-cli
 ```
 
-Then run the following command in your project directory:
-
 ```sh
 npx mesh-migrate-config
 ```
 
-During the migration process, you might get some errors or warnings related to the deprecated or
-removed functionalities. Please make sure to update your legacy v0 configuration and setup according
-to those warnings and errors to get the best out of the new version.
+Optional flags:
 
-## Package Changes
+| Flag          | Meaning                                        |
+| ------------- | ---------------------------------------------- |
+| `--dry-run`   | Print `mesh.config.ts` to stdout, do not write |
+| `--force`     | Overwrite an existing `mesh.config.ts`         |
+| `[directory]` | Project root (default: cwd)                    |
 
-Instead of `@graphql-mesh/cli`, you should now use `@graphql-mesh/compose-cli` and
-`@graphql-hive/gateway` packages.
+The CLI prints packages to add/remove, then:
 
-For example with `npm`:
-
-```bash
-npm uninstall @graphql-mesh/cli
-npm install @graphql-mesh/compose-cli @graphql-hive/gateway
+```sh
+npx mesh-compose -o supergraph.graphql
+npx hive-gateway supergraph
 ```
 
-Source handler packages are also changed, now we have `@omnigraph/*` packages instead of
-`@graphql-mesh/*` packages.
+Errors mean it **did not write** a file (root transforms, unknown handler, removed transform).
+Warnings mean it wrote a file but you still have manual work (codegen, pubsub, merger, …).
 
-## Using Artifacts
+## 2. Packages
 
-GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTTPHandler` functions.
-Instead, it generates a GraphQL SDL file that you can use with Hive Gateway.
+Uninstall `@graphql-mesh/cli`. Install `@graphql-mesh/compose-cli` and `@graphql-hive/gateway`.
+Source packages moved from `@graphql-mesh/<handler>` to `@omnigraph/<handler>` (see table below).
 
-Read more about
-[Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
-setup your gateway with the new artifacts.
+## 3. Handler mapping
 
-If you need local execution, refer to the local execution guide [here](/v1/local-execution).
+| v0 `handler`   | v0 package                   | v1 loader                                                | v1 package                  |
+| -------------- | ---------------------------- | -------------------------------------------------------- | --------------------------- |
+| `graphql`      | `@graphql-mesh/graphql`      | `loadGraphQLHTTPSubgraph`                                | `@graphql-mesh/compose-cli` |
+| `openapi`      | `@graphql-mesh/openapi`      | `loadOpenAPISubgraph`                                    | `@omnigraph/openapi`        |
+| `jsonSchema`   | `@graphql-mesh/json-schema`  | `loadJSONSchemaSubgraph`                                 | `@omnigraph/json-schema`    |
+| `grpc`         | `@graphql-mesh/grpc`         | `loadGRPCSubgraph`                                       | `@omnigraph/grpc`           |
+| `soap`         | `@graphql-mesh/soap`         | `loadSOAPSubgraph`                                       | `@omnigraph/soap`           |
+| `raml`         | `@graphql-mesh/raml`         | `loadRAMLSubgraph`                                       | `@omnigraph/raml`           |
+| `mysql`        | `@graphql-mesh/mysql`        | `loadMySQLSubgraph`                                      | `@omnigraph/mysql`          |
+| `postgraphile` | `@graphql-mesh/postgraphile` | `loadPostgreSQLSubgraph`                                 | `@omnigraph/postgresql`     |
+| `mongoose`     | `@graphql-mesh/mongoose`     | `loadMongooseSubgraph`                                   | `@omnigraph/mongoose`       |
+| `neo4j`        | `@graphql-mesh/neo4j`        | `loadNeo4jSubgraph`                                      | `@omnigraph/neo4j`          |
+| `odata`        | `@graphql-mesh/odata`        | `loadODataSubgraph`                                      | `@omnigraph/odata`          |
+| `thrift`       | `@graphql-mesh/thrift`       | `loadThriftSubgraph`                                     | `@omnigraph/thrift`         |
+| `tuql`         | `@graphql-mesh/tuql`         | `loadSQLiteSubgraph`                                     | `@omnigraph/sqlite`         |
+| `supergraph`   | —                            | **Do not compose.** Pass the supergraph to Hive Gateway. | `@graphql-hive/gateway`     |
+
+GraphQL handler notes:
+
+- HTTP `{ endpoint }` is copied as-is.
+- Code-first `{ source: './schema.ts' }` becomes `{ endpoint: './schema.ts' }` for
+  `loadGraphQLHTTPSubgraph`.
+- `sources` + `fallback` / `race` / `highestValue` is **not** auto-migrated. Split into subgraphs or
+  keep a single endpoint.
+
+See [Source Handlers](/v1/source-handlers).
+
+## 4. Transform mapping
+
+Source-level transforms become `create*Transform` from `@graphql-mesh/compose-cli`. `bare` mode is
+gone; `mode: wrap` is dropped. Root-level `transforms:` on the mesh config is **not** supported —
+move them onto a source, or replace stitching with [Federation](/v1/transforms/federation).
+
+| v0 transform           | v1                                | Notes                                                       |
+| ---------------------- | --------------------------------- | ----------------------------------------------------------- |
+| `prefix`               | `createPrefixTransform`           | [docs](/v1/transforms/prefix)                               |
+| `rename`               | `createRenameTransform`           | [docs](/v1/transforms/rename)                               |
+| `filterSchema`         | `createFilterTransform`           | Arrays become `{ filters: [...] }`                          |
+| `encapsulate`          | `createEncapsulateTransform`      | [docs](/v1/transforms/encapsulate)                          |
+| `namingConvention`     | `createNamingConventionTransform` | [docs](/v1/transforms/naming-convention)                    |
+| `hoistField`           | `createHoistFieldTransform`       | Arrays become `{ mapping: [...] }`                          |
+| `prune`                | `createPruneTransform`            | [docs](/v1/transforms/prune)                                |
+| `federation`           | `createFederationTransform`       | [docs](/v1/transforms/federation)                           |
+| `extend`               | `createExtendTransform(typeDefs)` | `extend.resolvers` → `gatewayConfig.additionalResolvers`    |
+| `typeMerging`          | **manual**                        | Use Federation transform / [type merging](/v1/type-merging) |
+| `cache`                | **manual**                        | [Response caching](/v1/response-caching) on the gateway     |
+| `rateLimit`            | **manual**                        | [Rate limit](/v1/rate-limit) on the gateway                 |
+| `replaceField`         | **manual**                        | Hoist / rename / `additionalTypeDefs`                       |
+| `resolversComposition` | **manual**                        | `additionalResolvers` or a gateway plugin                   |
+
+## 5. What goes on compose vs gateway
+
+| v0                                                                                      | v1                                                                                              |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `sources`, source `transforms`, `additionalTypeDefs`, `customFetch` (compose fetch)     | `composeConfig`                                                                                 |
+| `serve.*`, `plugins`, `cache`, `additionalResolvers`, `logger`, `customFetch` (runtime) | `gatewayConfig`                                                                                 |
+| `codegen`, `sdk`, `documents`                                                           | GraphQL Codegen / your client, not Mesh                                                         |
+| `merger`                                                                                | Federation composition (warning only)                                                           |
+| `pubsub`                                                                                | Hive Gateway subscriptions — [docs](/v1/subscriptions-webhooks)                                 |
+| `persistedOperations`                                                                   | [Hive persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) |
+| `serve.extraParamNames`, `serve.browser`                                                | not migrated                                                                                    |
+
+Serve field mapping: `port` → `port`, `hostname` → `host`, `endpoint` → `graphqlEndpoint`,
+`playground: false` → `graphiql: false`, `playgroundTitle` → `graphiql.title`, `cors`,
+`healthCheckEndpoint`, `batchingLimit` → `batching.limit`, `sslCredentials`, `fork`.
+
+Built-in plugin mapping: `hive` → `reporting` (+ `persistedDocuments` when present), `responseCache`
+→ `responseCaching`, `rateLimit` → `rateLimiting`, `prometheus` → `prometheus`, `maskedErrors` →
+`maskedErrors`, `immediateIntrospection` → `useImmediateIntrospection()`. Other plugins are resolved
+from `@envelop/*` / `@graphql-yoga/plugin-*` when possible.
+
+## 6. After the CLI
+
+1. Install the printed packages and remove the old handler/CLI packages.
+2. Fix every error/warning (especially root transforms and type merging).
+3. `npx mesh-compose -o supergraph.graphql`
+4. `npx hive-gateway supergraph`
+5. Replace `.mesh` HTTP handlers with Hive Gateway in your deployment.
+
+More: [Getting Started](/v1/getting-started),
+[Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway).

--- a/website/src/content/v1/migration-from-v0.mdx
+++ b/website/src/content/v1/migration-from-v0.mdx
@@ -1,38 +1,53 @@
 import { Callout } from '@theguild/components'
 
-# Migration from GraphQL Mesh v0 (Experimental)
+# Migration from GraphQL Mesh v0 (Experimental - Beta)
+
+<Callout>This feature is still work-in-progress. Please report any issues you encounter.</Callout>
+
+If you are migrating from GraphQL Mesh v0, you should be aware of the following changes:
+
+- GraphQL Mesh no longer comes with a built-in gateway. You should setup Hive Gateway to serve the
+  generated artifacts.
+- GraphQL Mesh no longer generates an executable JavaScript code in `.mesh` folder, but instead it
+  builds a GraphQL SDL (Supergraph or Subgraph) that you can use with Hive Gateway.
+- GraphQL Mesh Transforms no longer have `bare` mode. There is only `wrap` mode now, and all the
+  transforms are using Federation-compatible directives. Any transformed subgraph should be served
+  using Hive Gateway.
+- If you deploy GraphQL Mesh v0 by using the http handler provided in the artifacts under `.mesh`,
+  now you should take a look at
+  [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
+  deploy your gateway.
+- GraphQL Mesh no longer runs [GraphQL Code Generator](https://graphql-codegen.com) internally. You
+  should use it separately if you need to generate types or documents.
+- GraphQL Mesh no longer generates a Persisted Operations store. You should setup your gateway based
+  on your needs. [See here](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) for
+  more information.
+
+GraphQL Mesh is now only responsible of generating a GraphQL SDL file `supergraph.graphql` or
+`subgraph.graphql` that you can use with Hive Gateway. It is not responsible for serving the
+generated artifacts.
+
+For in-process execution (instead of a standalone gateway process), see
+[Local Execution](/v1/local-execution).
 
 <Callout>
-  The config migrator is still experimental. Run it, then review `mesh.config.ts` and the warnings
-  it prints. Please report anything it gets wrong.
+  Please make sure all of your `@graphql-mesh/` packages are up-to-date. Otherwise, the migration
+  script may not work as expected.
 </Callout>
 
-Mesh v1 is **compose + serve**, not a single runtime that writes `.mesh` artifacts.
+## Configuration Format
 
-- **Compose** (`@graphql-mesh/compose-cli`) builds a Supergraph/Subgraph SDL (`supergraph.graphql`).
-- **Serve** ([Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway)) executes that SDL.
-  Transforms are Federation-compatible wrap transforms; transformed subgraphs must be served by Hive
-  Gateway (or another Federation-aware gateway).
-- Mesh no longer generates executable JS in `.mesh`, does not run GraphQL Code Generator internally,
-  and does not write a persisted-operations store.
+Before, Mesh used a configuration file in `.meshrc.yml`, `.meshrc.yaml`, `.meshrc.json`, or
+`.meshrc.js` format. Now Mesh supports a configuration file in `mesh.config.ts` or `mesh.config.js`
+format, with `composeConfig` (SDL generation) and `gatewayConfig` (Hive Gateway).
 
-If you used `createBuiltMeshHTTPHandler` from `.mesh`, follow
-[Hive Gateway deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment). For
-in-process execution see [Local Execution](/v1/local-execution).
-
-<Callout>
-  Update every `@graphql-mesh/*` package on v0 first. The migrator reads the current YAML/JSON
-  schema; old handler option names may not parse.
-</Callout>
-
-## 1. Migrate `.meshrc` with the CLI
-
-v0: `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`.  
-v1: `mesh.config.ts` (or `mesh.config.js`) with `composeConfig` and `gatewayConfig`.
+Install `@graphql-mesh/migrate-config-cli` to migrate your configuration file from v0 to v1.
 
 ```sh npm2yarn
 npm install @graphql-mesh/migrate-config-cli
 ```
+
+Then run the following command in your project directory:
 
 ```sh
 npx mesh-migrate-config
@@ -46,22 +61,33 @@ Optional flags:
 | `--force`     | Overwrite an existing `mesh.config.ts`         |
 | `[directory]` | Project root (default: cwd)                    |
 
-The CLI prints packages to add/remove, then:
+During the migration process, you might get some errors or warnings related to the deprecated or
+removed functionalities. Please make sure to update your legacy v0 configuration and setup according
+to those warnings and errors.
 
-```sh
-npx mesh-compose -o supergraph.graphql
-npx hive-gateway supergraph
+- **Errors** mean the CLI **did not write** `mesh.config.ts` (root-level transforms, unknown
+  handler, removed transform such as `typeMerging`).
+- **Warnings** mean it wrote a file, but you still have manual work (codegen, pubsub, merger, …).
+
+<Callout>
+  The config migrator is still experimental. Review `mesh.config.ts` and the messages it prints.
+  Please report anything it gets wrong.
+</Callout>
+
+## Package Changes
+
+Instead of `@graphql-mesh/cli`, you should now use `@graphql-mesh/compose-cli` and
+`@graphql-hive/gateway`.
+
+For example with `npm`:
+
+```sh npm2yarn
+npm uninstall @graphql-mesh/cli
+npm install @graphql-mesh/compose-cli @graphql-hive/gateway
 ```
 
-Errors mean it **did not write** a file (root transforms, unknown handler, removed transform).
-Warnings mean it wrote a file but you still have manual work (codegen, pubsub, merger, …).
-
-## 2. Packages
-
-Uninstall `@graphql-mesh/cli`. Install `@graphql-mesh/compose-cli` and `@graphql-hive/gateway`.
-Source packages moved from `@graphql-mesh/<handler>` to `@omnigraph/<handler>` (see table below).
-
-## 3. Handler mapping
+Source handler packages are also changed: `@omnigraph/*` instead of `@graphql-mesh/*` for most
+handlers. The CLI prints the exact add/remove list for your config. Mapping:
 
 | v0 `handler`   | v0 package                   | v1 loader                                                | v1 package                  |
 | -------------- | ---------------------------- | -------------------------------------------------------- | --------------------------- |
@@ -80,7 +106,7 @@ Source packages moved from `@graphql-mesh/<handler>` to `@omnigraph/<handler>` (
 | `tuql`         | `@graphql-mesh/tuql`         | `loadSQLiteSubgraph`                                     | `@omnigraph/sqlite`         |
 | `supergraph`   | —                            | **Do not compose.** Pass the supergraph to Hive Gateway. | `@graphql-hive/gateway`     |
 
-GraphQL handler notes:
+GraphQL handler notes for the migrator:
 
 - HTTP `{ endpoint }` is copied as-is.
 - Code-first `{ source: './schema.ts' }` becomes `{ endpoint: './schema.ts' }` for
@@ -90,11 +116,13 @@ GraphQL handler notes:
 
 See [Source Handlers](/v1/source-handlers).
 
-## 4. Transform mapping
+## Transforms
 
-Source-level transforms become `create*Transform` from `@graphql-mesh/compose-cli`. `bare` mode is
-gone; `mode: wrap` is dropped. Root-level `transforms:` on the mesh config is **not** supported —
-move them onto a source, or replace stitching with [Federation](/v1/transforms/federation).
+Source-level transforms become `create*Transform` from `@graphql-mesh/compose-cli`. As above, there
+is no `bare` mode; `mode: wrap` is dropped because wrap is the only mode.
+
+Root-level `transforms:` on the mesh config is **not** supported. Move them onto a source, or
+replace stitching with [Federation](/v1/transforms/federation).
 
 | v0 transform           | v1                                | Notes                                                       |
 | ---------------------- | --------------------------------- | ----------------------------------------------------------- |
@@ -113,7 +141,7 @@ move them onto a source, or replace stitching with [Federation](/v1/transforms/f
 | `replaceField`         | **manual**                        | Hoist / rename / `additionalTypeDefs`                       |
 | `resolversComposition` | **manual**                        | `additionalResolvers` or a gateway plugin                   |
 
-## 5. What goes on compose vs gateway
+## What goes on compose vs gateway
 
 | v0                                                                                      | v1                                                                                              |
 | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
@@ -134,13 +162,20 @@ Built-in plugin mapping: `hive` → `reporting` (+ `persistedDocuments` when pre
 `maskedErrors`, `immediateIntrospection` → `useImmediateIntrospection()`. Other plugins are resolved
 from `@envelop/*` / `@graphql-yoga/plugin-*` when possible.
 
-## 6. After the CLI
+## Using Artifacts
 
-1. Install the printed packages and remove the old handler/CLI packages.
+GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTTPHandler` functions.
+Instead, it generates a GraphQL SDL file that you can use with Hive Gateway.
+
+After a successful config migration:
+
+1. Install the packages the CLI printed and remove the old handler/CLI packages.
 2. Fix every error/warning (especially root transforms and type merging).
-3. `npx mesh-compose -o supergraph.graphql`
-4. `npx hive-gateway supergraph`
-5. Replace `.mesh` HTTP handlers with Hive Gateway in your deployment.
+3. Run `npx mesh-compose -o supergraph.graphql` to generate the supergraph schema.
+4. Run `npx hive-gateway supergraph` to start the gateway server.
 
-More: [Getting Started](/v1/getting-started),
-[Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway).
+Read more about
+[Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
+setup your gateway with the new artifacts.
+
+If you need local execution, refer to the local execution guide [here](/v1/local-execution).

--- a/website/src/content/v1/migration-from-v0.mdx
+++ b/website/src/content/v1/migration-from-v0.mdx
@@ -29,9 +29,9 @@ If you are migrating from GraphQL Mesh v0, you should be aware of the following 
   [Hive Gateway's Deployment Guide](https://the-guild.dev/graphql/hive/docs/gateway/deployment) to
   deploy your gateway.
 - GraphQL Mesh no longer runs [GraphQL Code Generator](https://graphql-codegen.com) internally, and
-  it no longer writes a typed SDK into `.mesh`. You still get a type-safe SDK: generate it with
-  Codegen, then execute through Hive Gateway (`sdkRequester`). See [Type-safe SDK](#type-safe-sdk)
-  below.
+  it no longer writes SDKs into `.mesh`. You still have two typed paths: an **operation SDK**
+  (`getSdk` + Hive Gateway) and an **in-context SDK** (`context.Source.Query.field` in resolvers).
+  See [Type-safe SDKs](#type-safe-sdks).
 - GraphQL Mesh no longer generates a Persisted Operations store. You should setup your gateway based
   on your needs. [See here](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents) for
   more information.
@@ -40,19 +40,20 @@ GraphQL Mesh is now only responsible of generating a GraphQL SDL file `supergrap
 `subgraph.graphql` that you can use with Hive Gateway. It is not responsible for serving the
 generated artifacts.
 
-| Topic                | v0                                                                 | v1                                                                                                                                |
-| -------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                                                 |
-| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)                                       |
-| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                                                |
-| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                                            |
-| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                                          |
-| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                                                 |
-| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                                                     |
-| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)                                         |
-| Codegen / SDK        | `documents` + `sdk` → `.mesh` `getMeshSDK()`                       | Codegen + Hive Gateway `sdkRequester` ([typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)) |
-| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents)                           |
-| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                                                  |
+| Topic                | v0                                                                 | v1                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| Role of Mesh         | One runtime: load sources, merge, transform, **and** serve GraphQL | **Compose only**: produce Supergraph/Subgraph SDL                                                                    |
+| Serving              | Built into `@graphql-mesh/cli` (`mesh dev` / `mesh start`)         | [Hive Gateway](https://the-guild.dev/graphql/hive/docs/gateway) (`hive-gateway supergraph`)                          |
+| Config               | `.meshrc.yml` / `.meshrc.yaml` / `.meshrc.json` / `.meshrc.js`     | `mesh.config.ts` (or `.js`) with `composeConfig` + `gatewayConfig`                                                   |
+| Packages             | `@graphql-mesh/cli` + `@graphql-mesh/<handler>`                    | `@graphql-mesh/compose-cli` + `@omnigraph/*` + `@graphql-hive/gateway`                                               |
+| Output               | `.mesh/` (JS SDK, `execute`, HTTP handler, schema)                 | `supergraph.graphql` (or `.js`) — SDL, not a Node server                                                             |
+| Schema merge         | `merger` (stitching / bare / federation)                           | Federation-compatible composition                                                                                    |
+| Transforms           | `bare` or `wrap`; can sit on a source **or** on the unified schema | Wrap only; **source-level** in compose; Federation directives                                                        |
+| Type merging         | `typeMerging` transform / stitching                                | [Federation transform](/v1/transforms/federation) / [`@resolveTo`](/v1/schema-extensions)                            |
+| Operation SDK        | `documents` + `sdk` → `getMeshSDK()`                               | Codegen + `sdkRequester` ([typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)) |
+| In-context SDK       | `.mesh` `MeshContext` / `context.Source.Query.*`                   | [`@graphql-mesh/incontext-sdk-codegen`](/v1/schema-extensions#in-context-sdk-typed-additionalresolvers)              |
+| Persisted operations | Mesh-generated store                                               | [Hive Gateway persisted documents](https://the-guild.dev/graphql/hive/docs/gateway/persisted-documents)              |
+| In-process execute   | `getBuiltMesh()` / `.mesh` `execute`                               | [Local Execution](/v1/local-execution) via Hive Gateway executor                                                     |
 
 ```mermaid
 flowchart LR
@@ -320,17 +321,21 @@ v1, anything that **builds SDL** is compose; anything that **runs requests** is 
 v0 `cache:` (Redis, Localforage, …) becomes `gatewayConfig.cache: new Cache(...)` with
 `@graphql-mesh/cache-*`. That is **not** the old Cache **transform**.
 
-## Type-safe SDK
+## Type-safe SDKs
 
-v0 Mesh **was** an SDK generator. `documents` + `sdk` in `.meshrc` plus `mesh build` wrote
-`getMeshSDK()` into `.mesh`. v1 Mesh Compose does **not** do that. The same pattern is the
-[Hive Gateway typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk):
-Codegen emits `getSdk`, Hive Gateway supplies `sdkRequester`.
+v0 mixed two things into `.mesh`. They are separate in v1.
+
+### Operation SDK (`getSdk`) — client-style
+
+v0 `documents` + `sdk` + `getMeshSDK()`. v1: GraphQL Codegen `typescript-generic-sdk` + Hive Gateway
+`sdkRequester`. Canonical example:
+[Hive Gateway `examples/typed-sdk`](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)
+([CodeSandbox](https://githubbox.com/graphql-hive/gateway/tree/main/examples/typed-sdk)).
 
 | v0                                                   | v1                                                                              |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
 | `documents: ['./src/**/*.graphql']`                  | Codegen `documents` (e.g. `sdk/operations.graphql`)                             |
-| `sdk: { generateOperations: { selectionSetDepth } }` | You own the `.graphql` operations; Codegen does not invent them from Mesh       |
+| `sdk: { generateOperations: { selectionSetDepth } }` | You own the `.graphql` operations                                               |
 | `mesh build` → `.mesh` SDK                           | `graphql-codegen` against `supergraph.graphql`                                  |
 | `import { getMeshSDK } from './.mesh'`               | `import { getSdk } from './sdk/generated'`                                      |
 | `getMeshSDK()`                                       | `getSdk(runtime.sdkRequester)` or `getSdk(getSdkRequesterForUnifiedGraph(...))` |
@@ -344,9 +349,7 @@ const sdk = getMeshSDK()
 const { getSomething } = await sdk.myQuery({ someVar: 'foo' })
 ```
 
-v1 — same stack as the
-[Hive Gateway typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)
-([CodeSandbox](https://githubbox.com/graphql-hive/gateway/tree/main/examples/typed-sdk)):
+v1:
 
 ```ts filename="codegen.ts"
 import type { CodegenConfig } from '@graphql-codegen/cli'
@@ -375,17 +378,46 @@ const sdk = getSdk(runtime.sdkRequester)
 const todos = await sdk.Todos()
 ```
 
-The example also runs mutations and subscriptions on the same `getSdk` (`sdk.AddTodo(...)`,
-`sdk.TodoAdded()` as an async iterable). See
-[`example.ts`](https://github.com/graphql-hive/gateway/blob/main/examples/typed-sdk/example.ts).
+See [`example.ts`](https://github.com/graphql-hive/gateway/blob/main/examples/typed-sdk/example.ts)
+for mutations and subscriptions. In-process without `createGatewayRuntime`:
+`getSdkRequesterForUnifiedGraph` in [Local Execution](/v1/local-execution).
 
-If you only need in-process execution without `createGatewayRuntime`, use
-`getSdkRequesterForUnifiedGraph` as in [Local Execution](/v1/local-execution). Compose the
-supergraph first (`mesh-compose -o supergraph.graphql`); Codegen’s `schema` must point at that file
-(or `supergraph.js`), not at `.mesh`.
+The migrator **warns** on `sdk` / `codegen` / `documents` and does not write `codegen.ts`.
 
-The migrator **warns** on `sdk` / `codegen` / `documents` and does not generate `codegen.ts`. Copy
-your v0 `documents` into Codegen yourself.
+### In-context SDK (`context.Source.Query.field`) — resolvers
+
+v0 `mesh build` also typed **Mesh context** so `additionalResolvers` could call a source without
+hand-writing GraphQL documents: `context.Wiki.Query.someField({ root, args, context, info })`.
+
+v1: Codegen plugin
+[`@graphql-mesh/incontext-sdk-codegen`](https://github.com/ardatan/graphql-mesh/tree/master/packages/incontext-sdk-codegen)
+against the supergraph. Example:
+[`e2e/openapi-javascript-wiki`](https://github.com/ardatan/graphql-mesh/tree/master/e2e/openapi-javascript-wiki).
+
+```ts filename="codegen.ts"
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+export default {
+  schema: './supergraph.graphql',
+  generates: {
+    './types/incontext-sdk.ts': {
+      plugins: ['@graphql-mesh/incontext-sdk-codegen']
+    }
+  }
+} satisfies CodegenConfig
+```
+
+```ts
+import type { MeshInContextSDK } from './types/incontext-sdk'
+
+async function viewsInPastMonth(root, { project }, context: MeshInContextSDK, info) {
+  return context.Wiki.Query.metrics_pageviews_aggregate_by_project_by_access_by_agent_by_granularity_by_start_by_end(
+    { root, args: { project /* … */ }, context, info, selectionSet: `{ items { views } }` }
+  )
+}
+```
+
+Full walkthrough: [In-context SDK](/v1/schema-extensions#in-context-sdk-typed-additionalresolvers).
 
 ## Using Artifacts
 
@@ -393,12 +425,13 @@ GraphQL Mesh no longer generates artifacts with `execute` or `createBuiltMeshHTT
 deployment used those from `.mesh` after `mesh build`. v1 deployment uses an SDL file plus Hive
 Gateway.
 
-| v0 artifact                                 | v1                                                                                                                                       |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                                      |
-| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment)                       |
-| Generated SDK from `sdk:` / `getMeshSDK()`  | Codegen generic SDK + `runtime.sdkRequester` — [typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk) |
-| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                                                 |
+| v0 artifact                                 | v1                                                                                                                    |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `.mesh/index.js` `getBuiltMesh` / `execute` | Compose SDL + [local execution](/v1/local-execution) (`getExecutorForUnifiedGraph`)                                   |
+| `.mesh` `createBuiltMeshHTTPHandler`        | Hive Gateway Node / serverless adapters — [deployment](https://the-guild.dev/graphql/hive/docs/gateway/deployment)    |
+| Generated SDK from `sdk:` / `getMeshSDK()`  | [typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk) (`getSdk` + `sdkRequester`) |
+| `MeshContext` / `context.Source.Query.*`    | [`@graphql-mesh/incontext-sdk-codegen`](/v1/schema-extensions#in-context-sdk-typed-additionalresolvers)               |
+| Playground on `mesh dev`                    | GraphiQL on Hive Gateway                                                                                              |
 
 After a successful config migration:
 
@@ -412,6 +445,8 @@ Read more about
 setup your gateway with the new artifacts.
 
 If you need local execution or a typed SDK, see [Local Execution & SDK](/v1/local-execution) and
-[Type-safe SDK](#type-safe-sdk), or clone
-[examples/typed-sdk](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk). Compose
-background: [Getting Started](/v1/getting-started).
+[Type-safe SDKs](#type-safe-sdks). Operation SDK:
+[examples/typed-sdk](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk).
+In-context SDK:
+[e2e/openapi-javascript-wiki](https://github.com/ardatan/graphql-mesh/tree/master/e2e/openapi-javascript-wiki).
+Compose background: [Getting Started](/v1/getting-started).

--- a/website/src/content/v1/schema-extensions.mdx
+++ b/website/src/content/v1/schema-extensions.mdx
@@ -372,8 +372,8 @@ export const composeConfig = defineConfig({
   get `null` / the first match
 
 If the delegated query does not conform to these expectations and `valueKeyField` is not enough, you
-can provide a custom resolver function in `additionalResolvers` to the Hive Gateway runtime
-configuration. {/* `TODO: Add example for custom resolver function programmatically` */}
+can provide a custom resolver in `gatewayConfig.additionalResolvers`. Type those resolvers with the
+**in-context SDK** (see below): `context.SourceName.Query.fieldName(...)`.
 
 Batch delegation is generally preferable over plain delegation because it eliminates the redundancy
 of requesting the same field across an array of parent objects. Even so, delegation costs can add up
@@ -423,6 +423,92 @@ export const composeConfig = defineConfig({
   `
 })
 ```
+
+## In-context SDK (typed `additionalResolvers`)
+
+This is a **different** SDK from Hive Gateway’s operation `getSdk()`
+([typed-sdk example](https://github.com/graphql-hive/gateway/tree/main/examples/typed-sdk)).
+
+v0 `mesh build` wrote `MeshContext` into `.mesh` so resolvers could call sources as
+`context.Authors.Query.getAuthor({ root, args, context, info })`. v1 does the same with a Codegen
+plugin:
+[`@graphql-mesh/incontext-sdk-codegen`](https://github.com/ardatan/graphql-mesh/tree/master/packages/incontext-sdk-codegen).
+It reads the **composed supergraph** and emits `MeshInContextSDK` plus per-subgraph types.
+
+Working Mesh example:
+[`e2e/openapi-javascript-wiki`](https://github.com/ardatan/graphql-mesh/tree/master/e2e/openapi-javascript-wiki).
+
+```ts filename="codegen.ts"
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: './supergraph.graphql',
+  generates: {
+    './types/incontext-sdk.ts': {
+      plugins: ['@graphql-mesh/incontext-sdk-codegen']
+    }
+  }
+}
+
+export default config
+```
+
+```sh
+npx mesh-compose -o supergraph.graphql
+npx graphql-codegen
+```
+
+Then type `context` in `gatewayConfig.additionalResolvers`:
+
+```ts filename="mesh.config.ts"
+import type { GraphQLResolveInfo } from 'graphql'
+import { defineConfig as defineGatewayConfig } from '@graphql-hive/gateway'
+import type { MeshInContextSDK } from './types/incontext-sdk'
+
+export const gatewayConfig = defineGatewayConfig({
+  additionalResolvers: {
+    Query: {
+      async viewsInPastMonth(
+        root: never,
+        { project }: { project: string },
+        context: MeshInContextSDK,
+        info: GraphQLResolveInfo
+      ) {
+        const result =
+          await context.Wiki.Query.metrics_pageviews_aggregate_by_project_by_access_by_agent_by_granularity_by_start_by_end(
+            {
+              root,
+              args: {
+                access: 'all_access',
+                agent: 'user',
+                start: '20200101',
+                end: '20200226',
+                project,
+                granularity: 'daily'
+              },
+              context,
+              info,
+              selectionSet: /* GraphQL */ `
+                {
+                  ... on pageview_project {
+                    items {
+                      views
+                    }
+                  }
+                }
+              `
+            }
+          )
+        // …
+        return result
+      }
+    }
+  }
+})
+```
+
+The plugin also writes `types/subgraphs/<SourceName>.ts`. Prefer `@resolveTo` when the mapping is
+declarative; use in-context SDK when you need custom TypeScript around the delegated call.
 
 ## Schema Registry / Hive
 


### PR DESCRIPTION
## Summary
- Extract `migrateLegacyConfig` so v0 → v1 config conversion can be unit-tested without writing files or calling `process.exit`.
- Fail closed on unsupported handlers/transforms (root transforms, supergraph, typeMerging, GraphQL multi-`sources`); add `--dry-run` and `--force`.
- Expand the v0 migration guide with handler, transform, and compose vs gateway mapping tables.

## Test plan
- [x] `yarn jest packages/legacy/migrate-config-cli/tests/migrate.test.ts`
- [ ] Review `/v1/migration-from-v0` on the website preview
- [ ] Spot-check `npx mesh-migrate-config --dry-run` against a small `.meshrc.yml`