### PR TITLE
fix(http): do not fall back to CDN GraphiQL when playground.offline is set

### DIFF
--- a/.changeset/playground-offline-review.md
+++ b/.changeset/playground-offline-review.md
@@ -1,0 +1,7 @@
+---
+"@graphql-mesh/http": patch
+"@graphql-mesh/cli": patch
+"@graphql-mesh/types": patch
+---
+
+Do not silently fall back to CDN GraphiQL when `serve.playground.offline` is set without `renderGraphiQL`, and document that `@graphql-yoga/render-graphiql` must be installed in the app.

--- a/packages/legacy/cli/src/commands/serve/serve.ts
+++ b/packages/legacy/cli/src/commands/serve/serve.ts
@@ -12,6 +12,32 @@ import type { GraphQLMeshCLIParams } from '../../index.js';
 import { getMaxConcurrency } from './getMaxConcurency.js';
 import { startNodeHttpServer } from './node-http.js';
 
+type RenderGraphiQL = (options?: any) => string | Promise<string>;
+
+function isModuleNotFoundError(error: unknown): boolean {
+  const err = error as { code?: string; message?: string };
+  return (
+    err?.code === 'ERR_MODULE_NOT_FOUND' ||
+    err?.code === 'MODULE_NOT_FOUND' ||
+    (typeof err?.message === 'string' &&
+      err.message.includes("Cannot find package '@graphql-yoga/render-graphiql'"))
+  );
+}
+
+async function loadOfflineRenderGraphiQL(): Promise<RenderGraphiQL> {
+  try {
+    const { renderGraphiQL } = await import('@graphql-yoga/render-graphiql');
+    return renderGraphiQL;
+  } catch (error) {
+    if (isModuleNotFoundError(error)) {
+      throw new Error(
+        'serve.playground.offline requires `@graphql-yoga/render-graphiql`. Install it as a direct dependency of this project.',
+      );
+    }
+    throw error;
+  }
+}
+
 function portSelectorFn(sources: [number, number, number], logger: Logger) {
   const port = sources.find(source => Boolean(source)) || 4000;
   if (sources.filter(source => Boolean(source)).length > 1) {
@@ -90,6 +116,11 @@ export async function serveMesh(
   if (!playgroundTitle) {
     playgroundTitle = rawServeConfig?.playgroundTitle || cliParams.playgroundTitle;
   }
+  const playgroundOffline = resolvePlaygroundConfig(rawServeConfig.playground, false).offline;
+  let renderGraphiQL: RenderGraphiQL | undefined;
+  if (playgroundOffline) {
+    renderGraphiQL = await loadOfflineRenderGraphiQL();
+  }
   if (!cluster.isWorker && forkNum > 1) {
     let mainProcessKilled = false;
     registerTerminateHandler(eventName => {
@@ -133,16 +164,6 @@ export async function serveMesh(
         .catch(e => eventLogger.error(e));
     });
 
-    let renderGraphiQL;
-    if (resolvePlaygroundConfig(rawServeConfig.playground, false).offline) {
-      try {
-        ({ renderGraphiQL } = await import('@graphql-yoga/render-graphiql'));
-      } catch {
-        throw new Error(
-          'serve.playground.offline requires `@graphql-yoga/render-graphiql`. Install it in this project: `yarn add @graphql-yoga/render-graphiql`.',
-        );
-      }
-    }
     const meshHTTPHandler = createMeshHTTPHandler({
       baseDir,
       getBuiltMesh,

--- a/packages/legacy/cli/src/commands/serve/serve.ts
+++ b/packages/legacy/cli/src/commands/serve/serve.ts
@@ -133,14 +133,22 @@ export async function serveMesh(
         .catch(e => eventLogger.error(e));
     });
 
+    let renderGraphiQL;
+    if (resolvePlaygroundConfig(rawServeConfig.playground, false).offline) {
+      try {
+        ({ renderGraphiQL } = await import('@graphql-yoga/render-graphiql'));
+      } catch {
+        throw new Error(
+          'serve.playground.offline requires `@graphql-yoga/render-graphiql`. Install it in this project: `yarn add @graphql-yoga/render-graphiql`.',
+        );
+      }
+    }
     const meshHTTPHandler = createMeshHTTPHandler({
       baseDir,
       getBuiltMesh,
       rawServeConfig,
       playgroundTitle,
-      ...(resolvePlaygroundConfig(rawServeConfig.playground, false).offline
-        ? { renderGraphiQL: (await import('@graphql-yoga/render-graphiql')).renderGraphiQL }
-        : {}),
+      ...(renderGraphiQL ? { renderGraphiQL } : {}),
     });
 
     const { stop } = await startNodeHttpServer({

--- a/packages/legacy/cli/src/commands/serve/yaml-config.graphql
+++ b/packages/legacy/cli/src/commands/serve/yaml-config.graphql
@@ -95,7 +95,7 @@ type PlaygroundConfig {
   Use an offline GraphiQL that bundles JS, CSS and fonts inline instead of loading them from a CDN.
   Useful for air-gapped or on-premise environments with no internet access.
 
-  Requires `@graphql-yoga/render-graphiql`. Mesh CLI installs it; generated `createBuiltMeshHTTPHandler` artifacts import it.
+  Requires `@graphql-yoga/render-graphiql` in the same project (install it yourself; `mesh serve` and generated `createBuiltMeshHTTPHandler` artifacts import it directly).
   """
   offline: Boolean
 }

--- a/packages/legacy/http/src/graphqlHandler.ts
+++ b/packages/legacy/http/src/graphqlHandler.ts
@@ -8,6 +8,7 @@ export const graphqlHandler = ({
   getBuiltMesh,
   playgroundTitle,
   playgroundEnabled,
+  playgroundOffline,
   graphqlEndpoint,
   corsConfig,
   batchingLimit,
@@ -18,6 +19,7 @@ export const graphqlHandler = ({
   getBuiltMesh: () => Promise<MeshInstance>;
   playgroundTitle: string;
   playgroundEnabled: boolean;
+  playgroundOffline?: boolean;
   graphqlEndpoint: string;
   corsConfig: CORSOptions;
   batchingLimit?: number;
@@ -52,7 +54,12 @@ export const graphqlHandler = ({
       disposeOnProcessTerminate: true,
     };
 
-    if (playgroundEnabled && renderGraphiQLFn) {
+    if (playgroundEnabled && playgroundOffline) {
+      if (!renderGraphiQLFn) {
+        throw new Error(
+          'serve.playground.offline is enabled but renderGraphiQL was not provided. Import `renderGraphiQL` from `@graphql-yoga/render-graphiql` and pass it to createMeshHTTPHandler (generated Mesh artifacts do this automatically).',
+        );
+      }
       yogaOptions.renderGraphiQL = renderGraphiQLFn;
     }
 

--- a/packages/legacy/http/src/index.ts
+++ b/packages/legacy/http/src/index.ts
@@ -52,6 +52,7 @@ export function createMeshHTTPHandler<TServerContext>({
       getBuiltMesh,
       playgroundTitle,
       playgroundEnabled,
+      playgroundOffline,
       graphqlEndpoint: graphqlPath,
       corsConfig,
       batchingLimit,

--- a/packages/legacy/http/test/http.spec.ts
+++ b/packages/legacy/http/test/http.spec.ts
@@ -233,6 +233,24 @@ describe('http', () => {
       expect(renderGraphiQL).toHaveBeenCalled();
     });
 
+    it('throws instead of using CDN GraphiQL when playground.offline is set without renderGraphiQL', async () => {
+      await using mesh = await getTestMesh();
+      const httpHandler = createMeshHTTPHandler({
+        baseDir: __dirname,
+        getBuiltMesh: async () => mesh,
+        rawServeConfig: {
+          playground: {
+            offline: true,
+          },
+        },
+      });
+      await expect(
+        httpHandler.fetch('http://localhost:4000/graphql', {
+          headers: { Accept: 'text/html' },
+        }),
+      ).rejects.toThrow('@graphql-yoga/render-graphiql');
+    });
+
     it('does not call renderGraphiQL when playground.offline is not set', async () => {
       await using mesh = await getTestMesh();
       const renderGraphiQL = jest.fn().mockReturnValue('<html>custom</html>');

--- a/packages/legacy/types/src/config-schema.json
+++ b/packages/legacy/types/src/config-schema.json
@@ -340,7 +340,7 @@
       "properties": {
         "offline": {
           "type": "boolean",
-          "description": "Use an offline GraphiQL that bundles JS, CSS and fonts inline instead of loading them from a CDN.\nUseful for air-gapped or on-premise environments with no internet access.\n\nRequires `@graphql-yoga/render-graphiql`. Mesh CLI installs it; generated `createBuiltMeshHTTPHandler` artifacts import it."
+          "description": "Use an offline GraphiQL that bundles JS, CSS and fonts inline instead of loading them from a CDN.\nUseful for air-gapped or on-premise environments with no internet access.\n\nRequires `@graphql-yoga/render-graphiql` in the same project (install it yourself; `mesh serve` and generated `createBuiltMeshHTTPHandler` artifacts import it directly)."
         }
       }
     },

--- a/packages/legacy/types/src/config.ts
+++ b/packages/legacy/types/src/config.ts
@@ -150,7 +150,7 @@ export interface PlaygroundConfig {
    * Use an offline GraphiQL that bundles JS, CSS and fonts inline instead of loading them from a CDN.
    * Useful for air-gapped or on-premise environments with no internet access.
    *
-   * Requires `@graphql-yoga/render-graphiql`. Mesh CLI installs it; generated `createBuiltMeshHTTPHandler` artifacts import it.
+   * Requires `@graphql-yoga/render-graphiql` in the same project (install it yourself; `mesh serve` and generated `createBuiltMeshHTTPHandler` artifacts import it directly).
    */
   offline?: boolean;
 }


### PR DESCRIPTION
## Summary
- Throw if `serve.playground.offline` is enabled without `renderGraphiQL` instead of silently using CDN GraphiQL.
- Give a clear error when `@graphql-yoga/render-graphiql` cannot be imported from `mesh serve`.
- Document that the package must be installed in the app (pnpm/strict layouts).

Addresses review comments on #9627.

## Test plan
- [x] HTTP handler test: offline without `renderGraphiQL` throws
- [x] existing offline GraphiQL tests still pass


