### PR TITLE
fix(openapi,json-schema): form-urlencoded oneOf bodies and shared $ref types

### DIFF
--- a/.changeset/fix-form-urlencoded-oneof.md
+++ b/.changeset/fix-form-urlencoded-oneof.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/openapi": patch
+---
+
+Prefer `application/x-www-form-urlencoded` for request bodies when it is listed before JSON (OAuth token endpoints with `oneOf` + discriminator).

--- a/.changeset/fix-shared-json-schema-ref-types.md
+++ b/.changeset/fix-shared-json-schema-ref-types.md
@@ -1,0 +1,6 @@
+---
+"json-machete": patch
+"@omnigraph/json-schema": patch
+---
+
+Reuse a JSON Schema `$ref` target reached via different relative paths instead of minting `Type2` / `Type3` duplicates.

--- a/packages/json-machete/src/dereferenceObject.ts
+++ b/packages/json-machete/src/dereferenceObject.ts
@@ -38,6 +38,38 @@ function normalizeUrl(url: string) {
   return new URL(url).toString();
 }
 
+/**
+ * Collapse `.` / `..` segments so the same file reached via different relative
+ * `$ref`s (`utils.json` vs `../../utils.json`) shares one cache key.
+ */
+export function normalizeFsPath(path: string): string {
+  if (isUrl(path)) {
+    return path;
+  }
+  const windowsAbs = /^[a-zA-Z]:/.test(path);
+  const isAbs = path.startsWith('/') || windowsAbs;
+  const parts = path.replace(/\\/g, '/').split('/');
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === '.' || part === '') {
+      continue;
+    }
+    if (part === '..') {
+      if (stack.length && stack[stack.length - 1] !== '..' && !(windowsAbs && stack.length === 1)) {
+        stack.pop();
+      } else if (!isAbs) {
+        stack.push('..');
+      }
+      continue;
+    }
+    stack.push(part);
+  }
+  if (windowsAbs) {
+    return stack.join('/');
+  }
+  return (isAbs ? '/' : '') + stack.join('/');
+}
+
 export function getAbsolutePath(path: string, cwd: string) {
   if (isUrl(path)) {
     return path;
@@ -46,9 +78,9 @@ export function getAbsolutePath(path: string, cwd: string) {
     return normalizeUrl(urlJoin(cwd, path));
   }
   if (path.startsWith('/') || path.substring(1).startsWith(':\\')) {
-    return path;
+    return normalizeFsPath(path);
   }
-  return cwd + '/' + path;
+  return normalizeFsPath(cwd + '/' + path);
 }
 
 export function getCwd(path: string) {

--- a/packages/json-machete/tests/dereferenceObject.test.ts
+++ b/packages/json-machete/tests/dereferenceObject.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-nodejs-modules
 import { readFileSync } from 'fs';
 import type { JSONSchemaObject } from '@json-schema-tools/meta-schema';
-import { dereferenceObject } from '../src/dereferenceObject.js';
+import { dereferenceObject, getAbsolutePath, normalizeFsPath } from '../src/dereferenceObject.js';
 
 describe('dereferenceObject', () => {
   it('should resolve all $ref', async () => {
@@ -79,6 +79,58 @@ describe('dereferenceObject', () => {
     expect(result.title).toBe('PostsResponse');
     expect(result.properties.items.items.title).toBe('Post');
     expect(result.properties.items.items.properties.author.title).toBe('Author');
+  });
+  it('normalizes relative paths so the same file is loaded once', async () => {
+    expect(normalizeFsPath('/api/rest/types/extension/../../utils.json')).toBe(
+      '/api/rest/utils.json',
+    );
+    expect(getAbsolutePath('../../utils.json', '/api/rest/types/extension')).toBe(
+      '/api/rest/utils.json',
+    );
+    expect(getAbsolutePath('utils.json', '/api/rest')).toBe('/api/rest/utils.json');
+  });
+  it('reuses the same object for one definition reached via different relative $refs', async () => {
+    const files: Record<string, any> = {
+      '/api/rest/utils.json': {
+        definitions: {
+          SingleMediaSelection: {
+            $ref: 'types/singleMediaSelection.json',
+          },
+        },
+      },
+      '/api/rest/types/singleMediaSelection.json': {
+        title: 'SingleMediaSelection',
+        type: 'object',
+        properties: {
+          id: { type: 'integer' },
+        },
+      },
+    };
+    const result = await dereferenceObject<JSONSchemaObject>(
+      {
+        title: 'Root',
+        type: 'object',
+        properties: {
+          image: { $ref: 'utils.json#/definitions/SingleMediaSelection' },
+          icon: {
+            type: 'array',
+            items: { $ref: 'types/extension/../../utils.json#/definitions/SingleMediaSelection' },
+          },
+        },
+      },
+      {
+        cwd: '/api/rest',
+        readFileOrUrl: path => {
+          const file = files[path];
+          if (!file) {
+            throw new Error('unexpected path ' + path);
+          }
+          return structuredClone(file);
+        },
+      },
+    );
+    expect(result.properties.image).toBe(result.properties.icon.items);
+    expect(result.properties.image.title).toBe('SingleMediaSelection');
   });
   it('should dereference OpenAPI schemas', async () => {
     const openapiSchema = {

--- a/packages/loaders/json-schema/test/fixtures/reprod-9019/ambassador.json
+++ b/packages/loaders/json-schema/test/fixtures/reprod-9019/ambassador.json
@@ -1,0 +1,22 @@
+{
+  "definitions": {
+    "AmbassadorList": {
+      "title": "AmbassadorList",
+      "type": "object",
+      "properties": {
+        "content": {
+          "title": "AmbassadorListContent",
+          "type": "object",
+          "properties": {
+            "image": {
+              "$ref": "utils.json#/definitions/SingleMediaSelection"
+            }
+          }
+        },
+        "extension": {
+          "$ref": "types/extension.json"
+        }
+      }
+    }
+  }
+}

--- a/packages/loaders/json-schema/test/fixtures/reprod-9019/types/extension.json
+++ b/packages/loaders/json-schema/test/fixtures/reprod-9019/types/extension.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "title": "Extension",
+  "properties": {
+    "excerpt": {
+      "$ref": "extension/excerpt.json"
+    }
+  }
+}

--- a/packages/loaders/json-schema/test/fixtures/reprod-9019/types/extension/excerpt.json
+++ b/packages/loaders/json-schema/test/fixtures/reprod-9019/types/extension/excerpt.json
@@ -1,0 +1,12 @@
+{
+  "title": "Excerpt",
+  "type": "object",
+  "properties": {
+    "icon": {
+      "type": "array",
+      "items": {
+        "$ref": "../../utils.json#/definitions/SingleMediaSelection"
+      }
+    }
+  }
+}

--- a/packages/loaders/json-schema/test/fixtures/reprod-9019/types/singleMediaSelection.json
+++ b/packages/loaders/json-schema/test/fixtures/reprod-9019/types/singleMediaSelection.json
@@ -1,0 +1,23 @@
+{
+  "title": "SingleMediaSelection",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["integer", "null"]
+    },
+    "url": {
+      "type": ["string", "null"]
+    },
+    "type": {
+      "type": ["object", "null"],
+      "properties": {
+        "name": {
+          "type": ["string", "null"]
+        },
+        "id": {
+          "type": ["integer", "null"]
+        }
+      }
+    }
+  }
+}

--- a/packages/loaders/json-schema/test/fixtures/reprod-9019/utils.json
+++ b/packages/loaders/json-schema/test/fixtures/reprod-9019/utils.json
@@ -1,0 +1,7 @@
+{
+  "definitions": {
+    "SingleMediaSelection": {
+      "$ref": "types/singleMediaSelection.json"
+    }
+  }
+}

--- a/packages/loaders/json-schema/test/reprod-9019.test.ts
+++ b/packages/loaders/json-schema/test/reprod-9019.test.ts
@@ -1,0 +1,29 @@
+import { OperationTypeNode } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { loadGraphQLSchemaFromJSONSchemas } from '../src/loadGraphQLSchemaFromJSONSchemas.js';
+
+describe('Reproduction #9019', () => {
+  it('reuses a shared $ref type reached via different relative paths', async () => {
+    const schema = await loadGraphQLSchemaFromJSONSchemas('SuluRest', {
+      endpoint: 'http://localhost',
+      cwd: __dirname,
+      operations: [
+        {
+          type: OperationTypeNode.QUERY,
+          field: 'ambassadorList',
+          method: 'GET',
+          path: '/ambassadors.json',
+          responseSchema: './fixtures/reprod-9019/ambassador.json#/definitions/AmbassadorList',
+        },
+      ],
+    });
+
+    const typeMap = schema.getTypeMap();
+    expect(typeMap.SingleMediaSelection).toBeDefined();
+    expect(typeMap.SingleMediaSelection2).toBeUndefined();
+    expect(typeMap.SingleMediaSelection3).toBeUndefined();
+
+    const sdl = printSchemaWithDirectives(schema);
+    expect(sdl).not.toMatch(/SingleMediaSelection\d/);
+  });
+});

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -39,28 +39,26 @@ function mimeType(contentType: string): string {
  * is listed first (OAuth token endpoints, RFC 6749).
  */
 function pickRequestContentKey(
-  contentKeys: string[],
+  contentKeys: readonly (string | number)[],
   preferredContentType?: string,
 ): string | undefined {
-  if (contentKeys.length === 0) {
+  const keys = contentKeys.map(String);
+  if (keys.length === 0) {
     return undefined;
   }
   if (preferredContentType) {
     const preferred = mimeType(preferredContentType);
-    const match = contentKeys.find(key => mimeType(key) === preferred);
+    const match = keys.find(key => mimeType(key) === preferred);
     if (match) {
       return match;
     }
   }
-  const formKey = contentKeys.find(key => mimeType(key) === 'application/x-www-form-urlencoded');
-  const jsonKey = contentKeys.find(key => mimeType(key).includes('json'));
-  if (
-    formKey != null &&
-    (jsonKey == null || contentKeys.indexOf(formKey) < contentKeys.indexOf(jsonKey))
-  ) {
+  const formKey = keys.find(key => mimeType(key) === 'application/x-www-form-urlencoded');
+  const jsonKey = keys.find(key => mimeType(key).includes('json'));
+  if (formKey != null && (jsonKey == null || keys.indexOf(formKey) < keys.indexOf(jsonKey))) {
     return formKey;
   }
-  return jsonKey ?? contentKeys[0];
+  return jsonKey ?? keys[0];
 }
 
 export interface HATEOASConfig {

--- a/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
+++ b/packages/loaders/openapi/src/getJSONSchemaOptionsFromOpenAPIOptions.ts
@@ -28,6 +28,41 @@ import type {
 import type { SelectQueryOrMutationFieldConfig } from './types.js';
 import { getFieldNameFromPath } from './utils.js';
 
+function mimeType(contentType: string): string {
+  return contentType.split(';')[0].trim().toLowerCase();
+}
+
+/**
+ * Pick a request body content type.
+ * Prefer an explicit Content-Type header when it matches the spec.
+ * Otherwise keep `application/json` unless `application/x-www-form-urlencoded`
+ * is listed first (OAuth token endpoints, RFC 6749).
+ */
+function pickRequestContentKey(
+  contentKeys: string[],
+  preferredContentType?: string,
+): string | undefined {
+  if (contentKeys.length === 0) {
+    return undefined;
+  }
+  if (preferredContentType) {
+    const preferred = mimeType(preferredContentType);
+    const match = contentKeys.find(key => mimeType(key) === preferred);
+    if (match) {
+      return match;
+    }
+  }
+  const formKey = contentKeys.find(key => mimeType(key) === 'application/x-www-form-urlencoded');
+  const jsonKey = contentKeys.find(key => mimeType(key).includes('json'));
+  if (
+    formKey != null &&
+    (jsonKey == null || contentKeys.indexOf(formKey) < contentKeys.indexOf(jsonKey))
+  ) {
+    return formKey;
+  }
+  return jsonKey ?? contentKeys[0];
+}
+
 export interface HATEOASConfig {
   /**
    * @default "rel"
@@ -778,28 +813,30 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
       if ('requestBody' in methodObj) {
         const requestBodyObj = methodObj.requestBody;
         if ('content' in requestBodyObj) {
-          // use json if available, otherwise fall back to the first type
+          const preferredContentType =
+            typeof operationHeaders === 'object'
+              ? operationHeaders['Content-Type'] || operationHeaders['content-type']
+              : undefined;
           const contentKeys = Object.keys(requestBodyObj.content);
-          const contentKey =
-            contentKeys.find(
-              contentKey => typeof contentKey === 'string' && contentKey.includes('json'),
-            ) || contentKeys[0];
-          const contentSchema = requestBodyObj.content[contentKey]?.schema;
-          if (contentSchema && Object.keys(contentSchema).length > 0) {
-            operationConfig.requestSchema = contentSchema as JSONSchemaObject;
-          }
-          const examplesObj = requestBodyObj.content[contentKey]?.examples;
-          if (examplesObj) {
-            const firstItem = Object.values(examplesObj)[0];
-            if (typeof firstItem === 'object' && 'value' in firstItem) {
-              operationConfig.requestSample = firstItem.value;
-            } else {
-              operationConfig.requestSample = firstItem;
+          const contentKey = pickRequestContentKey(contentKeys, preferredContentType);
+          if (contentKey) {
+            const contentSchema = requestBodyObj.content[contentKey]?.schema;
+            if (contentSchema && Object.keys(contentSchema).length > 0) {
+              operationConfig.requestSchema = contentSchema as JSONSchemaObject;
             }
-          }
-          if (!operationConfig.headers?.['Content-Type'] && typeof contentKey === 'string') {
-            operationConfig.headers = operationConfig.headers || {};
-            operationConfig.headers['Content-Type'] = contentKey;
+            const examplesObj = requestBodyObj.content[contentKey]?.examples;
+            if (examplesObj) {
+              const firstItem = Object.values(examplesObj)[0];
+              if (typeof firstItem === 'object' && 'value' in firstItem) {
+                operationConfig.requestSample = firstItem.value;
+              } else {
+                operationConfig.requestSample = firstItem;
+              }
+            }
+            if (!operationConfig.headers?.['Content-Type']) {
+              operationConfig.headers = operationConfig.headers || {};
+              operationConfig.headers['Content-Type'] = contentKey;
+            }
           }
         }
       }
@@ -817,9 +854,19 @@ export async function getJSONSchemaOptionsFromOpenAPIOptions(
 
         let schemaObj: JSONSchemaObject;
 
-        if ('consumes' in methodObj) {
+        if (
+          'consumes' in methodObj &&
+          Array.isArray(methodObj.consumes) &&
+          methodObj.consumes.length
+        ) {
           operationConfig.headers = operationConfig.headers || {};
-          operationConfig.headers['Content-Type'] = methodObj.consumes.join(', ');
+          const preferredContentType =
+            typeof operationHeaders === 'object'
+              ? operationHeaders['Content-Type'] || operationHeaders['content-type']
+              : undefined;
+          operationConfig.headers['Content-Type'] =
+            pickRequestContentKey(methodObj.consumes, preferredContentType) ||
+            methodObj.consumes[0];
         }
 
         if ('produces' in methodObj) {

--- a/packages/loaders/openapi/tests/__snapshots__/docusign.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/docusign.test.ts.snap
@@ -19,7 +19,7 @@ type Query {
   
   You do not need an integrator key to view the REST API versions and resources.
   """
-  ServiceInformation_GetServiceInformation: Services @httpOperation(subgraph: "test", path: "/service_information", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ServiceInformation_GetServiceInformation: Services @httpOperation(subgraph: "test", path: "/service_information", httpMethod: GET)
   """
   Retrieves the base resources available for the DocuSign REST APIs.
   
@@ -31,9 +31,9 @@ type Query {
   
   Example: https://demo.docusign.net/restapi/help lists the REST API operations on the DocuSign Demo system with XML and JSON request and response samples.
   """
-  ServiceInformation_GetResourceInformation: Resources @httpOperation(subgraph: "test", path: "/v2", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ServiceInformation_GetResourceInformation: Resources @httpOperation(subgraph: "test", path: "/v2", httpMethod: GET)
   """Retrieves the account provisioning information for the account."""
-  Accounts_GetProvisioning: provisioningInformation @httpOperation(subgraph: "test", path: "/v2/accounts/provisioning", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  Accounts_GetProvisioning: provisioningInformation @httpOperation(subgraph: "test", path: "/v2/accounts/provisioning", httpMethod: GET)
   """
   Retrieves the account information for the specified account.
   
@@ -47,7 +47,7 @@ type Query {
     When set to **true**, includes the account settings for the account in the response.
     """
     include_account_settings: String
-  ): Accounts @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_account_settings\\":\\"include_account_settings\\"}")
+  ): Accounts @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}", httpMethod: GET, queryParamArgMap: "{\\"include_account_settings\\":\\"include_account_settings\\"}")
   """
   Retrieves the list of recurring and usage charges for the account. This can be used to determine the charge structure and usage of charge plan items. 
   
@@ -64,7 +64,7 @@ type Query {
     * seats
     """
     include_charges: String
-  ): billingChargeResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_charges", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_charges\\":\\"include_charges\\"}")
+  ): billingChargeResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_charges", httpMethod: GET, queryParamArgMap: "{\\"include_charges\\":\\"include_charges\\"}")
   """
   Retrieves a list of invoices for the account. If the from date or to date queries are not specified, the response returns invoices for the last 365 days.
   
@@ -81,7 +81,7 @@ type Query {
     Specifies the date/time of the latest invoice in the account to retrieve.
     """
     to_date: String
-  ): billingInvoicesResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_invoices", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
+  ): billingInvoicesResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_invoices", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
   """
   Retrieves the specified invoice. 
   
@@ -121,7 +121,7 @@ type Query {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     invoiceId: String!
-  ): Invoices @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_invoices/{args.invoiceId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): Invoices @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_invoices/{args.invoiceId}", httpMethod: GET)
   """
   Returns a list past due invoices for the account and notes if payment can be made through the REST API. 
   
@@ -130,7 +130,7 @@ type Query {
   BillingInvoices_GetBillingInvoicesPastDue(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): billingInvoicesSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_invoices_past_due", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): billingInvoicesSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_invoices_past_due", httpMethod: GET)
   """
   Retrieves a list containing information about one or more payments. If the from date or to date queries are not used, the response returns payment information for the last 365 days. 
   
@@ -147,7 +147,7 @@ type Query {
     Specifies the date/time of the latest payment in the account to retrieve.
     """
     to_date: String
-  ): billingPaymentsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_payments", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
+  ): billingPaymentsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_payments", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
   """
   Retrieves the information for a specified payment. 
   
@@ -157,7 +157,7 @@ type Query {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     paymentId: String!
-  ): Payments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_payments/{args.paymentId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): Payments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_payments/{args.paymentId}", httpMethod: GET)
   """
   Retrieves the billing plan information for the specified account, including the current billing plan, successor plans, billing address, and billing credit card.
   
@@ -182,12 +182,12 @@ type Query {
     When set to **true**, excludes successor information from the response.
     """
     include_successor_plans: String
-  ): BillingPlans @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_credit_card_information\\":\\"include_credit_card_information\\",\\"include_metadata\\":\\"include_metadata\\",\\"include_successor_plans\\":\\"include_successor_plans\\"}")
+  ): BillingPlans @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan", httpMethod: GET, queryParamArgMap: "{\\"include_credit_card_information\\":\\"include_credit_card_information\\",\\"include_metadata\\":\\"include_metadata\\",\\"include_successor_plans\\":\\"include_successor_plans\\"}")
   """Get metadata for a given credit card."""
   BillingPlan_GetCreditCardInfo(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): creditCardInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan/credit_card", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): creditCardInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan/credit_card", httpMethod: GET)
   """
   Retrieves the list of brand profiles associated with the account and the default brand profiles. The Account Branding feature (accountSettings properties \`canSelfBrandSend\` and \`canSelfBrandSend\`)  must be set to **true** for the account to use this call.
   """
@@ -200,7 +200,7 @@ type Query {
     exclude_distributor_brand: String
     """When set to **true**, returns the logos associated with the brand."""
     include_logos: String
-  ): AccountBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"exclude_distributor_brand\\":\\"exclude_distributor_brand\\",\\"include_logos\\":\\"include_logos\\"}")
+  ): AccountBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands", httpMethod: GET, queryParamArgMap: "{\\"exclude_distributor_brand\\":\\"exclude_distributor_brand\\",\\"include_logos\\":\\"include_logos\\"}")
   """Get information for a specific brand."""
   Brand_GetBrand(
     """The external account number (int) or account ID Guid."""
@@ -209,14 +209,14 @@ type Query {
     brandId: String!
     include_external_references: String
     include_logos: String
-  ): brand @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_external_references\\":\\"include_external_references\\",\\"include_logos\\":\\"include_logos\\"}")
+  ): brand @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}", httpMethod: GET, queryParamArgMap: "{\\"include_external_references\\":\\"include_external_references\\",\\"include_logos\\":\\"include_logos\\"}")
   """Export a specific brand."""
   BrandExport_GetBrandExportFile(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The unique identifier of a brand."""
     brandId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/file", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/file", httpMethod: GET)
   """Obtains the specified image for a brand."""
   BrandLogo_GetBrandLogo(
     """The external account number (int) or account ID Guid."""
@@ -225,14 +225,14 @@ type Query {
     brandId: String!
     """One of **Primary**, **Secondary** or **Email**."""
     logoType: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/logos/{args.logoType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/logos/{args.logoType}", httpMethod: GET)
   """Returns the specified account's list of branding resources (metadata)."""
   BrandResources_GetBrandResourcesList(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The unique identifier of a brand."""
     brandId: String!
-  ): brandResourcesList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/resources", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): brandResourcesList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/resources", httpMethod: GET)
   """Returns the specified branding resource file."""
   BrandResources_GetBrandResources(
     """The external account number (int) or account ID Guid."""
@@ -242,7 +242,7 @@ type Query {
     resourceContentType: String!
     langcode: String
     return_master: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/resources/{args.resourceContentType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"langcode\\":\\"langcode\\",\\"return_master\\":\\"return_master\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/resources/{args.resourceContentType}", httpMethod: GET, queryParamArgMap: "{\\"langcode\\":\\"langcode\\",\\"return_master\\":\\"return_master\\"}")
   """
   Retrieves status information about all the bulk recipient batches. A bulk recipient batch is the set of envelopes sent from a single bulk recipient file. The response includes general information about each bulk recipient batch. 
   
@@ -268,7 +268,7 @@ type Query {
     The position of the bulk envelope items in the response. This is used for repeated calls, when the number of bulk envelopes returned is too large for one return. The default value is 0.
     """
     start_position: String
-  ): BulkEnvelopes @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/bulk_envelopes", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"include\\":\\"include\\",\\"start_position\\":\\"start_position\\"}")
+  ): BulkEnvelopes @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/bulk_envelopes", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"include\\":\\"include\\",\\"start_position\\":\\"start_position\\"}")
   """
   Retrieves the status information of a single bulk recipient batch. A bulk recipient batch is the set of envelopes sent from a single bulk recipient file. 
   """
@@ -291,7 +291,7 @@ type Query {
     include: String
     """Specifies the location in the list of envelopes from which to start."""
     start_position: String
-  ): bulkEnvelopeStatus @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/bulk_envelopes/{args.batchId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"include\\":\\"include\\",\\"start_position\\":\\"start_position\\"}")
+  ): bulkEnvelopeStatus @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/bulk_envelopes/{args.batchId}", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"include\\":\\"include\\",\\"start_position\\":\\"start_position\\"}")
   """Retrieves the current metadata of a ChunkedUpload."""
   ChunkedUploads_GetChunkedUpload(
     """The external account number (int) or account ID Guid."""
@@ -301,14 +301,14 @@ type Query {
     A comma-separated list of additional template attributes to include in the response. Valid values are: recipients, folders, documents, custom_fields, and notifications.
     """
     include: String
-  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """
   Retrieves all the DocuSign Custom Connect definitions for the specified account.
   """
   Connect_GetConnectConfigs(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): connectConfigResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): connectConfigResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect", httpMethod: GET)
   """
   Retrieves the Connect Failure Log information. It can be used to determine which envelopes failed to post, so a republish request can be created.
   """
@@ -323,7 +323,7 @@ type Query {
     End of the search date range. Only returns templates created up to this date/time. If no value is provided, this defaults to the current date.
     """
     to_date: String
-  ): ConnectEvents @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/failures", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
+  ): ConnectEvents @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/failures", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
   """Retrieves a list of connect log entries for your account."""
   ConnectLog_GetConnectLogs(
     """The external account number (int) or account ID Guid."""
@@ -336,7 +336,7 @@ type Query {
     End of the search date range. Only returns templates created up to this date/time. If no value is provided, this defaults to the current date.
     """
     to_date: String
-  ): ConnectEvents @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
+  ): ConnectEvents @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
   """Retrieves the specified Connect log entry for your account."""
   ConnectLog_GetConnectLog(
     """The external account number (int) or account ID Guid."""
@@ -347,7 +347,7 @@ type Query {
     When true, the connectDebugLog information is included in the response.
     """
     additional_info: String
-  ): connectLog @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs/{args.logId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"additional_info\\":\\"additional_info\\"}")
+  ): connectLog @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs/{args.logId}", httpMethod: GET, queryParamArgMap: "{\\"additional_info\\":\\"additional_info\\"}")
   """
   Retrieves the information for the specified DocuSign Connect configuration.
   
@@ -357,7 +357,7 @@ type Query {
     accountId: String!
     """The ID of the custom Connect configuration being accessed."""
     connectId: String!
-  ): connectConfigResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/{args.connectId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): connectConfigResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/{args.connectId}", httpMethod: GET)
   """Returns users from the configured Connect service."""
   Connect_GetConnectUsers(
     """The external account number (int) or account ID Guid."""
@@ -391,7 +391,7 @@ type Query {
     Filters the user records returned by the user name or a sub-string of user name.
     """
     user_name_substring: String
-  ): integratedUserInfoList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/{args.connectId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"email_substring\\":\\"email_substring\\",\\"list_included_users\\":\\"list_included_users\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"user_name_substring\\":\\"user_name_substring\\"}")
+  ): integratedUserInfoList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/{args.connectId}/users", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"email_substring\\":\\"email_substring\\",\\"list_included_users\\":\\"list_included_users\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"user_name_substring\\":\\"user_name_substring\\"}")
   """
   Retrieves the Electronic Record and Signature Disclosure, with HTML formatting, associated with the account. You can use an optional query string to set the language for the disclosure.
   """
@@ -404,7 +404,7 @@ type Query {
     Additionally, the value can be set to \`browser\` to automatically detect the browser language being used by the viewer and display the disclosure in that language.
     """
     langCode: String
-  ): AccountConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/consumer_disclosure", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"langCode\\":\\"langCode\\"}")
+  ): AccountConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/consumer_disclosure", httpMethod: GET, queryParamArgMap: "{\\"langCode\\":\\"langCode\\"}")
   """
   Retrieves the Electronic Record and Signature Disclosure, with HTML formatting, for the requested envelope recipient. This might be different than the current account disclosure depending on account settings, such as branding, and when the account disclosure was last updated. An optional query string can be included to return the language for the disclosure.  
   """
@@ -415,7 +415,7 @@ type Query {
     The simple type enumeration the language used in the response. The supported languages, with the language value shown in parenthesis, are:Arabic (ar), Bulgarian (bg), Czech (cs), Chinese Simplified (zh_CN), Chinese Traditional (zh_TW), Croatian (hr), Danish (da), Dutch (nl), English US (en), English UK (en_GB), Estonian (et), Farsi (fa), Finnish (fi), French (fr), French Canada (fr_CA), German (de), Greek (el), Hebrew (he), Hindi (hi), Hungarian (hu), Bahasa Indonesia (id), Italian (it), Japanese (ja), Korean (ko), Latvian (lv), Lithuanian (lt), Bahasa Melayu (ms), Norwegian (no), Polish (pl), Portuguese (pt), Portuguese Brazil (pt_BR), Romanian (ro), Russian (ru), Serbian (sr), Slovak (sk), Slovenian (sl), Spanish (es),Spanish Latin America (es_MX), Swedish (sv), Thai (th), Turkish (tr), Ukrainian (uk) and Vietnamese (vi). Additionally, the value can be set to "browser" to automatically detect the browser language being used by the viewer and display the disclosure in that language.
     """
     langCode: String!
-  ): AccountConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/consumer_disclosure/{args.langCode}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): AccountConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/consumer_disclosure/{args.langCode}", httpMethod: GET)
   """Gets a particular contact associated with the user's account."""
   Contacts_GetContactById(
     """The external account number (int) or account ID Guid."""
@@ -423,7 +423,7 @@ type Query {
     """The unique identifier of a person in the contacts address book."""
     contactId: String!
     cloud_provider: String
-  ): contactGetResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts/{args.contactId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"cloud_provider\\":\\"cloud_provider\\"}")
+  ): contactGetResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts/{args.contactId}", httpMethod: GET, queryParamArgMap: "{\\"cloud_provider\\":\\"cloud_provider\\"}")
   """
   Retrieves a list of envelope custom fields associated with the account. You can use these fields in the envelopes for your account to record information about the envelope, help search for envelopes and track information. The envelope custom fields are shown in the Envelope Settings section when a user is creating an envelope in the DocuSign member console. The envelope custom fields are not seen by the envelope recipients.
   
@@ -432,7 +432,7 @@ type Query {
   AccountCustomFields_GetAccountCustomFields(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): AccountCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): AccountCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields", httpMethod: GET)
   """
   Retrieves a list of envelopes that match your request. 
   A large set of optional filters let you filter
@@ -663,7 +663,7 @@ type Query {
     must refer to an existing account user.
     """
     user_name: String
-  ): envelopesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"ac_status\\":\\"ac_status\\",\\"block\\":\\"block\\",\\"count\\":\\"count\\",\\"custom_field\\":\\"custom_field\\",\\"email\\":\\"email\\",\\"envelope_ids\\":\\"envelope_ids\\",\\"exclude\\":\\"exclude\\",\\"folder_ids\\":\\"folder_ids\\",\\"folder_types\\":\\"folder_types\\",\\"from_date\\":\\"from_date\\",\\"from_to_status\\":\\"from_to_status\\",\\"include\\":\\"include\\",\\"include_purge_information\\":\\"include_purge_information\\",\\"intersecting_folder_ids\\":\\"intersecting_folder_ids\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"powerformids\\":\\"powerformids\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"to_date\\":\\"to_date\\",\\"transaction_ids\\":\\"transaction_ids\\",\\"user_filter\\":\\"user_filter\\",\\"user_id\\":\\"user_id\\",\\"user_name\\":\\"user_name\\"}")
+  ): envelopesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes", httpMethod: GET, queryParamArgMap: "{\\"ac_status\\":\\"ac_status\\",\\"block\\":\\"block\\",\\"count\\":\\"count\\",\\"custom_field\\":\\"custom_field\\",\\"email\\":\\"email\\",\\"envelope_ids\\":\\"envelope_ids\\",\\"exclude\\":\\"exclude\\",\\"folder_ids\\":\\"folder_ids\\",\\"folder_types\\":\\"folder_types\\",\\"from_date\\":\\"from_date\\",\\"from_to_status\\":\\"from_to_status\\",\\"include\\":\\"include\\",\\"include_purge_information\\":\\"include_purge_information\\",\\"intersecting_folder_ids\\":\\"intersecting_folder_ids\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"powerformids\\":\\"powerformids\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"to_date\\":\\"to_date\\",\\"transaction_ids\\":\\"transaction_ids\\",\\"user_filter\\":\\"user_filter\\",\\"user_id\\":\\"user_id\\",\\"user_name\\":\\"user_name\\"}")
   """Retrieves the overall status for the specified envelope."""
   Envelopes_GetEnvelope(
     """The external account number (int) or account ID Guid."""
@@ -674,14 +674,14 @@ type Query {
     advanced_update: String
     """Reserved for DocuSign."""
     include: String
-  ): Envelopes @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"advanced_update\\":\\"advanced_update\\",\\"include\\":\\"include\\"}")
+  ): Envelopes @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}", httpMethod: GET, queryParamArgMap: "{\\"advanced_update\\":\\"advanced_update\\",\\"include\\":\\"include\\"}")
   """Returns a list of attachments associated with the specified envelope"""
   Attachments_GetAttachments(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments", httpMethod: GET)
   """Retrieves an attachment from the envelope."""
   Attachments_GetAttachment(
     """The external account number (int) or account ID Guid."""
@@ -689,14 +689,14 @@ type Query {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     attachmentId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments/{args.attachmentId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments/{args.attachmentId}", httpMethod: GET)
   """Gets the envelope audit events for the specified envelope."""
   AuditEvents_GetAuditEvents(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): envelopeAuditEventResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/audit_events", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): envelopeAuditEventResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/audit_events", httpMethod: GET)
   """
   Retrieves the custom field information for the specified envelope. You can use these fields in the envelopes for your account to record information about the envelope, help search for envelopes, and track information. The envelope custom fields are shown in the Envelope Settings section when a user is creating an envelope in the DocuSign member console. The envelope custom fields are not seen by the envelope recipients.
   
@@ -707,7 +707,7 @@ type Query {
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): customFieldsEnvelope @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): customFieldsEnvelope @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", httpMethod: GET)
   """Retrieves a list of documents associated with the specified envelope."""
   Documents_GetDocuments(
     """The external account number (int) or account ID Guid."""
@@ -716,7 +716,7 @@ type Query {
     envelopeId: String!
     """Reserved for DocuSign."""
     include_metadata: String
-  ): EnvelopeDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_metadata\\":\\"include_metadata\\"}")
+  ): EnvelopeDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents", httpMethod: GET, queryParamArgMap: "{\\"include_metadata\\":\\"include_metadata\\"}")
   """
   Retrieves the specified document from the envelope. If the account has the Highlight Data Changes feature enabled, there is an option to request that any changes in the envelope be highlighted.
   
@@ -757,7 +757,7 @@ type Query {
     When set to **true**, the account has the watermark feature enabled, and the envelope is not complete, the watermark for the account is added to the PDF documents. This option can remove the watermark.
     """
     watermark: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "application/pdf"]], httpMethod: GET, queryParamArgMap: "{\\"certificate\\":\\"certificate\\",\\"encoding\\":\\"encoding\\",\\"encrypt\\":\\"encrypt\\",\\"language\\":\\"language\\",\\"recipient_id\\":\\"recipient_id\\",\\"show_changes\\":\\"show_changes\\",\\"watermark\\":\\"watermark\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}", operationSpecificHeaders: [["Accept", "application/pdf"]], httpMethod: GET, queryParamArgMap: "{\\"certificate\\":\\"certificate\\",\\"encoding\\":\\"encoding\\",\\"encrypt\\":\\"encrypt\\",\\"language\\":\\"language\\",\\"recipient_id\\":\\"recipient_id\\",\\"show_changes\\":\\"show_changes\\",\\"watermark\\":\\"watermark\\"}")
   """
   Retrieves the custom document field information from an existing envelope document.
   """
@@ -768,7 +768,7 @@ type Query {
     envelopeId: String!
     """The ID of the document being accessed."""
     documentId: String!
-  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", httpMethod: GET)
   """Returns document page image(s) based on input."""
   Pages_GetPageImages(
     """The external account number (int) or account ID Guid."""
@@ -793,7 +793,7 @@ type Query {
     The position within the total result set from which to start returning values. The value **thumbnail** may be used to return the page image.
     """
     start_position: String
-  ): pageImages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"nocache\\":\\"nocache\\",\\"show_changes\\":\\"show_changes\\",\\"start_position\\":\\"start_position\\"}")
+  ): pageImages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"nocache\\":\\"nocache\\",\\"show_changes\\":\\"show_changes\\",\\"start_position\\":\\"start_position\\"}")
   """Retrieves a page image for display from the specified envelope."""
   Pages_GetPageImage(
     """The external account number (int) or account ID Guid."""
@@ -815,7 +815,7 @@ type Query {
     """
     max_width: String
     show_changes: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "image/png"]], httpMethod: GET, queryParamArgMap: "{\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"show_changes\\":\\"show_changes\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", operationSpecificHeaders: [["Accept", "image/png"]], httpMethod: GET, queryParamArgMap: "{\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"show_changes\\":\\"show_changes\\"}")
   """Returns tabs on the specified page."""
   Tabs_GetPageTabs(
     """The external account number (int) or account ID Guid."""
@@ -826,7 +826,7 @@ type Query {
     documentId: String!
     """The page number being accessed."""
     pageNumber: String!
-  ): EnvelopeDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}/tabs", httpMethod: GET)
   """Returns tabs on the document."""
   Tabs_GetDocumentTabs(
     """The external account number (int) or account ID Guid."""
@@ -836,7 +836,7 @@ type Query {
     """The ID of the document being accessed."""
     documentId: String!
     page_numbers: String
-  ): EnvelopeDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"page_numbers\\":\\"page_numbers\\"}")
+  ): EnvelopeDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/tabs", httpMethod: GET, queryParamArgMap: "{\\"page_numbers\\":\\"page_numbers\\"}")
   """
   Retrieves the templates associated with a document in the specified envelope.
   """
@@ -856,21 +856,21 @@ type Query {
     * matched
     """
     include: String
-  ): EnvelopeTemplates @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/templates", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): EnvelopeTemplates @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/templates", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """Retrieves the email override settings for the specified envelope."""
   EmailSettings_GetEmailSettings(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", httpMethod: GET)
   """Returns envelope form data for an existing envelope."""
   FormData_GetFormData(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): EnvelopeFormData @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/form_data", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeFormData @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/form_data", httpMethod: GET)
   """
   Retrieves general information about the envelope lock.
   
@@ -881,7 +881,7 @@ type Query {
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", httpMethod: GET)
   """
   Retrieves the envelope notification, reminders and expirations, information for an existing envelope.
   """
@@ -890,7 +890,7 @@ type Query {
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/notification", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/notification", httpMethod: GET)
   """
   Retrieves the status of all recipients in a single envelope and identifies the current recipient in the routing list. 
   
@@ -915,7 +915,7 @@ type Query {
     When set to **true**, the tab information associated with the recipient is included in the response.
     """
     include_tabs: String
-  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_extended\\":\\"include_extended\\",\\"include_metadata\\":\\"include_metadata\\",\\"include_tabs\\":\\"include_tabs\\"}")
+  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_extended\\":\\"include_extended\\",\\"include_metadata\\":\\"include_metadata\\",\\"include_tabs\\":\\"include_tabs\\"}")
   """
   Retrieves the bulk recipient file information from an envelope that has a bulk recipient.
   """
@@ -933,7 +933,7 @@ type Query {
     include_tabs: String
     """Reserved for DocuSign."""
     start_position: String
-  ): EnvelopeBulkRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/bulk_recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_tabs\\":\\"include_tabs\\",\\"start_position\\":\\"start_position\\"}")
+  ): EnvelopeBulkRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/bulk_recipients", httpMethod: GET, queryParamArgMap: "{\\"include_tabs\\":\\"include_tabs\\",\\"start_position\\":\\"start_position\\"}")
   """
   Retrieves the Electronic Record and Signature Disclosure, with html formatting, associated with the account. You can use an optional query string to set the language for the disclosure.
   """
@@ -945,7 +945,7 @@ type Query {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     langCode: String
-  ): EnvelopeConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/consumer_disclosure", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"langCode\\":\\"langCode\\"}")
+  ): EnvelopeConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/consumer_disclosure", httpMethod: GET, queryParamArgMap: "{\\"langCode\\":\\"langCode\\"}")
   """
   Reserved: Retrieves the Electronic Record and Signature Disclosure, with HTML formatting, associated with the account.
   """
@@ -957,7 +957,7 @@ type Query {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     langCode: String!
-  ): EnvelopeConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/consumer_disclosure/{args.langCode}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"langCode\\":\\"langCode\\"}")
+  ): EnvelopeConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/consumer_disclosure/{args.langCode}", httpMethod: GET, queryParamArgMap: "{\\"langCode\\":\\"langCode\\"}")
   """Returns document visibility for the recipients"""
   Recipients_GetRecipientDocumentVisibility(
     """The external account number (int) or account ID Guid."""
@@ -966,7 +966,7 @@ type Query {
     envelopeId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/document_visibility", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/document_visibility", httpMethod: GET)
   """
   Retrieves the initials image for the specified user. The image is returned in the same format as it was uploaded. In the request you can specify if the chrome (the added line and identifier around the initial image) is returned with the image.
   
@@ -989,7 +989,7 @@ type Query {
     The added line and identifier around the initial image. Note: Older envelopes might only have chromed images. If getting the non-chromed image fails, try getting the chromed image.
     """
     include_chrome: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/initials_image", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"include_chrome\\":\\"include_chrome\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/initials_image", operationSpecificHeaders: [["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"include_chrome\\":\\"include_chrome\\"}")
   """
   Retrieves signature information for a signer or sign-in-person recipient.
   """
@@ -1000,7 +1000,7 @@ type Query {
     envelopeId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/signature", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/signature", httpMethod: GET)
   """
   Retrieves the specified user signature image. The image is returned in the same format as uploaded. In the request you can specify if the chrome (the added line and identifier around the initial image) is returned with the image.
   
@@ -1023,7 +1023,7 @@ type Query {
     When set to **true**, indicates the chromed version of the signature image should be retrieved.
     """
     include_chrome: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/signature_image", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"include_chrome\\":\\"include_chrome\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/signature_image", operationSpecificHeaders: [["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"include_chrome\\":\\"include_chrome\\"}")
   """
   Retrieves information about the tabs associated with a recipient in a draft envelope.
   """
@@ -1040,7 +1040,7 @@ type Query {
     include_anchor_tab_locations: String
     """Reserved for DocuSign."""
     include_metadata: String
-  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_metadata\\":\\"include_metadata\\"}")
+  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_metadata\\":\\"include_metadata\\"}")
   """
   This returns a list of the server-side templates, their name and ID, used in an envelope.
   
@@ -1054,7 +1054,7 @@ type Query {
     The possible values are:  matching_applied - This returns template matching information for the template.
     """
     include: String
-  ): EnvelopeTemplates @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/templates", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): EnvelopeTemplates @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/templates", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """
   Retrieves a list of the folders for the account, including the folder hierarchy. You can specify whether to return just the template folder or template folder and normal folders by setting the \`template\` query string parameter.
   """
@@ -1075,7 +1075,7 @@ type Query {
     template: String
     """Reserved for DocuSign."""
     user_filter: String
-  ): Folders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/folders", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\",\\"include_items\\":\\"include_items\\",\\"start_position\\":\\"start_position\\",\\"template\\":\\"template\\",\\"user_filter\\":\\"user_filter\\"}")
+  ): Folders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/folders", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\",\\"include_items\\":\\"include_items\\",\\"start_position\\":\\"start_position\\",\\"template\\":\\"template\\",\\"user_filter\\":\\"user_filter\\"}")
   """
   Retrieves a list of the envelopes in the specified folder. You can narrow the query by specifying search criteria in the query string parameters.
   """
@@ -1109,7 +1109,7 @@ type Query {
     Only return items up to this date. If no value is provided, the default search is to the current date.
     """
     to_date: String
-  ): folderItemsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/folders/{args.folderId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"include_items\\":\\"include_items\\",\\"owner_email\\":\\"owner_email\\",\\"owner_name\\":\\"owner_name\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"to_date\\":\\"to_date\\"}")
+  ): folderItemsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/folders/{args.folderId}", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"include_items\\":\\"include_items\\",\\"owner_email\\":\\"owner_email\\",\\"owner_name\\":\\"owner_name\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"to_date\\":\\"to_date\\"}")
   """Retrieves information about groups associated with the account."""
   Groups_GetGroups(
     """The external account number (int) or account ID Guid."""
@@ -1126,7 +1126,7 @@ type Query {
     search_text: String
     """Starting value for the list."""
     start_position: String
-  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"group_name\\":\\"group_name\\",\\"group_type\\":\\"group_type\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\"}")
+  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"group_name\\":\\"group_name\\",\\"group_type\\":\\"group_type\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\"}")
   """
   Retrieves information about the brands associated with the requested group.
   """
@@ -1135,7 +1135,7 @@ type Query {
     accountId: String!
     """The ID of the group being accessed."""
     groupId: String!
-  ): GroupBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/brands", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): GroupBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/brands", httpMethod: GET)
   """Retrieves a list of users in a group."""
   Groups_GetGroupUsers(
     """The external account number (int) or account ID Guid."""
@@ -1148,12 +1148,12 @@ type Query {
     count: String
     """Starting value for the list."""
     start_position: String
-  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"start_position\\":\\"start_position\\"}")
+  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/users", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"start_position\\":\\"start_position\\"}")
   """List payment gateway account information"""
   PaymentGatewayAccounts_GetAllPaymentGatewayAccounts(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): paymentGatewayAccountsInfo @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/payment_gateway_accounts", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): paymentGatewayAccountsInfo @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/payment_gateway_accounts", httpMethod: GET)
   """
   Retrieves a list of Permission Profiles. Permission Profiles are a standard set of user permissions that you can apply to individual users or users in a Group. This makes it easier to manage user permissions for a large number of users, without having to change permissions on a user-by-user basis.
   
@@ -1164,7 +1164,7 @@ type Query {
     accountId: String!
     """Reserved for DocuSign."""
     include: String
-  ): permissionProfileInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): permissionProfileInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """Returns a permissions profile in the specified account."""
   PermissionProfiles_GetPermissionProfile(
     """The external account number (int) or account ID Guid."""
@@ -1174,7 +1174,7 @@ type Query {
     A comma-separated list of additional template attributes to include in the response. Valid values are: recipients, folders, documents, custom_fields, and notifications.
     """
     include: String
-  ): AccountPermissionProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles/{args.permissionProfileId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): AccountPermissionProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles/{args.permissionProfileId}", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """Returns the list of PowerForms available to the user."""
   PowerForms_GetPowerFormsList(
     """The external account number (int) or account ID Guid."""
@@ -1205,7 +1205,7 @@ type Query {
     End of the search date range. Only returns templates created up to this date/time. If no value is provided, this defaults to the current date.
     """
     to_date: String
-  ): powerFormsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"to_date\\":\\"to_date\\"}")
+  ): powerFormsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"to_date\\":\\"to_date\\"}")
   """Returns the list of PowerForms available to the user."""
   PowerForms_GetPowerFormsSenders(
     """The external account number (int) or account ID Guid."""
@@ -1214,13 +1214,13 @@ type Query {
     The position within the total result set from which to start returning values. The value **thumbnail** may be used to return the page image.
     """
     start_position: String
-  ): powerFormSendersResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/senders", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"start_position\\":\\"start_position\\"}")
+  ): powerFormSendersResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/senders", httpMethod: GET, queryParamArgMap: "{\\"start_position\\":\\"start_position\\"}")
   """Returns a single PowerForm."""
   PowerForms_GetPowerForm(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     powerFormId: String!
-  ): PowerForms @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): PowerForms @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}", httpMethod: GET)
   """Returns the form data associated with the usage of a PowerForm."""
   PowerForms_GetPowerFormFormData(
     """The external account number (int) or account ID Guid."""
@@ -1234,7 +1234,7 @@ type Query {
     End of the search date range. Only returns templates created up to this date/time. If no value is provided, this defaults to the current date.
     """
     to_date: String
-  ): powerFormsFormDataResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}/form_data", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
+  ): powerFormsFormDataResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}/form_data", httpMethod: GET, queryParamArgMap: "{\\"from_date\\":\\"from_date\\",\\"to_date\\":\\"to_date\\"}")
   """
   Retrieves a list of recipients in the specified account that are associated with a email address supplied in the query string.
   """
@@ -1243,7 +1243,7 @@ type Query {
     accountId: String!
     """The email address for the user"""
     email: String
-  ): recipientNamesResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/recipient_names", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"email\\":\\"email\\"}")
+  ): recipientNamesResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/recipient_names", httpMethod: GET, queryParamArgMap: "{\\"email\\":\\"email\\"}")
   """
   Retrieves a list of envelopes that match the criteria specified in the query.
   
@@ -1284,29 +1284,29 @@ type Query {
     start_position: String
     """Specifies the end of the date range to return."""
     to_date: String
-  ): folderItemResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/search_folders/{args.searchFolderId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"all\\":\\"all\\",\\"count\\":\\"count\\",\\"from_date\\":\\"from_date\\",\\"include_recipients\\":\\"include_recipients\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"start_position\\":\\"start_position\\",\\"to_date\\":\\"to_date\\"}")
+  ): folderItemResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/search_folders/{args.searchFolderId}", httpMethod: GET, queryParamArgMap: "{\\"all\\":\\"all\\",\\"count\\":\\"count\\",\\"from_date\\":\\"from_date\\",\\"include_recipients\\":\\"include_recipients\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"start_position\\":\\"start_position\\",\\"to_date\\":\\"to_date\\"}")
   """Retrieves the account settings information for the specified account."""
   Settings_GetSettings(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): accountSettingsInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): accountSettingsInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings", httpMethod: GET)
   """
   Returns the configuration information for the eNote eOriginal integration.
   """
   ENoteConfiguration_GetENoteConfiguration(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): ENoteConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/enote_configuration", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): ENoteConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/enote_configuration", httpMethod: GET)
   """Get the password rules"""
   AccountPasswordRules_GetAccountPasswordRules(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): AccountPasswordRules @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/password_rules", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): AccountPasswordRules @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/password_rules", httpMethod: GET)
   """Returns tab settings list for specified account"""
   TabSettings_GetTabSettings(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): AccountTabSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): AccountTabSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/tabs", httpMethod: GET)
   """
   Reserved: Retrieves shared item status for one or more users and types of items.
   
@@ -1334,12 +1334,12 @@ type Query {
     start_position: String
     """Reserved:"""
     user_ids: String
-  ): accountSharedAccess @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/shared_access", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"envelopes_not_shared_user_status\\":\\"envelopes_not_shared_user_status\\",\\"folder_ids\\":\\"folder_ids\\",\\"item_type\\":\\"item_type\\",\\"search_text\\":\\"search_text\\",\\"shared\\":\\"shared\\",\\"start_position\\":\\"start_position\\",\\"user_ids\\":\\"user_ids\\"}")
+  ): accountSharedAccess @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/shared_access", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"envelopes_not_shared_user_status\\":\\"envelopes_not_shared_user_status\\",\\"folder_ids\\":\\"folder_ids\\",\\"item_type\\":\\"item_type\\",\\"search_text\\":\\"search_text\\",\\"shared\\":\\"shared\\",\\"start_position\\":\\"start_position\\",\\"user_ids\\":\\"user_ids\\"}")
   """Returns Account available signature providers for specified account."""
   AccountSignatureProviders_GetSignatureProviders(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): AccountSignatureProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signatureProviders", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): AccountSignatureProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signatureProviders", httpMethod: GET)
   """Retrieves a list of all signing groups in the specified account."""
   SigningGroups_GetSigningGroups(
     """The external account number (int) or account ID Guid."""
@@ -1347,7 +1347,7 @@ type Query {
     group_type: String
     """When set to **true**, the response includes the signing group members."""
     include_users: String
-  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"group_type\\":\\"group_type\\",\\"include_users\\":\\"include_users\\"}")
+  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", httpMethod: GET, queryParamArgMap: "{\\"group_type\\":\\"group_type\\",\\"include_users\\":\\"include_users\\"}")
   """
   Retrieves information, including group member information, for the specified signing group. 
   """
@@ -1355,25 +1355,25 @@ type Query {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     signingGroupId: String!
-  ): SigningGroups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): SigningGroups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}", httpMethod: GET)
   """Retrieves the list of members in the specified Signing Group."""
   SigningGroups_GetSigningGroupUsers(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     signingGroupId: String!
-  ): SigningGroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): SigningGroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}/users", httpMethod: GET)
   """List supported languages for the recipient language setting"""
   SupportedLanguages_GetSupportedLanguages(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): supportedLanguages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/supported_languages", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): supportedLanguages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/supported_languages", httpMethod: GET)
   """Retrieves a list of all tabs associated with the account."""
   Tabs_GetTabDefinitions(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """When set to **true**, only custom tabs are returned in the response."""
     custom_tab_only: String
-  ): tabMetadataList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"custom_tab_only\\":\\"custom_tab_only\\"}")
+  ): tabMetadataList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions", httpMethod: GET, queryParamArgMap: "{\\"custom_tab_only\\":\\"custom_tab_only\\"}")
   """
   Retrieves information about the requested custom tab on the specified account.
   """
@@ -1381,7 +1381,7 @@ type Query {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     customTabId: String!
-  ): CustomTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions/{args.customTabId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): CustomTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions/{args.customTabId}", httpMethod: GET)
   """
   Retrieves the list of templates for the specified account. The request can be limited to a specific folder.
   """
@@ -1450,7 +1450,7 @@ type Query {
     """
     user_filter: String
     user_id: String
-  ): envelopeTemplateResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"folder\\":\\"folder\\",\\"folder_ids\\":\\"folder_ids\\",\\"folder_types\\":\\"folder_types\\",\\"from_date\\":\\"from_date\\",\\"include\\":\\"include\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"search_text\\":\\"search_text\\",\\"shared\\":\\"shared\\",\\"shared_by_me\\":\\"shared_by_me\\",\\"start_position\\":\\"start_position\\",\\"to_date\\":\\"to_date\\",\\"used_from_date\\":\\"used_from_date\\",\\"used_to_date\\":\\"used_to_date\\",\\"user_filter\\":\\"user_filter\\",\\"user_id\\":\\"user_id\\"}")
+  ): envelopeTemplateResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"folder\\":\\"folder\\",\\"folder_ids\\":\\"folder_ids\\",\\"folder_types\\":\\"folder_types\\",\\"from_date\\":\\"from_date\\",\\"include\\":\\"include\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"search_text\\":\\"search_text\\",\\"shared\\":\\"shared\\",\\"shared_by_me\\":\\"shared_by_me\\",\\"start_position\\":\\"start_position\\",\\"to_date\\":\\"to_date\\",\\"used_from_date\\":\\"used_from_date\\",\\"used_to_date\\":\\"used_to_date\\",\\"user_filter\\":\\"user_filter\\",\\"user_id\\":\\"user_id\\"}")
   """Retrieves the definition of the specified template."""
   Templates_GetTemplate(
     """The external account number (int) or account ID Guid."""
@@ -1461,7 +1461,7 @@ type Query {
     A comma-separated list of additional template attributes to include in the response. Valid values are: recipients, folders, documents, custom_fields, and notifications.
     """
     include: String
-  ): Templates @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): Templates @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}", httpMethod: GET, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """
   Retrieves the custom document field information from an existing template.
   """
@@ -1470,14 +1470,14 @@ type Query {
     accountId: String!
     """The ID of the template being accessed."""
     templateId: String!
-  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", httpMethod: GET)
   """Retrieves a list of documents associated with the specified template."""
   Documents_GetTemplateDocuments(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The ID of the template being accessed."""
     templateId: String!
-  ): TemplateDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): TemplateDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents", httpMethod: GET)
   """
   Retrieves one or more PDF documents from the specified template.
   
@@ -1492,7 +1492,7 @@ type Query {
     documentId: String!
     encrypt: String
     show_changes: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "application/pdf"]], httpMethod: GET, queryParamArgMap: "{\\"encrypt\\":\\"encrypt\\",\\"show_changes\\":\\"show_changes\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}", operationSpecificHeaders: [["Accept", "application/pdf"]], httpMethod: GET, queryParamArgMap: "{\\"encrypt\\":\\"encrypt\\",\\"show_changes\\":\\"show_changes\\"}")
   """
   Retrieves the custom document fields for an existing template document.
   """
@@ -1503,7 +1503,7 @@ type Query {
     templateId: String!
     """The ID of the document being accessed."""
     documentId: String!
-  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", httpMethod: GET)
   """Returns document page image(s) based on input."""
   Pages_GetTemplatePageImages(
     """The external account number (int) or account ID Guid."""
@@ -1528,7 +1528,7 @@ type Query {
     The position within the total result set from which to start returning values. The value **thumbnail** may be used to return the page image.
     """
     start_position: String
-  ): pageImages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"nocache\\":\\"nocache\\",\\"show_changes\\":\\"show_changes\\",\\"start_position\\":\\"start_position\\"}")
+  ): pageImages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"nocache\\":\\"nocache\\",\\"show_changes\\":\\"show_changes\\",\\"start_position\\":\\"start_position\\"}")
   """Retrieves a page image for display from the specified template."""
   Pages_GetTemplatePageImage(
     """The external account number (int) or account ID Guid."""
@@ -1548,7 +1548,7 @@ type Query {
     """Sets the maximum width (in pixels) of the returned image."""
     max_width: String
     show_changes: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "image/png"]], httpMethod: GET, queryParamArgMap: "{\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"show_changes\\":\\"show_changes\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", operationSpecificHeaders: [["Accept", "image/png"]], httpMethod: GET, queryParamArgMap: "{\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"show_changes\\":\\"show_changes\\"}")
   """Returns tabs on the specified page."""
   Tabs_GetTemplatePageTabs(
     """The external account number (int) or account ID Guid."""
@@ -1559,7 +1559,7 @@ type Query {
     documentId: String!
     """The page number being accessed."""
     pageNumber: String!
-  ): TemplateDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): TemplateDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}/tabs", httpMethod: GET)
   """Returns tabs on the document."""
   Tabs_GetTemplateDocumentTabs(
     """The external account number (int) or account ID Guid."""
@@ -1569,7 +1569,7 @@ type Query {
     """The ID of the document being accessed."""
     documentId: String!
     page_numbers: String
-  ): TemplateDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"page_numbers\\":\\"page_numbers\\"}")
+  ): TemplateDocumentTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/tabs", httpMethod: GET, queryParamArgMap: "{\\"page_numbers\\":\\"page_numbers\\"}")
   """
   Retrieves general information about the template lock.
   
@@ -1580,7 +1580,7 @@ type Query {
     accountId: String!
     """The ID of the template being accessed."""
     templateId: String!
-  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", httpMethod: GET)
   """
   Retrieves the envelope notification, reminders and expirations, information for an existing template.
   """
@@ -1589,7 +1589,7 @@ type Query {
     accountId: String!
     """The ID of the template being accessed."""
     templateId: String!
-  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/notification", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/notification", httpMethod: GET)
   """
   Retrieves the information for all recipients in the specified template.
   """
@@ -1610,7 +1610,7 @@ type Query {
     When set to **true**, the tab information associated with the recipient is included in the response.
     """
     include_tabs: String
-  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_extended\\":\\"include_extended\\",\\"include_tabs\\":\\"include_tabs\\"}")
+  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_extended\\":\\"include_extended\\",\\"include_tabs\\":\\"include_tabs\\"}")
   """
   Retrieves the bulk recipient file information from a template that has a bulk recipient.
   """
@@ -1627,7 +1627,7 @@ type Query {
     include_tabs: String
     """Reserved for DocuSign."""
     start_position: String
-  ): TemplateBulkRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/bulk_recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_tabs\\":\\"include_tabs\\",\\"start_position\\":\\"start_position\\"}")
+  ): TemplateBulkRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/bulk_recipients", httpMethod: GET, queryParamArgMap: "{\\"include_tabs\\":\\"include_tabs\\",\\"start_position\\":\\"start_position\\"}")
   """Returns document visibility for the recipients"""
   Recipients_GetTemplateRecipientDocumentVisibility(
     """The external account number (int) or account ID Guid."""
@@ -1636,7 +1636,7 @@ type Query {
     templateId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/document_visibility", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/document_visibility", httpMethod: GET)
   """
   Gets the tabs information for a signer or sign-in-person recipient in a template.
   """
@@ -1653,14 +1653,14 @@ type Query {
     include_anchor_tab_locations: String
     """Reserved for DocuSign."""
     include_metadata: String
-  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_metadata\\":\\"include_metadata\\"}")
+  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", httpMethod: GET, queryParamArgMap: "{\\"include_anchor_tab_locations\\":\\"include_anchor_tab_locations\\",\\"include_metadata\\":\\"include_metadata\\"}")
   """
   Retrieves a list of file types (mime-types and file-extensions) that are not supported for upload through the DocuSign system.
   """
   UnsupportedFileTypes_GetUnsupportedFileTypes(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): fileTypeList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/unsupported_file_types", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): fileTypeList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/unsupported_file_types", httpMethod: GET)
   """
   Retrieves the list of users for the specified account.
   
@@ -1705,7 +1705,7 @@ type Query {
     Filters the user records returned by the user name or a sub-string of user name.
     """
     user_name_substring: String
-  ): userInformationList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"additional_info\\":\\"additional_info\\",\\"count\\":\\"count\\",\\"email\\":\\"email\\",\\"email_substring\\":\\"email_substring\\",\\"group_id\\":\\"group_id\\",\\"include_usersettings_for_csv\\":\\"include_usersettings_for_csv\\",\\"login_status\\":\\"login_status\\",\\"not_group_id\\":\\"not_group_id\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"user_name_substring\\":\\"user_name_substring\\"}")
+  ): userInformationList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", httpMethod: GET, queryParamArgMap: "{\\"additional_info\\":\\"additional_info\\",\\"count\\":\\"count\\",\\"email\\":\\"email\\",\\"email_substring\\":\\"email_substring\\",\\"group_id\\":\\"group_id\\",\\"include_usersettings_for_csv\\":\\"include_usersettings_for_csv\\",\\"login_status\\":\\"login_status\\",\\"not_group_id\\":\\"not_group_id\\",\\"start_position\\":\\"start_position\\",\\"status\\":\\"status\\",\\"user_name_substring\\":\\"user_name_substring\\"}")
   """
   Retrieves the user information for the specified user. 
   
@@ -1723,7 +1723,7 @@ type Query {
     """
     additional_info: String
     email: String
-  ): Users @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"additional_info\\":\\"additional_info\\",\\"email\\":\\"email\\"}")
+  ): Users @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}", httpMethod: GET, queryParamArgMap: "{\\"additional_info\\":\\"additional_info\\",\\"email\\":\\"email\\"}")
   """
   Retrieves the list of cloud storage providers enabled for the account and the configuration information for the user.
   
@@ -1741,7 +1741,7 @@ type Query {
     The redirectUrl is restricted to URLs in the docusign.com or docusign.net domains.
     """
     redirectUrl: String
-  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"redirectUrl\\":\\"redirectUrl\\"}")
+  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage", httpMethod: GET, queryParamArgMap: "{\\"redirectUrl\\":\\"redirectUrl\\"}")
   """
   Retrieves the list of cloud storage providers enabled for the account and the configuration information for the user.
   """
@@ -1764,7 +1764,7 @@ type Query {
     The redirectUrl is restricted to URLs in the docusign.com or docusign.net domains.
     """
     redirectUrl: String
-  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"redirectUrl\\":\\"redirectUrl\\"}")
+  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}", httpMethod: GET, queryParamArgMap: "{\\"redirectUrl\\":\\"redirectUrl\\"}")
   """
   Retrieves a list of all the items in a specified folder from the specified cloud storage provider. 
   """
@@ -1812,7 +1812,7 @@ type Query {
     Indicates the starting point of the first item included in the response set. It uses a 0-based index. The default setting for this is 0.
     """
     start_position: String
-  ): CloudStorage @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}/folders", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"cloud_storage_folder_path\\":\\"cloud_storage_folder_path\\",\\"count\\":\\"count\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\"}")
+  ): CloudStorage @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}/folders", httpMethod: GET, queryParamArgMap: "{\\"cloud_storage_folder_path\\":\\"cloud_storage_folder_path\\",\\"count\\":\\"count\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\"}")
   """
   Retrieves a list of all the items in all  the folders associated with the user from the specified cloud storage provider. You can limit the scope of the returned items by providing a comma separated list of folder IDs in the request.
   """
@@ -1861,7 +1861,7 @@ type Query {
     Indicates the starting point of the first item included in the response set. It uses a 0-based index. The default setting for this is 0.
     """
     start_position: String
-  ): CloudStorage @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}/folders/{args.folderId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"cloud_storage_folder_path\\":\\"cloud_storage_folder_path\\",\\"count\\":\\"count\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\"}")
+  ): CloudStorage @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}/folders/{args.folderId}", httpMethod: GET, queryParamArgMap: "{\\"cloud_storage_folder_path\\":\\"cloud_storage_folder_path\\",\\"count\\":\\"count\\",\\"order\\":\\"order\\",\\"order_by\\":\\"order_by\\",\\"search_text\\":\\"search_text\\",\\"start_position\\":\\"start_position\\"}")
   """
   Retrieves a list of custom user settings for a single user.
   
@@ -1884,7 +1884,7 @@ type Query {
     The user ID of the user being accessed. Generally this is the user ID of the authenticated user, but if the authenticated user is an Admin on the account, this may be another user the Admin user is accessing.
     """
     userId: String!
-  ): UserCustomSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/custom_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): UserCustomSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/custom_settings", httpMethod: GET)
   """
   Retrieves the user profile information, the privacy settings and personal information (address, phone number, etc.) for the specified user.
   
@@ -1897,7 +1897,7 @@ type Query {
     The user ID of the user being accessed. Generally this is the user ID of the authenticated user, but if the authenticated user is an Admin on the account, this may be another user the Admin user is accessing.
     """
     userId: String!
-  ): UserProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): UserProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile", httpMethod: GET)
   """
   Retrieves the user profile picture for the specified user. The image is returned in the same format as uploaded.
   
@@ -1913,7 +1913,7 @@ type Query {
     """
     userId: String!
     encoding: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile/image", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"encoding\\":\\"encoding\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile/image", operationSpecificHeaders: [["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"encoding\\":\\"encoding\\"}")
   """
   Retrieves a list of the account settings and email notification information for the specified user.
   
@@ -1926,7 +1926,7 @@ type Query {
     The user ID of the user being accessed. Generally this is the user ID of the authenticated user, but if the authenticated user is an Admin on the account, this may be another user the Admin user is accessing.
     """
     userId: String!
-  ): userSettingsInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): userSettingsInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/settings", httpMethod: GET)
   """
   Retrieves the signature definitions for the specified user.
   
@@ -1944,7 +1944,7 @@ type Query {
     """
     userId: String!
     stamp_type: String
-  ): userSignaturesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"stamp_type\\":\\"stamp_type\\"}")
+  ): userSignaturesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures", httpMethod: GET, queryParamArgMap: "{\\"stamp_type\\":\\"stamp_type\\"}")
   """
   Retrieves the structure of a single signature with a known signature name.
   
@@ -1963,7 +1963,7 @@ type Query {
     userId: String!
     """The ID of the signature being accessed."""
     signatureId: String!
-  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}", httpMethod: GET)
   """
   Retrieves the specified initials image or signature image for the specified user. The image is returned in the same format as uploaded. In the request you can specify if the chrome (the added line and identifier around the initial image) is returned with the image.
   
@@ -1985,7 +1985,7 @@ type Query {
     """One of **signature_image** or **initials_image**."""
     imageType: String!
     include_chrome: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}/{args.imageType}", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"include_chrome\\":\\"include_chrome\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}/{args.imageType}", operationSpecificHeaders: [["Accept", "image/gif"]], httpMethod: GET, queryParamArgMap: "{\\"include_chrome\\":\\"include_chrome\\"}")
   """Retrieves a list of social accounts linked to a user's account."""
   UserSocialLogin_GetUserSocialLogin(
     """The external account number (int) or account ID Guid."""
@@ -1994,24 +1994,24 @@ type Query {
     The user ID of the user being accessed. Generally this is the user ID of the authenticated user, but if the authenticated user is an Admin on the account, this may be another user the Admin user is accessing.
     """
     userId: String!
-  ): userSocialIdResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/social", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): userSocialIdResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/social", httpMethod: GET)
   """Get watermark information."""
   Watermark_GetWatermark(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): AccountWatermarks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/watermark", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): AccountWatermarks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/watermark", httpMethod: GET)
   """Gets information about the Workspaces that have been created."""
   Workspace_GetWorkspaces(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): workspaceList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): workspaceList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces", httpMethod: GET)
   """Retrives properties about a workspace given a unique workspaceId. """
   Workspace_GetWorkspace(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """Specifies the workspace ID GUID."""
     workspaceId: String!
-  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}", httpMethod: GET)
   """
   Retrieves workspace folder contents, which can include sub folders and files.
   """
@@ -2048,7 +2048,7 @@ type Query {
     If set, then the results are filtered to those associated with the specified userId.
     """
     workspace_user_id: String
-  ): workspaceFolderContents @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"include_files\\":\\"include_files\\",\\"include_sub_folders\\":\\"include_sub_folders\\",\\"include_thumbnails\\":\\"include_thumbnails\\",\\"include_user_detail\\":\\"include_user_detail\\",\\"start_position\\":\\"start_position\\",\\"workspace_user_id\\":\\"workspace_user_id\\"}")
+  ): workspaceFolderContents @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"include_files\\":\\"include_files\\",\\"include_sub_folders\\":\\"include_sub_folders\\",\\"include_thumbnails\\":\\"include_thumbnails\\",\\"include_user_detail\\":\\"include_user_detail\\",\\"start_position\\":\\"start_position\\",\\"workspace_user_id\\":\\"workspace_user_id\\"}")
   """Retrieves a workspace file (the binary)."""
   WorkspaceFile_GetWorkspaceFile(
     """The external account number (int) or account ID Guid."""
@@ -2065,7 +2065,7 @@ type Query {
     is_download: String
     """When set to **true** the file returned as a PDF."""
     pdf_version: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files/{args.fileId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"is_download\\":\\"is_download\\",\\"pdf_version\\":\\"pdf_version\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files/{args.fileId}", httpMethod: GET, queryParamArgMap: "{\\"is_download\\":\\"is_download\\",\\"pdf_version\\":\\"pdf_version\\"}")
   """Retrieves a workspace file as rasterized pages."""
   WorkspaceFilePages_GetWorkspaceFilePages(
     """The external account number (int) or account ID Guid."""
@@ -2090,16 +2090,16 @@ type Query {
     The position within the total result set from which to start returning values. The value **thumbnail** may be used to return the page image.
     """
     start_position: String
-  ): pageImages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files/{args.fileId}/pages", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"start_position\\":\\"start_position\\"}")
+  ): pageImages @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files/{args.fileId}/pages", httpMethod: GET, queryParamArgMap: "{\\"count\\":\\"count\\",\\"dpi\\":\\"dpi\\",\\"max_height\\":\\"max_height\\",\\"max_width\\":\\"max_width\\",\\"start_position\\":\\"start_position\\"}")
   """Retrieves a list of the billing plans associated with a distributor."""
-  BillingPlans_GetBillingPlans: billingPlansResponse @httpOperation(subgraph: "test", path: "/v2/billing_plans", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  BillingPlans_GetBillingPlans: billingPlansResponse @httpOperation(subgraph: "test", path: "/v2/billing_plans", httpMethod: GET)
   """Retrieves the billing plan details for the specified billing plan ID."""
   BillingPlans_GetBillingPlan(
     """The ID of the billing plan being accessed."""
     billingPlanId: String!
-  ): billingPlanResponse @httpOperation(subgraph: "test", path: "/v2/billing_plans/{args.billingPlanId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  ): billingPlanResponse @httpOperation(subgraph: "test", path: "/v2/billing_plans/{args.billingPlanId}", httpMethod: GET)
   """Get membership account password rules"""
-  PasswordRules_GetPasswordRules: userPasswordRules @httpOperation(subgraph: "test", path: "/v2/current_user/password_rules", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  PasswordRules_GetPasswordRules: userPasswordRules @httpOperation(subgraph: "test", path: "/v2/current_user/password_rules", httpMethod: GET)
   """
   Retrieves a list of log entries as a JSON or xml object or as a zip file containing the entries.
   
@@ -2107,7 +2107,7 @@ type Query {
   
   If the Accept header is set to \`application/json\` or \`application/xml\`, the response returns list of log entries in either JSON or XML. An example JSON response body is shown below. 
   """
-  APIRequestLog_GetRequestLogs(encoding: String): apiRequestLogsResult @httpOperation(subgraph: "test", path: "/v2/diagnostics/request_logs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"encoding\\":\\"encoding\\"}")
+  APIRequestLog_GetRequestLogs(encoding: String): apiRequestLogsResult @httpOperation(subgraph: "test", path: "/v2/diagnostics/request_logs", httpMethod: GET, queryParamArgMap: "{\\"encoding\\":\\"encoding\\"}")
   """
   Retrieves information for a single log entry.
   
@@ -2117,14 +2117,14 @@ type Query {
   **Response**
   If the Content-Transfer-Encoding header was set to base64, the log is returned as a base64 string.
   """
-  APIRequestLog_GetRequestLog(requestLogId: String!): JSON @httpOperation(subgraph: "test", path: "/v2/diagnostics/request_logs/{args.requestLogId}", operationSpecificHeaders: [["Content-Type", ""], ["Accept", "text/plain"]], httpMethod: GET)
+  APIRequestLog_GetRequestLog(requestLogId: String!): JSON @httpOperation(subgraph: "test", path: "/v2/diagnostics/request_logs/{args.requestLogId}", operationSpecificHeaders: [["Accept", "text/plain"]], httpMethod: GET)
   """
   Retrieves the current API request logging setting for the user and remaining log entries.
   
   **Response**
   The response includes the current API request logging setting for the user, along with the maximum log entries and remaining log entries.
   """
-  APIRequestLog_GetRequestLogSettings: RequestLogs @httpOperation(subgraph: "test", path: "/v2/diagnostics/settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET)
+  APIRequestLog_GetRequestLogSettings: RequestLogs @httpOperation(subgraph: "test", path: "/v2/diagnostics/settings", httpMethod: GET)
   """
   Retrieves account information for the authenticated user. Since the API is sessionless, this method does not actually log you in. 
   Instead, the method returns information about the account or accounts that the authenticated user has access to.
@@ -2165,7 +2165,7 @@ type Query {
     * none - no login settings are returned.
     """
     login_settings: String
-  ): Authentication @httpOperation(subgraph: "test", path: "/v2/login_information", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: GET, queryParamArgMap: "{\\"api_password\\":\\"api_password\\",\\"embed_account_id_guid\\":\\"embed_account_id_guid\\",\\"include_account_id_guid\\":\\"include_account_id_guid\\",\\"login_settings\\":\\"login_settings\\"}")
+  ): Authentication @httpOperation(subgraph: "test", path: "/v2/login_information", httpMethod: GET, queryParamArgMap: "{\\"api_password\\":\\"api_password\\",\\"embed_account_id_guid\\":\\"embed_account_id_guid\\",\\"include_account_id_guid\\":\\"include_account_id_guid\\",\\"login_settings\\":\\"login_settings\\"}")
 }
 
 """API service information"""
@@ -13107,14 +13107,14 @@ type Mutation {
     """
     preview_billing_plan: String
     input: newAccountDefinition_Input
-  ): newAccountSummary @httpOperation(subgraph: "test", path: "/v2/accounts", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST, queryParamArgMap: "{\\"preview_billing_plan\\":\\"preview_billing_plan\\"}")
+  ): newAccountSummary @httpOperation(subgraph: "test", path: "/v2/accounts", httpMethod: POST, queryParamArgMap: "{\\"preview_billing_plan\\":\\"preview_billing_plan\\"}")
   """
   This closes the specified account. You must be an account admin to close your account. Once closed, an account must be reopened by DocuSign.
   """
   Accounts_DeleteAccount(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}", httpMethod: DELETE)
   """
   Posts a payment to a past due invoice. 
   
@@ -13127,7 +13127,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: billingPaymentRequest_Input
-  ): billingPaymentResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_payments", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): billingPaymentResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_payments", httpMethod: POST)
   """
   Updates the billing plan information, billing address, and credit card information for the specified account.
   """
@@ -13139,7 +13139,7 @@ type Mutation {
     """
     preview_billing_plan: String
     input: billingPlanInformation_Input
-  ): billingPlanUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"preview_billing_plan\\":\\"preview_billing_plan\\"}")
+  ): billingPlanUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan", httpMethod: PUT, queryParamArgMap: "{\\"preview_billing_plan\\":\\"preview_billing_plan\\"}")
   """
   Reserved: At this time, this endpoint is limited to DocuSign internal use only. Completes the purchase of envelopes for your account. The actual purchase is done as part of an internal workflow interaction with an envelope vendor.
   """
@@ -13147,7 +13147,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: purchasedEnvelopesInformation_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan/purchased_envelopes", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/billing_plan/purchased_envelopes", httpMethod: PUT)
   """
   Deletes one or more brand profiles from an account. The Account Branding feature (accountSettings properties \`canSelfBrandSend\` and \`canSelfBrandSend\`) must be set to **true** to use this call.
   """
@@ -13155,7 +13155,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: brandsRequest_Input
-  ): AccountBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): AccountBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands", httpMethod: DELETE)
   """
   Creates one or more brand profile files for the account. The Account Branding feature (accountSettings properties \`canSelfBrandSend\` and \`canSelfBrandSig\`) must be set to **true** for the account to use this call.
   
@@ -13167,14 +13167,14 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: brand_Input
-  ): AccountBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): AccountBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands", httpMethod: POST)
   """Removes a brand."""
   Brand_DeleteBrand(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The unique identifier of a brand."""
     brandId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}", httpMethod: DELETE)
   """Updates an existing brand."""
   Brand_PutBrand(
     """The external account number (int) or account ID Guid."""
@@ -13182,7 +13182,7 @@ type Mutation {
     """The unique identifier of a brand."""
     brandId: String!
     input: brand_Input
-  ): brand @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): brand @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}", httpMethod: PUT)
   """Delete one branding logo."""
   BrandLogo_DeleteBrandLogo(
     """The external account number (int) or account ID Guid."""
@@ -13191,7 +13191,7 @@ type Mutation {
     brandId: String!
     """One of **Primary**, **Secondary** or **Email**."""
     logoType: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/logos/{args.logoType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/logos/{args.logoType}", httpMethod: DELETE)
   """Put one branding logo."""
   BrandLogo_PutBrandLogo(
     """The external account number (int) or account ID Guid."""
@@ -13200,7 +13200,7 @@ type Mutation {
     brandId: String!
     """One of **Primary**, **Secondary** or **Email**."""
     logoType: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/logos/{args.logoType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/logos/{args.logoType}", httpMethod: PUT)
   """Uploads a branding resource file."""
   BrandResources_PutBrandResources(
     """The external account number (int) or account ID Guid."""
@@ -13208,7 +13208,7 @@ type Mutation {
     """The unique identifier of a brand."""
     brandId: String!
     resourceContentType: String!
-  ): brandResources @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/resources/{args.resourceContentType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): brandResources @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/brands/{args.brandId}/resources/{args.resourceContentType}", httpMethod: PUT)
   """
   Deletes the signature for one or more captive recipient records; it is primarily used for testing. This provides a way to reset the signature associated with a client user ID so that a new signature can be created the next time the client user ID is used.
   """
@@ -13217,19 +13217,19 @@ type Mutation {
     accountId: String!
     recipientPart: String!
     input: captiveRecipientInformation_Input
-  ): captiveRecipientInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/captive_recipients/{args.recipientPart}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): captiveRecipientInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/captive_recipients/{args.recipientPart}", httpMethod: DELETE)
   """Initiate a new ChunkedUpload."""
   ChunkedUploads_PostChunkedUploads(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: chunkedUploadRequest_Input
-  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads", httpMethod: POST)
   """Delete an existing ChunkedUpload."""
   ChunkedUploads_DeleteChunkedUpload(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     chunkedUploadId: String!
-  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}", httpMethod: DELETE)
   """
   Integrity-Check and Commit a ChunkedUpload, readying it for use elsewhere.
   """
@@ -13238,7 +13238,7 @@ type Mutation {
     accountId: String!
     chunkedUploadId: String!
     action: String
-  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"action\\":\\"action\\"}")
+  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}", httpMethod: PUT, queryParamArgMap: "{\\"action\\":\\"action\\"}")
   """Add a chunk, a chunk 'part', to an existing ChunkedUpload."""
   ChunkedUploads_PutChunkedUploadPart(
     """The external account number (int) or account ID Guid."""
@@ -13246,7 +13246,7 @@ type Mutation {
     chunkedUploadId: String!
     chunkedUploadPartSeq: String!
     input: chunkedUploadRequest_Input
-  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}/{args.chunkedUploadPartSeq}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): ChunkedUploads @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/chunked_uploads/{args.chunkedUploadId}/{args.chunkedUploadPartSeq}", httpMethod: PUT)
   """
   Creates a DocuSign Custom Connect definition for your account. DocuSign Connect enables the sending of real-time data updates to external applications. These updates are generated by user transactions as the envelope progresses through actions to completion. The Connect Service provides updated information about the status of these transactions and returns updates that include the actual content of document form fields. Be aware that, these updates might or might not include the document itself. For more information about Connect, see the [ML:DocuSign Connect Service Guide].
   """
@@ -13254,13 +13254,13 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: ConnectConfigurations_Input
-  ): ConnectConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): ConnectConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect", httpMethod: POST)
   """Updates the specified DocuSign Connect configuration in your account."""
   Connect_PutConnectConfiguration(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: ConnectConfigurations_Input
-  ): ConnectConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): ConnectConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect", httpMethod: PUT)
   """
   Republishes Connect information for the  specified set of envelopes. The primary use is to republish Connect post failures by including envelope IDs for the envelopes that failed to post in the request. The list of envelope IDs that failed to post correctly can be retrieved by calling to [ML:GetConnectLog] retrieve the failure log.
   """
@@ -13268,26 +13268,26 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: connectFailureFilter_Input
-  ): connectFailureResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/envelopes/retry_queue", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): connectFailureResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/envelopes/retry_queue", httpMethod: PUT)
   """Republishes Connect information for the specified envelope."""
   ConnectPublish_PutConnectRetryByEnvelope(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): connectFailureResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/envelopes/{args.envelopeId}/retry_queue", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): connectFailureResults @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/envelopes/{args.envelopeId}/retry_queue", httpMethod: PUT)
   """Deletes the Connect failure log information for the specified entry."""
   ConnectFailures_DeleteConnectFailureLog(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """The ID of the failed connect log entry."""
     failureId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/failures/{args.failureId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/failures/{args.failureId}", httpMethod: DELETE)
   """Retrieves a list of connect log entries for your account."""
   ConnectLog_DeleteConnectLogs(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs", httpMethod: DELETE)
   """
   Deletes a specified entry from the Connect Log.
   
@@ -13297,7 +13297,7 @@ type Mutation {
     accountId: String!
     """The ID of the connect log entry"""
     logId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs/{args.logId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/logs/{args.logId}", httpMethod: DELETE)
   """
   Deletes the specified DocuSign Connect configuration.
   
@@ -13310,7 +13310,7 @@ type Mutation {
     accountId: String!
     """The ID of the custom Connect configuration being accessed."""
     connectId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/{args.connectId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/connect/{args.connectId}", httpMethod: DELETE)
   """Update Consumer Disclosure."""
   ConsumerDisclosure_PutConsumerDisclosure(
     """The external account number (int) or account ID Guid."""
@@ -13322,13 +13322,13 @@ type Mutation {
     """Reserved for DocuSign."""
     include_metadata: String
     input: EnvelopeConsumerDisclosures_Input
-  ): EnvelopeConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/consumer_disclosure/{args.langCode}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"include_metadata\\":\\"include_metadata\\"}")
+  ): EnvelopeConsumerDisclosures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/consumer_disclosure/{args.langCode}", httpMethod: PUT, queryParamArgMap: "{\\"include_metadata\\":\\"include_metadata\\"}")
   """Delete contacts associated with an account for the DocuSign service."""
   Contacts_DeleteContacts(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: contactModRequest_Input
-  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts", httpMethod: DELETE)
   """
   Imports multiple new contacts into the contacts collection from CSV, JSON, or XML (based on content type).
   """
@@ -13336,13 +13336,13 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: contactModRequest_Input
-  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts", httpMethod: POST)
   """Replaces contacts associated with an account for the DocuSign service."""
   Contacts_PutContacts(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: contactModRequest_Input
-  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts", httpMethod: PUT)
   """
   Replaces a particular contact associated with an account for the DocuSign service.
   """
@@ -13351,21 +13351,21 @@ type Mutation {
     accountId: String!
     """The unique identifier of a person in the contacts address book."""
     contactId: String!
-  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts/{args.contactId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): contactUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/contacts/{args.contactId}", httpMethod: DELETE)
   """Creates an acount custom field."""
   AccountCustomFields_PostAccountCustomFields(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     apply_to_templates: String
     input: customField_Input
-  ): AccountCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST, queryParamArgMap: "{\\"apply_to_templates\\":\\"apply_to_templates\\"}")
+  ): AccountCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields", httpMethod: POST, queryParamArgMap: "{\\"apply_to_templates\\":\\"apply_to_templates\\"}")
   """Delete an existing account custom field."""
   AccountCustomFields_DeleteAccountCustomFields(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     customFieldId: String!
     apply_to_templates: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields/{args.customFieldId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE, queryParamArgMap: "{\\"apply_to_templates\\":\\"apply_to_templates\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields/{args.customFieldId}", httpMethod: DELETE, queryParamArgMap: "{\\"apply_to_templates\\":\\"apply_to_templates\\"}")
   """Updates an existing account custom field."""
   AccountCustomFields_PutAccountCustomFields(
     """The external account number (int) or account ID Guid."""
@@ -13373,13 +13373,13 @@ type Mutation {
     customFieldId: String!
     apply_to_templates: String
     input: customField_Input
-  ): AccountCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields/{args.customFieldId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"apply_to_templates\\":\\"apply_to_templates\\"}")
+  ): AccountCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/custom_fields/{args.customFieldId}", httpMethod: PUT, queryParamArgMap: "{\\"apply_to_templates\\":\\"apply_to_templates\\"}")
   """Starts a new eMortgage Transaction"""
   EMortgage_PostTransactions(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: EMortgageTransactions_Input
-  ): postTransactionsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/eMortgage/transactions", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): postTransactionsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/eMortgage/transactions", httpMethod: POST)
   """
   Creates and sends an envelope or creates a draft envelope.
   Envelopes are fundamental resources in the DocuSign platform
@@ -14026,7 +14026,7 @@ type Mutation {
     """
     merge_roles_on_draft: String
     input: envelopeDefinition_Input
-  ): envelopeSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST, queryParamArgMap: "{\\"cdse_mode\\":\\"cdse_mode\\",\\"completed_documents_only\\":\\"completed_documents_only\\",\\"merge_roles_on_draft\\":\\"merge_roles_on_draft\\"}")
+  ): envelopeSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes", httpMethod: POST, queryParamArgMap: "{\\"cdse_mode\\":\\"cdse_mode\\",\\"completed_documents_only\\":\\"completed_documents_only\\",\\"merge_roles_on_draft\\":\\"merge_roles_on_draft\\"}")
   """Retrieves the envelope status for the specified envelopes."""
   Envelopes_PutStatus(
     """The external account number (int) or account ID Guid."""
@@ -14050,7 +14050,7 @@ type Mutation {
     """
     to_date: String
     input: envelopeIdsRequest_Input
-  ): envelopesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/status", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"email\\":\\"email\\",\\"from_date\\":\\"from_date\\",\\"start_position\\":\\"start_position\\",\\"to_date\\":\\"to_date\\"}")
+  ): envelopesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/status", httpMethod: PUT, queryParamArgMap: "{\\"email\\":\\"email\\",\\"from_date\\":\\"from_date\\",\\"start_position\\":\\"start_position\\",\\"to_date\\":\\"to_date\\"}")
   """
   The Put Envelopes endpoint provides the following functionality:
   
@@ -14087,7 +14087,7 @@ type Mutation {
     """When set to **true**, sends the specified envelope again."""
     resend_envelope: String
     input: Envelopes_Input
-  ): envelopeUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"advanced_update\\":\\"advanced_update\\",\\"resend_envelope\\":\\"resend_envelope\\"}")
+  ): envelopeUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}", httpMethod: PUT, queryParamArgMap: "{\\"advanced_update\\":\\"advanced_update\\",\\"resend_envelope\\":\\"resend_envelope\\"}")
   """Delete one or more attachments from a DRAFT envelope."""
   Attachments_DeleteAttachments(
     """The external account number (int) or account ID Guid."""
@@ -14095,7 +14095,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: envelopeAttachmentsRequest_Input
-  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments", httpMethod: DELETE)
   """Add one or more attachments to a DRAFT or IN-PROCESS envelope."""
   Attachments_PutAttachments(
     """The external account number (int) or account ID Guid."""
@@ -14103,7 +14103,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: envelopeAttachmentsRequest_Input
-  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments", httpMethod: PUT)
   """Add an attachment to a DRAFT or IN-PROCESS envelope."""
   Attachments_PutAttachment(
     """The external account number (int) or account ID Guid."""
@@ -14112,7 +14112,7 @@ type Mutation {
     envelopeId: String!
     attachmentId: String!
     input: attachment_Input
-  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments/{args.attachmentId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): envelopeAttachmentsResult @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/attachments/{args.attachmentId}", httpMethod: PUT)
   """Deletes envelope custom fields for draft and in-process envelopes."""
   CustomFields_DeleteCustomFields(
     """The external account number (int) or account ID Guid."""
@@ -14120,7 +14120,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeCustomFields_Input
-  ): EnvelopeCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", httpMethod: DELETE)
   """
   Updates the envelope custom fields for draft and in-process envelopes.
   
@@ -14132,7 +14132,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeCustomFields_Input
-  ): EnvelopeCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", httpMethod: POST)
   """
   Updates the envelope custom fields in draft and in-process envelopes.
   
@@ -14145,7 +14145,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeCustomFields_Input
-  ): EnvelopeCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/custom_fields", httpMethod: PUT)
   """Deletes one or more documents from an existing draft envelope."""
   Documents_DeleteDocuments(
     """The external account number (int) or account ID Guid."""
@@ -14153,7 +14153,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: envelopeDefinition_Input
-  ): EnvelopeDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents", httpMethod: DELETE)
   """Adds one or more documents to an existing envelope document."""
   Documents_PutDocuments(
     """The external account number (int) or account ID Guid."""
@@ -14167,7 +14167,7 @@ type Mutation {
     """
     apply_document_fields: String
     input: envelopeDefinition_Input
-  ): EnvelopeDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\"}")
+  ): EnvelopeDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents", httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\"}")
   """Adds a document to an existing draft envelope."""
   Documents_PutDocument(
     """The external account number (int) or account ID Guid."""
@@ -14182,7 +14182,7 @@ type Mutation {
     while adding or modifying envelope documents.
     """
     apply_document_fields: String
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\"}")
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}", httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\"}")
   """Deletes custom document fields from an existing envelope document."""
   DocumentFields_DeleteDocumentFields(
     """The external account number (int) or account ID Guid."""
@@ -14192,7 +14192,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: EnvelopeDocumentFields_Input
-  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", httpMethod: DELETE)
   """Creates custom document fields in an existing envelope document."""
   DocumentFields_PostDocumentFields(
     """The external account number (int) or account ID Guid."""
@@ -14202,7 +14202,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: EnvelopeDocumentFields_Input
-  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", httpMethod: POST)
   """
   Updates existing custom document fields in an existing envelope document.
   """
@@ -14214,7 +14214,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: EnvelopeDocumentFields_Input
-  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/fields", httpMethod: PUT)
   """
   Deletes a page from a document in an envelope based on the page number.
   """
@@ -14227,7 +14227,7 @@ type Mutation {
     documentId: String!
     """The page number being accessed."""
     pageNumber: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}", httpMethod: DELETE)
   """
   Rotates page image from an envelope for display. The page image can be rotated to the left or right.
   """
@@ -14241,7 +14241,7 @@ type Mutation {
     """The page number being accessed."""
     pageNumber: String!
     input: pageRequest_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", httpMethod: PUT)
   """Adds templates to a document in the specified envelope."""
   Templates_PostDocumentTemplates(
     """The external account number (int) or account ID Guid."""
@@ -14251,7 +14251,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: documentTemplateList_Input
-  ): documentTemplateList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/templates", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): documentTemplateList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/templates", httpMethod: POST)
   """
   Deletes the specified template from a document in an existing envelope.
   """
@@ -14264,7 +14264,7 @@ type Mutation {
     documentId: String!
     """The ID of the template being accessed."""
     templateId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/templates/{args.templateId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/documents/{args.documentId}/templates/{args.templateId}", httpMethod: DELETE)
   """
   Deletes all existing email override settings for the envelope. If you want to delete an individual email override setting, use the PUT and set the value to an empty string. Note that deleting email settings will only affect email communications that occur after the deletion and the normal account email settings are used for future email communications.
   """
@@ -14273,7 +14273,7 @@ type Mutation {
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", httpMethod: DELETE)
   """
   Adds email override settings, changing the email address to reply to an email address, name, or the BCC for email archive information, for the envelope. Note that adding email settings will only affect email communications that occur after the addition was made.
   """
@@ -14283,7 +14283,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeEmailSettings_Input
-  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", httpMethod: POST)
   """
   Updates the existing email override settings for the specified envelope. Note that modifying email settings will only affect email communications that occur after the modification was made.
   
@@ -14295,7 +14295,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeEmailSettings_Input
-  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeEmailSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/email_settings", httpMethod: PUT)
   """
   Deletes the lock from the specified envelope. The \`X-DocuSign-Edit\` header must be included in the request.
   """
@@ -14304,7 +14304,7 @@ type Mutation {
     accountId: String!
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
-  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", httpMethod: DELETE)
   """
   Locks the specified envelope, and sets the time until the lock expires, to prevent other users or recipients from accessing and changing the envelope.
   """
@@ -14314,7 +14314,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: lockRequest_Input
-  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", httpMethod: POST)
   """
   Updates the lock duration time or update the \`lockedByApp\` property information for the specified envelope. The user and integrator key must match the user specified by the \`lockByUser\` property and integrator key information and the \`X-DocuSign-Edit\` header must be included or an error will be generated.
   """
@@ -14324,7 +14324,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: lockRequest_Input
-  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/lock", httpMethod: PUT)
   """
   Sets envelope notification (Reminders/Expirations) structure for an existing envelope.
   """
@@ -14334,7 +14334,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: envelopeNotificationRequest_Input
-  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/notification", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/notification", httpMethod: PUT)
   """
   Deletes one or more recipients from a draft or sent envelope. Recipients to be deleted are listed in the request, with the \`recipientId\` being used as the key for deleting recipients.
   
@@ -14346,7 +14346,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeRecipients_Input
-  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", httpMethod: DELETE)
   """
   Adds one or more recipients to an envelope.
   
@@ -14362,7 +14362,7 @@ type Mutation {
     """
     resend_envelope: String
     input: EnvelopeRecipients_Input
-  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
+  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", httpMethod: POST, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
   """
   Updates recipients in a draft envelope or corrects recipient information for an in process envelope. 
   
@@ -14382,7 +14382,7 @@ type Mutation {
     """
     resend_envelope: String
     input: EnvelopeRecipients_Input
-  ): recipientsUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
+  ): recipientsUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients", httpMethod: PUT, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
   """Updates document visibility for the recipients"""
   Recipients_PutRecipientsDocumentVisibility(
     """The external account number (int) or account ID Guid."""
@@ -14390,7 +14390,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: EnvelopeDocumentVisibility_Input
-  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/document_visibility", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/document_visibility", httpMethod: PUT)
   """
   Deletes a recipient from a \`draft\` or \`sent\` envelope.
   
@@ -14403,7 +14403,7 @@ type Mutation {
     envelopeId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}", httpMethod: DELETE)
   """
   Deletes the bulk recipient file from an envelope. This cannot be used if the envelope has been sent.
   
@@ -14416,7 +14416,7 @@ type Mutation {
     envelopeId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): bulkRecipientsUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/bulk_recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): bulkRecipientsUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/bulk_recipients", httpMethod: DELETE)
   """
   Updates the bulk recipients in a draft envelope using a file upload. The Content-Type supported for uploading a bulk recipient file is CSV (text/csv).
   
@@ -14430,7 +14430,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: bulkRecipientsRequest_Input
-  ): bulkRecipientsSummaryResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/bulk_recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): bulkRecipientsSummaryResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/bulk_recipients", httpMethod: PUT)
   """Updates document visibility for the recipients"""
   Recipients_PutRecipientDocumentVisibility(
     """The external account number (int) or account ID Guid."""
@@ -14440,7 +14440,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: EnvelopeDocumentVisibility_Input
-  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/document_visibility", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/document_visibility", httpMethod: PUT)
   """
   Updates the initials image for a signer that does not have a DocuSign account. The supported image formats for this file are: gif, png, jpeg, and bmp. The file size must be less than 200K.
   
@@ -14453,7 +14453,7 @@ type Mutation {
     envelopeId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/initials_image", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/initials_image", httpMethod: PUT)
   """
   Updates the signature image for an accountless signer. The supported image formats for this file are: gif, png, jpeg, and bmp. The file size must be less than 200K.
   
@@ -14466,7 +14466,7 @@ type Mutation {
     envelopeId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/signature_image", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/signature_image", httpMethod: PUT)
   """
   Deletes one or more tabs associated with a recipient in a draft envelope.
   """
@@ -14478,7 +14478,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: EnvelopeRecipientTabs_Input
-  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", httpMethod: DELETE)
   """Adds one or more tabs for a recipient."""
   Recipients_PostRecipientTabs(
     """The external account number (int) or account ID Guid."""
@@ -14488,7 +14488,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: EnvelopeRecipientTabs_Input
-  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", httpMethod: POST)
   """Updates one or more tabs for a recipient in a draft envelope."""
   Recipients_PutRecipientTabs(
     """The external account number (int) or account ID Guid."""
@@ -14498,7 +14498,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: EnvelopeRecipientTabs_Input
-  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): EnvelopeRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/recipients/{args.recipientId}/tabs", httpMethod: PUT)
   """Adds templates to the specified envelope."""
   Templates_PostEnvelopeTemplates(
     """The external account number (int) or account ID Guid."""
@@ -14506,7 +14506,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: documentTemplateList_Input
-  ): documentTemplateList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/templates", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): documentTemplateList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/templates", httpMethod: POST)
   """
   Returns a URL that allows you to embed the envelope correction view of the DocuSign UI in your applications.
   
@@ -14518,7 +14518,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: correctViewRequest_Input
-  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/correct", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/correct", httpMethod: POST)
   """
   Returns a URL that allows you to embed the edit view of the DocuSign UI in your applications. This is a one-time use login token that allows the user to be placed into the DocuSign editing view. 
   
@@ -14532,7 +14532,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: returnUrlRequest_Input
-  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/edit", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/edit", httpMethod: POST)
   """
   Returns a URL that enables you to embed the recipient view of the DocuSign UI in your applications. If the recipient is a signer, then the view will provide the signing ceremony.
   
@@ -14557,7 +14557,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: recipientViewRequest_Input
-  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/recipient", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/recipient", httpMethod: POST)
   """
   Returns a URL that enables you to embed the sender view of the DocuSign UI in your applications. 
   
@@ -14582,7 +14582,7 @@ type Mutation {
     """The envelope's GUID. Eg 93be49ab-afa0-4adf-933c-f752070d71ec"""
     envelopeId: String!
     input: returnUrlRequest_Input
-  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/sender", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/envelopes/{args.envelopeId}/views/sender", httpMethod: POST)
   """Moves an envelope from its current folder to the specified folder."""
   Folders_PutFolderById(
     """The external account number (int) or account ID Guid."""
@@ -14590,13 +14590,13 @@ type Mutation {
     """The ID of the folder being accessed."""
     folderId: String!
     input: foldersRequest_Input
-  ): Folders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/folders/{args.folderId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): Folders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/folders/{args.folderId}", httpMethod: PUT)
   """Deletes an existing user group."""
   Groups_DeleteGroups(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: Groups_Input
-  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", httpMethod: DELETE)
   """
   Creates one or more groups for the account.
   
@@ -14606,7 +14606,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: Groups_Input
-  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", httpMethod: POST)
   """
   Updates the group name and modifies, or sets, the permission profile for the group.
   """
@@ -14614,7 +14614,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: Groups_Input
-  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups", httpMethod: PUT)
   """Deletes brand information from the requested group."""
   Brands_DeleteGroupBrands(
     """The external account number (int) or account ID Guid."""
@@ -14622,7 +14622,7 @@ type Mutation {
     """The ID of the group being accessed."""
     groupId: String!
     input: brandsRequest_Input
-  ): GroupBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/brands", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): GroupBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/brands", httpMethod: DELETE)
   """Adds group brand ID information to a group."""
   Brands_PutGroupBrands(
     """The external account number (int) or account ID Guid."""
@@ -14630,7 +14630,7 @@ type Mutation {
     """The ID of the group being accessed."""
     groupId: String!
     input: brandsRequest_Input
-  ): GroupBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/brands", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): GroupBrands @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/brands", httpMethod: PUT)
   """
   Deletes one or more users from a group.
   
@@ -14641,7 +14641,7 @@ type Mutation {
     """The ID of the group being accessed."""
     groupId: String!
     input: userInfoList_Input
-  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/users", httpMethod: DELETE)
   """Adds one or more users to an existing group."""
   Groups_PutGroupUsers(
     """The external account number (int) or account ID Guid."""
@@ -14649,7 +14649,7 @@ type Mutation {
     """The ID of the group being accessed."""
     groupId: String!
     input: userInfoList_Input
-  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/groups/{args.groupId}/users", httpMethod: PUT)
   """Creates a new permission profile in the specified account."""
   PermissionProfiles_PostPermissionProfiles(
     """The external account number (int) or account ID Guid."""
@@ -14659,13 +14659,13 @@ type Mutation {
     """
     include: String
     input: AccountPermissionProfiles_Input
-  ): AccountPermissionProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): AccountPermissionProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles", httpMethod: POST, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """Deletes a permissions profile within the specified account."""
   PermissionProfiles_DeletePermissionProfiles(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     permissionProfileId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles/{args.permissionProfileId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles/{args.permissionProfileId}", httpMethod: DELETE)
   """Updates a permission profile within the specified account."""
   PermissionProfiles_PutPermissionProfiles(
     """The external account number (int) or account ID Guid."""
@@ -14676,61 +14676,61 @@ type Mutation {
     """
     include: String
     input: AccountPermissionProfiles_Input
-  ): AccountPermissionProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles/{args.permissionProfileId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"include\\":\\"include\\"}")
+  ): AccountPermissionProfiles @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/permission_profiles/{args.permissionProfileId}", httpMethod: PUT, queryParamArgMap: "{\\"include\\":\\"include\\"}")
   """Deletes one or more PowerForms"""
   PowerForms_DeletePowerFormsList(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: powerFormsRequest_Input
-  ): powerFormsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): powerFormsResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms", httpMethod: DELETE)
   """Creates a new PowerForm."""
   PowerForms_PostPowerForm(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: PowerForms_Input
-  ): PowerForms @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): PowerForms @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms", httpMethod: POST)
   """Delete a PowerForm."""
   PowerForms_DeletePowerForm(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     powerFormId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}", httpMethod: DELETE)
   """Creates a new PowerForm."""
   PowerForms_PutPowerForm(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     powerFormId: String!
     input: PowerForms_Input
-  ): PowerForms @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): PowerForms @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/powerforms/{args.powerFormId}", httpMethod: PUT)
   """Updates the account settings for the specified account."""
   Settings_PutSettings(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: accountSettingsInformation_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings", httpMethod: PUT)
   """Deletes configuration information for the eNote eOriginal integration."""
   ENoteConfiguration_DeleteENoteConfiguration(
     """The external account number (int) or account ID Guid."""
     accountId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/enote_configuration", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/enote_configuration", httpMethod: DELETE)
   """Updates configuration information for the eNote eOriginal integration."""
   ENoteConfiguration_PutENoteConfiguration(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: ENoteConfigurations_Input
-  ): ENoteConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/enote_configuration", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): ENoteConfigurations @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/enote_configuration", httpMethod: PUT)
   """Update the password rules"""
   AccountPasswordRules_PutAccountPasswordRules(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: AccountPasswordRules_Input
-  ): AccountPasswordRules @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/password_rules", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): AccountPasswordRules @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/password_rules", httpMethod: PUT)
   """Modifies tab settings for specified account"""
   TabSettings_PutSettings(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: AccountTabSettings_Input
-  ): AccountTabSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): AccountTabSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/settings/tabs", httpMethod: PUT)
   """Reserved: Sets the shared access information for one or more users."""
   SharedAccess_PutSharedAccess(
     """The external account number (int) or account ID Guid."""
@@ -14738,13 +14738,13 @@ type Mutation {
     item_type: String
     user_ids: String
     input: accountSharedAccess_Input
-  ): accountSharedAccess @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/shared_access", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"item_type\\":\\"item_type\\",\\"user_ids\\":\\"user_ids\\"}")
+  ): accountSharedAccess @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/shared_access", httpMethod: PUT, queryParamArgMap: "{\\"item_type\\":\\"item_type\\",\\"user_ids\\":\\"user_ids\\"}")
   """Deletes one or more signing groups in the specified account."""
   SigningGroups_DeleteSigningGroups(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: signingGroupInformation_Input
-  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", httpMethod: DELETE)
   """
   Creates one or more signing groups. 
   
@@ -14758,13 +14758,13 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: signingGroupInformation_Input
-  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", httpMethod: POST)
   """Updates the name of one or more existing signing groups. """
   SigningGroups_PutSigningGroups(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: signingGroupInformation_Input
-  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): signingGroupInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups", httpMethod: PUT)
   """
   Updates signing group name and member information. You can also add new members to the signing group. A signing group can have a maximum of 50 members. 
   """
@@ -14773,14 +14773,14 @@ type Mutation {
     accountId: String!
     signingGroupId: String!
     input: SigningGroups_Input
-  ): SigningGroups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): SigningGroups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}", httpMethod: PUT)
   """Deletes  one or more members from the specified signing group. """
   SigningGroups_DeleteSigningGroupUsers(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     signingGroupId: String!
     input: SigningGroupUsers_Input
-  ): SigningGroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): SigningGroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}/users", httpMethod: DELETE)
   """
   Adds one or more new members to a signing group. A signing group can have a maximum of 50 members. 
   """
@@ -14789,7 +14789,7 @@ type Mutation {
     accountId: String!
     signingGroupId: String!
     input: SigningGroupUsers_Input
-  ): SigningGroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): SigningGroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/signing_groups/{args.signingGroupId}/users", httpMethod: PUT)
   """
   Creates a tab with pre-defined properties, such as a text tab with a certain font type and validation pattern. Users can access the custom tabs when sending documents through the DocuSign web application.
   
@@ -14799,20 +14799,20 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: CustomTabs_Input
-  ): CustomTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): CustomTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions", httpMethod: POST)
   """Deletes the custom from the specified account."""
   Tab_DeleteCustomTab(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     customTabId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions/{args.customTabId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions/{args.customTabId}", httpMethod: DELETE)
   """Updates the information in a custom tab for the specified account."""
   Tab_PutCustomTab(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     customTabId: String!
     input: CustomTabs_Input
-  ): CustomTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions/{args.customTabId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): CustomTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/tab_definitions/{args.customTabId}", httpMethod: PUT)
   """
   Creates a template definition using a multipart request.
   
@@ -14848,7 +14848,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: Templates_Input
-  ): templateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): templateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates", httpMethod: POST)
   """Updates an existing template."""
   Templates_PutTemplate(
     """The external account number (int) or account ID Guid."""
@@ -14856,7 +14856,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: Templates_Input
-  ): templateUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): templateUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}", httpMethod: PUT)
   """Deletes envelope custom fields in a template."""
   CustomFields_DeleteTemplateCustomFields(
     """The external account number (int) or account ID Guid."""
@@ -14864,7 +14864,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: templateCustomFields_Input
-  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", httpMethod: DELETE)
   """Creates custom document fields in an existing template document."""
   CustomFields_PostTemplateCustomFields(
     """The external account number (int) or account ID Guid."""
@@ -14872,7 +14872,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: templateCustomFields_Input
-  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", httpMethod: POST)
   """
   Updates the custom fields in a template.
   
@@ -14884,7 +14884,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: templateCustomFields_Input
-  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): TemplateCustomFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/custom_fields", httpMethod: PUT)
   """Deletes one or more documents from an existing template."""
   Documents_DeleteTemplateDocuments(
     """The external account number (int) or account ID Guid."""
@@ -14892,7 +14892,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: envelopeDefinition_Input
-  ): TemplateDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents", httpMethod: DELETE)
   """Adds one or more documents to an existing template document."""
   Documents_PutTemplateDocuments(
     """The external account number (int) or account ID Guid."""
@@ -14906,7 +14906,7 @@ type Mutation {
     """
     apply_document_fields: String
     input: envelopeDefinition_Input
-  ): TemplateDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\"}")
+  ): TemplateDocuments @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents", httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\"}")
   """Adds the specified document to an existing template document."""
   Documents_PutTemplateDocument(
     """The external account number (int) or account ID Guid."""
@@ -14923,7 +14923,7 @@ type Mutation {
     apply_document_fields: String
     is_envelope_definition: String
     input: envelopeDefinition_Input
-  ): envelopeDocument @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\",\\"is_envelope_definition\\":\\"is_envelope_definition\\"}")
+  ): envelopeDocument @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}", httpMethod: PUT, queryParamArgMap: "{\\"apply_document_fields\\":\\"apply_document_fields\\",\\"is_envelope_definition\\":\\"is_envelope_definition\\"}")
   """Deletes custom document fields from an existing template document."""
   DocumentFields_DeleteTemplateDocumentFields(
     """The external account number (int) or account ID Guid."""
@@ -14933,7 +14933,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: TemplateDocumentFields_Input
-  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", httpMethod: DELETE)
   """Creates custom document fields in an existing template document."""
   DocumentFields_PostTemplateDocumentFields(
     """The external account number (int) or account ID Guid."""
@@ -14943,7 +14943,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: TemplateDocumentFields_Input
-  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", httpMethod: POST)
   """
   Updates existing custom document fields in an existing template document.
   """
@@ -14955,7 +14955,7 @@ type Mutation {
     """The ID of the document being accessed."""
     documentId: String!
     input: TemplateDocumentFields_Input
-  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): TemplateDocumentFields @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/fields", httpMethod: PUT)
   """Deletes a page from a document in a template based on the page number."""
   Pages_DeleteTemplatePage(
     """The external account number (int) or account ID Guid."""
@@ -14967,7 +14967,7 @@ type Mutation {
     """The page number being accessed."""
     pageNumber: String!
     input: pageRequest_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}", httpMethod: DELETE)
   """
   Rotates page image from a template for display. The page image can be rotated to the left or right.
   """
@@ -14981,7 +14981,7 @@ type Mutation {
     """The page number being accessed."""
     pageNumber: String!
     input: pageRequest_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/documents/{args.documentId}/pages/{args.pageNumber}/page_image", httpMethod: PUT)
   """
   Deletes the lock from the specified template. The \`X-DocuSign-Edit\` header must be included in the request.
   """
@@ -14991,7 +14991,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: lockRequest_Input
-  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", httpMethod: DELETE)
   """
   Locks the specified template, and sets the time until the lock expires, to prevent other users or recipients from accessing and changing the template.
   """
@@ -15001,7 +15001,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: lockRequest_Input
-  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", httpMethod: POST)
   """
   Updates the lock duration time or update the \`lockedByApp\` property information for the specified template. The user and integrator key must match the user specified by the \`lockByUser\` property and integrator key information and the \`X-DocuSign-Edit\` header must be included or an error will be generated.
   """
@@ -15011,7 +15011,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: lockRequest_Input
-  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): TemplateLocks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/lock", httpMethod: PUT)
   """
   Updates the notification structure for an existing template. Use this endpoint to set reminder and expiration notifications.
   """
@@ -15021,7 +15021,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: templateNotificationRequest_Input
-  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/notification", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): notification @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/notification", httpMethod: PUT)
   """
   Deletes one or more recipients from a template. Recipients to be deleted are listed in the request, with the \`recipientId\` being used as the key for deleting recipients.
   """
@@ -15031,7 +15031,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: templateRecipients_Input
-  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", httpMethod: DELETE)
   """Adds one or more recipients to a template."""
   Recipients_PostTemplateRecipients(
     """The external account number (int) or account ID Guid."""
@@ -15043,7 +15043,7 @@ type Mutation {
     """
     resend_envelope: String
     input: templateRecipients_Input
-  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
+  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", httpMethod: POST, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
   """
   Updates recipients in a template. 
   
@@ -15059,7 +15059,7 @@ type Mutation {
     """
     resend_envelope: String
     input: templateRecipients_Input
-  ): recipientsUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
+  ): recipientsUpdateSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients", httpMethod: PUT, queryParamArgMap: "{\\"resend_envelope\\":\\"resend_envelope\\"}")
   """Updates document visibility for the recipients"""
   Recipients_PutTemplateRecipientsDocumentVisibility(
     """The external account number (int) or account ID Guid."""
@@ -15067,7 +15067,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: TemplateDocumentVisibility_Input
-  ): TemplateDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/document_visibility", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): TemplateDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/document_visibility", httpMethod: PUT)
   """Deletes the specified recipient file from the specified template."""
   Recipients_DeleteTemplateRecipient(
     """The external account number (int) or account ID Guid."""
@@ -15077,7 +15077,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: templateRecipients_Input
-  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateRecipients @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}", httpMethod: DELETE)
   """Deletes the bulk recipient list on a template."""
   Recipients_DeleteTemplateBulkRecipientsFile(
     """The external account number (int) or account ID Guid."""
@@ -15086,7 +15086,7 @@ type Mutation {
     templateId: String!
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
-  ): bulkRecipientsUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/bulk_recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): bulkRecipientsUpdateResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/bulk_recipients", httpMethod: DELETE)
   """
   Updates the bulk recipients in a template using a file upload. The Content-Type supported for uploading a bulk recipient file is CSV (text/csv).
   
@@ -15100,7 +15100,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: bulkRecipientsRequest_Input
-  ): bulkRecipientsSummaryResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/bulk_recipients", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): bulkRecipientsSummaryResponse @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/bulk_recipients", httpMethod: PUT)
   """Updates document visibility for the recipients"""
   Recipients_PutTemplateRecipientDocumentVisibility(
     """The external account number (int) or account ID Guid."""
@@ -15110,7 +15110,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: TemplateDocumentVisibility_Input
-  ): TemplateDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/document_visibility", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): TemplateDocumentVisibility @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/document_visibility", httpMethod: PUT)
   """Deletes one or more tabs associated with a recipient in a template."""
   Recipients_DeleteTemplateRecipientTabs(
     """The external account number (int) or account ID Guid."""
@@ -15120,7 +15120,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: templateTabs_Input
-  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", httpMethod: DELETE)
   """Adds one or more tabs for a recipient."""
   Recipients_PostTemplateRecipientTabs(
     """The external account number (int) or account ID Guid."""
@@ -15130,7 +15130,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: templateTabs_Input
-  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", httpMethod: POST)
   """Updates one or more tabs for a recipient in a template."""
   Recipients_PutTemplateRecipientTabs(
     """The external account number (int) or account ID Guid."""
@@ -15140,7 +15140,7 @@ type Mutation {
     """The \`recipientId\` used when the envelope or template was created."""
     recipientId: String!
     input: templateTabs_Input
-  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): TemplateRecipientTabs @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/recipients/{args.recipientId}/tabs", httpMethod: PUT)
   """Provides a URL to start an edit view of the Template UI"""
   Views_PostTemplateEditView(
     """The external account number (int) or account ID Guid."""
@@ -15148,7 +15148,7 @@ type Mutation {
     """The ID of the template being accessed."""
     templateId: String!
     input: returnUrlRequest_Input
-  ): TemplateViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/views/edit", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): TemplateViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/views/edit", httpMethod: POST)
   """Removes a member group's sharing permissions for a specified template."""
   Templates_DeleteTemplatePart(
     """The external account number (int) or account ID Guid."""
@@ -15158,7 +15158,7 @@ type Mutation {
     """Currently, the only defined part is **groups**."""
     templatePart: String!
     input: Groups_Input
-  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/{args.templatePart}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/{args.templatePart}", httpMethod: DELETE)
   """Shares a template with the specified members group."""
   Templates_PutTemplatePart(
     """The external account number (int) or account ID Guid."""
@@ -15168,7 +15168,7 @@ type Mutation {
     """Currently, the only defined part is **groups**."""
     templatePart: String!
     input: Groups_Input
-  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/{args.templatePart}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): Groups @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/templates/{args.templateId}/{args.templatePart}", httpMethod: PUT)
   """
   This closes one or more user records in the account. Users are never deleted from an account, but closing a user prevents them from using account functions.
   
@@ -15178,7 +15178,7 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: userInfoList_Input
-  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): GroupUsers @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", httpMethod: DELETE)
   """
   Adds new users to your account. Set the \`userSettings\` property in the request to specify the actions the users can perform on the account.
   """
@@ -15186,13 +15186,13 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: newUsersDefinition_Input
-  ): newUsersSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): newUsersSummary @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", httpMethod: POST)
   """Change one or more user in the specified account."""
   Users_PutUsers(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: userInformationList_Input
-  ): userInformationList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): userInformationList @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users", httpMethod: PUT)
   """Updates the specified user information."""
   User_PutUser(
     """The external account number (int) or account ID Guid."""
@@ -15202,7 +15202,7 @@ type Mutation {
     """
     userId: String!
     input: Users_Input
-  ): Users @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): Users @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}", httpMethod: PUT)
   """
   Deletes the user authentication information for one or more cloud storage providers. The next time the user tries to access the cloud storage provider, they must pass normal authentication.
   """
@@ -15214,7 +15214,7 @@ type Mutation {
     """
     userId: String!
     input: CloudStorageProviders_Input
-  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage", httpMethod: DELETE)
   """
   Configures the redirect URL information  for one or more cloud storage providers for the specified user. The redirect URL is added to the authentication URL to complete the return route.
   """
@@ -15226,7 +15226,7 @@ type Mutation {
     """
     userId: String!
     input: CloudStorageProviders_Input
-  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage", httpMethod: POST)
   """
   Deletes the user authentication information for the specified cloud storage provider. The next time the user tries to access the cloud storage provider, they must pass normal authentication for this cloud storage provider.
   """
@@ -15243,7 +15243,7 @@ type Mutation {
     Valid values are the service name ("Box") or the numerical serviceId ("4136").
     """
     serviceId: String!
-  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): CloudStorageProviders @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/cloud_storage/{args.serviceId}", httpMethod: DELETE)
   """
   Deletes the specified custom user settings for a single user.
   
@@ -15264,7 +15264,7 @@ type Mutation {
     """
     userId: String!
     input: UserCustomSettings_Input
-  ): UserCustomSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/custom_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): UserCustomSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/custom_settings", httpMethod: DELETE)
   """
   Adds or updates custom user settings for the specified user.
   
@@ -15294,7 +15294,7 @@ type Mutation {
     """
     userId: String!
     input: UserCustomSettings_Input
-  ): UserCustomSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/custom_settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): UserCustomSettings @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/custom_settings", httpMethod: PUT)
   """
   Updates the user's detail information, profile information, privacy settings, and personal information in the user ID card.
   
@@ -15308,7 +15308,7 @@ type Mutation {
     """
     userId: String!
     input: UserProfiles_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile", httpMethod: PUT)
   """
   Deletes the user profile image from the  specified user's profile.
   
@@ -15321,7 +15321,7 @@ type Mutation {
     The user ID of the user being accessed. Generally this is the user ID of the authenticated user, but if the authenticated user is an Admin on the account, this may be another user the Admin user is accessing.
     """
     userId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile/image", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile/image", httpMethod: DELETE)
   """
   Updates the user profile image by uploading an image to the user profile.
   
@@ -15334,7 +15334,7 @@ type Mutation {
     The user ID of the user being accessed. Generally this is the user ID of the authenticated user, but if the authenticated user is an Admin on the account, this may be another user the Admin user is accessing.
     """
     userId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile/image", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/profile/image", httpMethod: PUT)
   """
   Updates the account settings list and email notification types for the specified user.
   """
@@ -15346,7 +15346,7 @@ type Mutation {
     """
     userId: String!
     input: userSettingsInformation_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/settings", httpMethod: PUT)
   """
   Adds a user signature image and/or user initials image to the specified user. 
   
@@ -15376,7 +15376,7 @@ type Mutation {
     """
     userId: String!
     input: userSignaturesInformation_Input
-  ): userSignaturesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): userSignaturesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures", httpMethod: POST)
   """Adds/updates a user signature."""
   UserSignatures_PutUserSignature(
     """The external account number (int) or account ID Guid."""
@@ -15386,7 +15386,7 @@ type Mutation {
     """
     userId: String!
     input: userSignaturesInformation_Input
-  ): userSignaturesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): userSignaturesInformation @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures", httpMethod: PUT)
   """
   Removes the signature information for the user.
   
@@ -15405,7 +15405,7 @@ type Mutation {
     userId: String!
     """The ID of the signature being accessed."""
     signatureId: String!
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}", httpMethod: DELETE)
   """
   Creates, or updates, the signature font and initials for the specified user. When creating a signature, you use this resource to create the signature name and then add the signature and initials images into the signature.
   
@@ -15428,7 +15428,7 @@ type Mutation {
     """When set to **true**, closes the current signature."""
     close_existing_signature: String
     input: userSignatureDefinition_Input
-  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT, queryParamArgMap: "{\\"close_existing_signature\\":\\"close_existing_signature\\"}")
+  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}", httpMethod: PUT, queryParamArgMap: "{\\"close_existing_signature\\":\\"close_existing_signature\\"}")
   """
   Deletes the specified initials image or signature image for the specified user.
   
@@ -15451,7 +15451,7 @@ type Mutation {
     signatureId: String!
     """One of **signature_image** or **initials_image**."""
     imageType: String!
-  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}/{args.imageType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}/{args.imageType}", httpMethod: DELETE)
   """
   Updates the user signature image or user initials image for the specified user. The supported image formats for this file are: gif, png, jpeg, and bmp. The file must be less than 200K.
   
@@ -15473,7 +15473,7 @@ type Mutation {
     signatureId: String!
     """One of **signature_image** or **initials_image**."""
     imageType: String!
-  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}/{args.imageType}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): UserSignatures @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/signatures/{args.signatureId}/{args.imageType}", httpMethod: PUT)
   """Deletes a social account from a use's account."""
   UserSocialLogin_DeleteUserSocialLogin(
     """The external account number (int) or account ID Guid."""
@@ -15483,7 +15483,7 @@ type Mutation {
     """
     userId: String!
     input: UserSocialAccountLogins_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/social", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/social", httpMethod: DELETE)
   """Adds a new social account to a user's account."""
   UserSocialLogin_PutUserSocialLogin(
     """The external account number (int) or account ID Guid."""
@@ -15493,7 +15493,7 @@ type Mutation {
     """
     userId: String!
     input: UserSocialAccountLogins_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/social", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/users/{args.userId}/social", httpMethod: PUT)
   """
   Returns a URL that allows you to embed the authentication view of the DocuSign UI in your applications.
   """
@@ -15501,32 +15501,32 @@ type Mutation {
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: consoleViewRequest_Input
-  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/views/console", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): EnvelopeViews @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/views/console", httpMethod: POST)
   """Update watermark information."""
   Watermark_PutWatermark(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: AccountWatermarks_Input
-  ): AccountWatermarks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/watermark", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): AccountWatermarks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/watermark", httpMethod: PUT)
   """Get watermark preview."""
   WatermarkPreview_PutWatermarkPreview(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: AccountWatermarks_Input
-  ): AccountWatermarks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/watermark/preview", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): AccountWatermarks @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/watermark/preview", httpMethod: PUT)
   """Creates a new workspace."""
   Workspace_PostWorkspace(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     input: Workspaces_Input
-  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces", httpMethod: POST)
   """Deletes an existing workspace (logically)."""
   Workspace_DeleteWorkspace(
     """The external account number (int) or account ID Guid."""
     accountId: String!
     """Specifies the workspace ID GUID."""
     workspaceId: String!
-  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}", httpMethod: DELETE)
   """Updates information about a specific workspace."""
   Workspace_PutWorkspace(
     """The external account number (int) or account ID Guid."""
@@ -15534,7 +15534,7 @@ type Mutation {
     """Specifies the workspace ID GUID."""
     workspaceId: String!
     input: Workspaces_Input
-  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): Workspaces @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}", httpMethod: PUT)
   """
   Deletes workspace one or more specific files/folders from the given folder or root.
   """
@@ -15546,7 +15546,7 @@ type Mutation {
     """The ID of the folder being accessed."""
     folderId: String!
     input: workspaceItemList_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}", httpMethod: DELETE)
   """Creates a workspace file."""
   WorkspaceFile_PostWorkspaceFiles(
     """The external account number (int) or account ID Guid."""
@@ -15555,7 +15555,7 @@ type Mutation {
     workspaceId: String!
     """The ID of the folder being accessed."""
     folderId: String!
-  ): WorkspaceItems @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  ): WorkspaceItems @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files", httpMethod: POST)
   """
   Updates workspace item metadata for one or more specific files/folders.
   """
@@ -15568,9 +15568,9 @@ type Mutation {
     folderId: String!
     """Specifies the room file ID GUID."""
     fileId: String!
-  ): WorkspaceItems @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files/{args.fileId}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): WorkspaceItems @httpOperation(subgraph: "test", path: "/v2/accounts/{args.accountId}/workspaces/{args.workspaceId}/folders/{args.folderId}/files/{args.fileId}", httpMethod: PUT)
   """Deletes the request log files."""
-  APIRequestLog_DeleteRequestLogs: JSON @httpOperation(subgraph: "test", path: "/v2/diagnostics/request_logs", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: DELETE)
+  APIRequestLog_DeleteRequestLogs: JSON @httpOperation(subgraph: "test", path: "/v2/diagnostics/request_logs", httpMethod: DELETE)
   """
   Enables or disables API request logging for troubleshooting.
   
@@ -15581,27 +15581,27 @@ type Mutation {
   Private information, such as passwords and integrator key information, which is normally located in the call header is omitted from the request/response log.
   
   """
-  APIRequestLog_PutRequestLogSettings(input: RequestLogs_Input): RequestLogs @httpOperation(subgraph: "test", path: "/v2/diagnostics/settings", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  APIRequestLog_PutRequestLogSettings(input: RequestLogs_Input): RequestLogs @httpOperation(subgraph: "test", path: "/v2/diagnostics/settings", httpMethod: PUT)
   """Updates the password for a specified user."""
   LoginInformation_PutLoginInformation(
     """Currently, only the value **password** is supported."""
     loginPart: String!
     input: userPasswordInformation_Input
-  ): JSON @httpOperation(subgraph: "test", path: "/v2/login_information/{args.loginPart}", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: PUT)
+  ): JSON @httpOperation(subgraph: "test", path: "/v2/login_information/{args.loginPart}", httpMethod: PUT)
   """
   **Deprecated**
   
   Revokes an OAuth2 authorization server token. After the revocation is complete, a caller must re-authenticate to restore access.
   
   """
-  OAuth2_PostRevoke: JSON @httpOperation(subgraph: "test", path: "/v2/oauth2/revoke", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  OAuth2_PostRevoke: JSON @httpOperation(subgraph: "test", path: "/v2/oauth2/revoke", httpMethod: POST)
   """
   **Deprecated**
   
   Creates an OAuth2 authorization server token endpoint.
   
   """
-  OAuth2_PostToken: oauthAccess @httpOperation(subgraph: "test", path: "/v2/oauth2/token", operationSpecificHeaders: [["Content-Type", ""]], httpMethod: POST)
+  OAuth2_PostToken: oauthAccess @httpOperation(subgraph: "test", path: "/v2/oauth2/token", httpMethod: POST)
 }
 
 type newAccountSummary {

--- a/packages/loaders/openapi/tests/__snapshots__/reprod-9106.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/reprod-9106.test.ts.snap
@@ -75,13 +75,13 @@ type Mutation {
   - **Refresh Token**, see [IETF 6749, section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6)
   - **Authorization Code Grant**, see [IETF 6749, section 4.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1).
   """
-  post_token(input: post_token_request_Input): post_token_200_response @httpOperation(subgraph: "test", path: "/token", operationSpecificHeaders: [["Content-Type", "application/json"], ["accept", "application/json"]], httpMethod: POST)
+  post_token(input: post_token_request_Input): post_token_200_response @httpOperation(subgraph: "test", path: "/token", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["accept", "application/json"]], httpMethod: POST)
   """
   Prevent tokens from being further used to access APIs by disposing one or more OAuth tokens that are no longer needed. Basic Authentication is used to access this resource, using the issued client Id and client secret. This resource is based on the *OAuth 2.0 Token Revocation* IETF Draft RFC 7009, August 2013.
   * [IETF 7009](https://datatracker.ietf.org/doc/html/rfc7009).
   
   """
-  post_revoke(input: Token_Revocation_Request_Input): JSON @httpOperation(subgraph: "test", path: "/revoke", operationSpecificHeaders: [["Content-Type", "application/json"], ["accept", "application/json"]], httpMethod: POST)
+  post_revoke(input: Token_Revocation_Request_Input): JSON @httpOperation(subgraph: "test", path: "/revoke", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["accept", "application/json"]], httpMethod: POST)
 }
 
 union post_token_200_response = Provider_specific_Access_Token_Response | Provider_specific_Tokens_Response

--- a/packages/loaders/openapi/tests/__snapshots__/schemas.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/schemas.test.ts.snap
@@ -76375,9 +76375,9 @@ type Query {
   """
   getServiceAccountIssuerOpenIDConfiguration: String @httpOperation(subgraph: "Kubernetes", path: "/.well-known/openid-configuration/", operationSpecificHeaders: [["Accept", "application/json"]], httpMethod: GET)
   """get available API versions"""
-  getCoreAPIVersions: io_k8s_apimachinery_pkg_apis_meta_v1_APIVersions @httpOperation(subgraph: "Kubernetes", path: "/api/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getCoreAPIVersions: io_k8s_apimachinery_pkg_apis_meta_v1_APIVersions @httpOperation(subgraph: "Kubernetes", path: "/api/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getCoreV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/api/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getCoreV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/api/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list objects of kind ComponentStatus"""
   listCoreV1ComponentStatus(
     """
@@ -80373,11 +80373,11 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/api/v1/watch/services", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available API versions"""
-  getAPIVersions: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroupList @httpOperation(subgraph: "Kubernetes", path: "/apis/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAPIVersions: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroupList @httpOperation(subgraph: "Kubernetes", path: "/apis/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get information of a group"""
-  getAdmissionregistrationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAdmissionregistrationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getAdmissionregistrationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAdmissionregistrationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind MutatingWebhookConfiguration"""
   listAdmissionregistrationV1MutatingWebhookConfiguration(
     """If 'true', then the output is pretty printed."""
@@ -80699,9 +80699,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/watch/validatingwebhookconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getApiextensionsAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getApiextensionsAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getApiextensionsV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getApiextensionsV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CustomResourceDefinition"""
   listApiextensionsV1CustomResourceDefinition(
     """If 'true', then the output is pretty printed."""
@@ -80870,9 +80870,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/watch/customresourcedefinitions/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getApiregistrationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getApiregistrationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getApiregistrationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getApiregistrationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind APIService"""
   listApiregistrationV1APIService(
     """If 'true', then the output is pretty printed."""
@@ -81041,9 +81041,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/watch/apiservices/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getAppsAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAppsAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getAppsV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAppsV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind ControllerRevision"""
   listAppsV1ControllerRevisionForAllNamespaces(
     """
@@ -82448,17 +82448,17 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/watch/statefulsets", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getAuthenticationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/authentication.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAuthenticationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/authentication.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getAuthenticationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/authentication.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAuthenticationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/authentication.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get information of a group"""
-  getAuthorizationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/authorization.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAuthorizationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/authorization.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getAuthorizationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/authorization.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAuthorizationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/authorization.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get information of a group"""
-  getAutoscalingAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAutoscalingAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getAutoscalingV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAutoscalingV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind HorizontalPodAutoscaler"""
   listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces(
     """
@@ -82737,7 +82737,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/watch/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getAutoscalingV2beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAutoscalingV2beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind HorizontalPodAutoscaler"""
   listAutoscalingV2beta1HorizontalPodAutoscalerForAllNamespaces(
     """
@@ -83016,7 +83016,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/watch/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getAutoscalingV2beta2APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getAutoscalingV2beta2APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind HorizontalPodAutoscaler"""
   listAutoscalingV2beta2HorizontalPodAutoscalerForAllNamespaces(
     """
@@ -83295,9 +83295,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/watch/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getBatchAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getBatchAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getBatchV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getBatchV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CronJob"""
   listBatchV1CronJobForAllNamespaces(
     """
@@ -83853,7 +83853,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/watch/namespaces/{args.namespace}/jobs/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getBatchV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getBatchV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CronJob"""
   listBatchV1beta1CronJobForAllNamespaces(
     """
@@ -84132,9 +84132,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/watch/namespaces/{args.namespace}/cronjobs/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getCertificatesAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getCertificatesAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getCertificatesV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getCertificatesV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CertificateSigningRequest"""
   listCertificatesV1CertificateSigningRequest(
     """If 'true', then the output is pretty printed."""
@@ -84310,9 +84310,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/watch/certificatesigningrequests/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getCoordinationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getCoordinationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getCoordinationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getCoordinationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind Lease"""
   listCoordinationV1LeaseForAllNamespaces(
     """
@@ -84582,9 +84582,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/v1/watch/namespaces/{args.namespace}/leases/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getDiscoveryAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getDiscoveryAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getDiscoveryV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getDiscoveryV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind EndpointSlice"""
   listDiscoveryV1EndpointSliceForAllNamespaces(
     """
@@ -84854,7 +84854,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1/watch/namespaces/{args.namespace}/endpointslices/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getDiscoveryV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getDiscoveryV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind EndpointSlice"""
   listDiscoveryV1beta1EndpointSliceForAllNamespaces(
     """
@@ -85124,9 +85124,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1beta1/watch/namespaces/{args.namespace}/endpointslices/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getEventsAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getEventsAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getEventsV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getEventsV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind Event"""
   listEventsV1EventForAllNamespaces(
     """
@@ -85396,7 +85396,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1/watch/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getEventsV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getEventsV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind Event"""
   listEventsV1beta1EventForAllNamespaces(
     """
@@ -85666,9 +85666,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1beta1/watch/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getFlowcontrolApiserverAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getFlowcontrolApiserverAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getFlowcontrolApiserverV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getFlowcontrolApiserverV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind FlowSchema"""
   listFlowcontrolApiserverV1beta1FlowSchema(
     """If 'true', then the output is pretty printed."""
@@ -86004,9 +86004,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/watch/prioritylevelconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getInternalApiserverAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getInternalApiserverAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getInternalApiserverV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getInternalApiserverV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind StorageVersion"""
   listInternalApiserverV1alpha1StorageVersion(
     """If 'true', then the output is pretty printed."""
@@ -86175,9 +86175,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/watch/storageversions/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getNetworkingAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getNetworkingAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getNetworkingV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getNetworkingV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind IngressClass"""
   listNetworkingV1IngressClass(
     """If 'true', then the output is pretty printed."""
@@ -86884,9 +86884,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/watch/networkpolicies", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getNodeAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getNodeAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getNodeV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getNodeV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind RuntimeClass"""
   listNodeV1RuntimeClass(
     """If 'true', then the output is pretty printed."""
@@ -87048,7 +87048,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1/watch/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getNodeV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getNodeV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind RuntimeClass"""
   listNodeV1alpha1RuntimeClass(
     """If 'true', then the output is pretty printed."""
@@ -87210,7 +87210,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1alpha1/watch/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getNodeV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getNodeV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind RuntimeClass"""
   listNodeV1beta1RuntimeClass(
     """If 'true', then the output is pretty printed."""
@@ -87372,9 +87372,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1beta1/watch/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getPolicyAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getPolicyAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getPolicyV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getPolicyV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind PodDisruptionBudget"""
   listPolicyV1NamespacedPodDisruptionBudget(
     """object name and auth scope, such as for teams and projects"""
@@ -87653,7 +87653,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/watch/poddisruptionbudgets", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getPolicyV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getPolicyV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind PodDisruptionBudget"""
   listPolicyV1beta1NamespacedPodDisruptionBudget(
     """object name and auth scope, such as for teams and projects"""
@@ -88092,9 +88092,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/watch/podsecuritypolicies/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getRbacAuthorizationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getRbacAuthorizationAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getRbacAuthorizationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getRbacAuthorizationV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind ClusterRoleBinding"""
   listRbacAuthorizationV1ClusterRoleBinding(
     """If 'true', then the output is pretty printed."""
@@ -88952,7 +88952,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/watch/roles", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getRbacAuthorizationV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getRbacAuthorizationV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind ClusterRoleBinding"""
   listRbacAuthorizationV1alpha1ClusterRoleBinding(
     """If 'true', then the output is pretty printed."""
@@ -89810,9 +89810,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/watch/roles", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getSchedulingAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getSchedulingAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getSchedulingV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getSchedulingV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind PriorityClass"""
   listSchedulingV1PriorityClass(
     """If 'true', then the output is pretty printed."""
@@ -89974,7 +89974,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1/watch/priorityclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getSchedulingV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getSchedulingV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind PriorityClass"""
   listSchedulingV1alpha1PriorityClass(
     """If 'true', then the output is pretty printed."""
@@ -90136,9 +90136,9 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1alpha1/watch/priorityclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get information of a group"""
-  getStorageAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getStorageAPIGroup: io_k8s_apimachinery_pkg_apis_meta_v1_APIGroup @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """get available resources"""
-  getStorageV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getStorageV1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CSIDriver"""
   listStorageV1CSIDriver(
     """If 'true', then the output is pretty printed."""
@@ -90787,7 +90787,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/watch/volumeattachments/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getStorageV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getStorageV1alpha1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CSIStorageCapacity"""
   listStorageV1alpha1CSIStorageCapacityForAllNamespaces(
     """
@@ -91217,7 +91217,7 @@ type Query {
     watch: Boolean
   ): io_k8s_apimachinery_pkg_apis_meta_v1_WatchEvent @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/watch/volumeattachments/{args.name}", operationSpecificHeaders: [["Content-Type", "*/*"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch"]], httpMethod: GET, queryParamArgMap: "{\\"allowWatchBookmarks\\":\\"allowWatchBookmarks\\",\\"continue\\":\\"continue\\",\\"fieldSelector\\":\\"fieldSelector\\",\\"labelSelector\\":\\"labelSelector\\",\\"limit\\":\\"limit\\",\\"pretty\\":\\"pretty\\",\\"resourceVersion\\":\\"resourceVersion\\",\\"resourceVersionMatch\\":\\"resourceVersionMatch\\",\\"timeoutSeconds\\":\\"timeoutSeconds\\",\\"watch\\":\\"watch\\"}")
   """get available resources"""
-  getStorageV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json, application/yaml, application/vnd.kubernetes.protobuf"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
+  getStorageV1beta1APIResources: io_k8s_apimachinery_pkg_apis_meta_v1_APIResourceList @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1beta1/", operationSpecificHeaders: [["Content-Type", "application/json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: GET)
   """list or watch objects of kind CSIStorageCapacity"""
   listStorageV1beta1CSIStorageCapacityForAllNamespaces(
     """
@@ -102026,7 +102026,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_ConfigMap @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/configmaps/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_ConfigMap @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/configmaps/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ConfigMap"""
   replaceCoreV1NamespacedConfigMap(
     """object name and auth scope, such as for teams and projects"""
@@ -102171,7 +102171,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Endpoints @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/endpoints/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Endpoints @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/endpoints/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Endpoints"""
   replaceCoreV1NamespacedEndpoints(
     """object name and auth scope, such as for teams and projects"""
@@ -102316,7 +102316,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Event @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Event @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Event"""
   replaceCoreV1NamespacedEvent(
     """object name and auth scope, such as for teams and projects"""
@@ -102461,7 +102461,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_LimitRange @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/limitranges/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_LimitRange @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/limitranges/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified LimitRange"""
   replaceCoreV1NamespacedLimitRange(
     """object name and auth scope, such as for teams and projects"""
@@ -102606,7 +102606,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_PersistentVolumeClaim @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/persistentvolumeclaims/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_PersistentVolumeClaim @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/persistentvolumeclaims/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PersistentVolumeClaim"""
   replaceCoreV1NamespacedPersistentVolumeClaim(
     """object name and auth scope, such as for teams and projects"""
@@ -102648,7 +102648,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_PersistentVolumeClaim @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/persistentvolumeclaims/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_PersistentVolumeClaim @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/persistentvolumeclaims/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified PersistentVolumeClaim"""
   replaceCoreV1NamespacedPersistentVolumeClaimStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -102793,7 +102793,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Pod @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/pods/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Pod @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/pods/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Pod"""
   replaceCoreV1NamespacedPod(
     """object name and auth scope, such as for teams and projects"""
@@ -102881,7 +102881,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Pod @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/pods/{args.name}/ephemeralcontainers", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Pod @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/pods/{args.name}/ephemeralcontainers", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace ephemeralcontainers of the specified Pod"""
   replaceCoreV1NamespacedPodEphemeralcontainers(
     """object name and auth scope, such as for teams and projects"""
@@ -103090,7 +103090,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Pod @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/pods/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Pod @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/pods/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Pod"""
   replaceCoreV1NamespacedPodStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -103235,7 +103235,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_PodTemplate @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/podtemplates/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_PodTemplate @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/podtemplates/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PodTemplate"""
   replaceCoreV1NamespacedPodTemplate(
     """object name and auth scope, such as for teams and projects"""
@@ -103380,7 +103380,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_ReplicationController @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/replicationcontrollers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_ReplicationController @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/replicationcontrollers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ReplicationController"""
   replaceCoreV1NamespacedReplicationController(
     """object name and auth scope, such as for teams and projects"""
@@ -103422,7 +103422,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/replicationcontrollers/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/replicationcontrollers/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace scale of the specified ReplicationController"""
   replaceCoreV1NamespacedReplicationControllerScale(
     """object name and auth scope, such as for teams and projects"""
@@ -103464,7 +103464,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_ReplicationController @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/replicationcontrollers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_ReplicationController @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/replicationcontrollers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified ReplicationController"""
   replaceCoreV1NamespacedReplicationControllerStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -103609,7 +103609,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_ResourceQuota @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/resourcequotas/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_ResourceQuota @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/resourcequotas/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ResourceQuota"""
   replaceCoreV1NamespacedResourceQuota(
     """object name and auth scope, such as for teams and projects"""
@@ -103651,7 +103651,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_ResourceQuota @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/resourcequotas/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_ResourceQuota @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/resourcequotas/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified ResourceQuota"""
   replaceCoreV1NamespacedResourceQuotaStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -103796,7 +103796,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Secret @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/secrets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Secret @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/secrets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Secret"""
   replaceCoreV1NamespacedSecret(
     """object name and auth scope, such as for teams and projects"""
@@ -103941,7 +103941,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_ServiceAccount @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/serviceaccounts/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_ServiceAccount @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/serviceaccounts/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ServiceAccount"""
   replaceCoreV1NamespacedServiceAccount(
     """object name and auth scope, such as for teams and projects"""
@@ -104045,7 +104045,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Service @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/services/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Service @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/services/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Service"""
   replaceCoreV1NamespacedService(
     """object name and auth scope, such as for teams and projects"""
@@ -104219,7 +104219,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Service @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/services/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Service @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.namespace}/services/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Service"""
   replaceCoreV1NamespacedServiceStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -104283,7 +104283,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Namespace @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Namespace @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Namespace"""
   replaceCoreV1Namespace(
     """name of the Namespace"""
@@ -104338,7 +104338,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Namespace @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Namespace @httpOperation(subgraph: "Kubernetes", path: "/api/v1/namespaces/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Namespace"""
   replaceCoreV1NamespaceStatus(
     """name of the Namespace"""
@@ -104473,7 +104473,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Node @httpOperation(subgraph: "Kubernetes", path: "/api/v1/nodes/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Node @httpOperation(subgraph: "Kubernetes", path: "/api/v1/nodes/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Node"""
   replaceCoreV1Node(
     """name of the Node"""
@@ -104595,7 +104595,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_Node @httpOperation(subgraph: "Kubernetes", path: "/api/v1/nodes/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_Node @httpOperation(subgraph: "Kubernetes", path: "/api/v1/nodes/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Node"""
   replaceCoreV1NodeStatus(
     """name of the Node"""
@@ -104730,7 +104730,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_PersistentVolume @httpOperation(subgraph: "Kubernetes", path: "/api/v1/persistentvolumes/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_PersistentVolume @httpOperation(subgraph: "Kubernetes", path: "/api/v1/persistentvolumes/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PersistentVolume"""
   replaceCoreV1PersistentVolume(
     """name of the PersistentVolume"""
@@ -104768,7 +104768,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_core_v1_PersistentVolume @httpOperation(subgraph: "Kubernetes", path: "/api/v1/persistentvolumes/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_core_v1_PersistentVolume @httpOperation(subgraph: "Kubernetes", path: "/api/v1/persistentvolumes/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified PersistentVolume"""
   replaceCoreV1PersistentVolumeStatus(
     """name of the PersistentVolume"""
@@ -104903,7 +104903,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_admissionregistration_v1_MutatingWebhookConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_admissionregistration_v1_MutatingWebhookConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified MutatingWebhookConfiguration"""
   replaceAdmissionregistrationV1MutatingWebhookConfiguration(
     """name of the MutatingWebhookConfiguration"""
@@ -105038,7 +105038,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_admissionregistration_v1_ValidatingWebhookConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_admissionregistration_v1_ValidatingWebhookConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ValidatingWebhookConfiguration"""
   replaceAdmissionregistrationV1ValidatingWebhookConfiguration(
     """name of the ValidatingWebhookConfiguration"""
@@ -105173,7 +105173,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_apiextensions_apiserver_pkg_apis_apiextensions_v1_CustomResourceDefinition @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_apiextensions_apiserver_pkg_apis_apiextensions_v1_CustomResourceDefinition @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CustomResourceDefinition"""
   replaceApiextensionsV1CustomResourceDefinition(
     """name of the CustomResourceDefinition"""
@@ -105211,7 +105211,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_apiextensions_apiserver_pkg_apis_apiextensions_v1_CustomResourceDefinition @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_apiextensions_apiserver_pkg_apis_apiextensions_v1_CustomResourceDefinition @httpOperation(subgraph: "Kubernetes", path: "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified CustomResourceDefinition"""
   replaceApiextensionsV1CustomResourceDefinitionStatus(
     """name of the CustomResourceDefinition"""
@@ -105346,7 +105346,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_kube_aggregator_pkg_apis_apiregistration_v1_APIService @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/apiservices/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_kube_aggregator_pkg_apis_apiregistration_v1_APIService @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/apiservices/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified APIService"""
   replaceApiregistrationV1APIService(
     """name of the APIService"""
@@ -105384,7 +105384,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_kube_aggregator_pkg_apis_apiregistration_v1_APIService @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/apiservices/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_kube_aggregator_pkg_apis_apiregistration_v1_APIService @httpOperation(subgraph: "Kubernetes", path: "/apis/apiregistration.k8s.io/v1/apiservices/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified APIService"""
   replaceApiregistrationV1APIServiceStatus(
     """name of the APIService"""
@@ -105527,7 +105527,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_ControllerRevision @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/controllerrevisions/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_ControllerRevision @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/controllerrevisions/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ControllerRevision"""
   replaceAppsV1NamespacedControllerRevision(
     """object name and auth scope, such as for teams and projects"""
@@ -105672,7 +105672,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_DaemonSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/daemonsets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_DaemonSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/daemonsets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified DaemonSet"""
   replaceAppsV1NamespacedDaemonSet(
     """object name and auth scope, such as for teams and projects"""
@@ -105714,7 +105714,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_DaemonSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/daemonsets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_DaemonSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/daemonsets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified DaemonSet"""
   replaceAppsV1NamespacedDaemonSetStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -105859,7 +105859,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_Deployment @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/deployments/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_Deployment @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/deployments/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Deployment"""
   replaceAppsV1NamespacedDeployment(
     """object name and auth scope, such as for teams and projects"""
@@ -105901,7 +105901,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/deployments/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/deployments/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace scale of the specified Deployment"""
   replaceAppsV1NamespacedDeploymentScale(
     """object name and auth scope, such as for teams and projects"""
@@ -105943,7 +105943,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_Deployment @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/deployments/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_Deployment @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/deployments/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Deployment"""
   replaceAppsV1NamespacedDeploymentStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -106088,7 +106088,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_ReplicaSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/replicasets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_ReplicaSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/replicasets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ReplicaSet"""
   replaceAppsV1NamespacedReplicaSet(
     """object name and auth scope, such as for teams and projects"""
@@ -106130,7 +106130,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/replicasets/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/replicasets/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace scale of the specified ReplicaSet"""
   replaceAppsV1NamespacedReplicaSetScale(
     """object name and auth scope, such as for teams and projects"""
@@ -106172,7 +106172,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_ReplicaSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/replicasets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_ReplicaSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/replicasets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified ReplicaSet"""
   replaceAppsV1NamespacedReplicaSetStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -106317,7 +106317,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_StatefulSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/statefulsets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_StatefulSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/statefulsets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified StatefulSet"""
   replaceAppsV1NamespacedStatefulSet(
     """object name and auth scope, such as for teams and projects"""
@@ -106359,7 +106359,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/statefulsets/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v1_Scale @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/statefulsets/{args.name}/scale", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace scale of the specified StatefulSet"""
   replaceAppsV1NamespacedStatefulSetScale(
     """object name and auth scope, such as for teams and projects"""
@@ -106401,7 +106401,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apps_v1_StatefulSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/statefulsets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apps_v1_StatefulSet @httpOperation(subgraph: "Kubernetes", path: "/apis/apps/v1/namespaces/{args.namespace}/statefulsets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified StatefulSet"""
   replaceAppsV1NamespacedStatefulSetStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -106623,7 +106623,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified HorizontalPodAutoscaler"""
   replaceAutoscalingV1NamespacedHorizontalPodAutoscaler(
     """object name and auth scope, such as for teams and projects"""
@@ -106665,7 +106665,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified HorizontalPodAutoscaler"""
   replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -106810,7 +106810,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v2beta1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v2beta1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified HorizontalPodAutoscaler"""
   replaceAutoscalingV2beta1NamespacedHorizontalPodAutoscaler(
     """object name and auth scope, such as for teams and projects"""
@@ -106852,7 +106852,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v2beta1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v2beta1_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta1/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified HorizontalPodAutoscaler"""
   replaceAutoscalingV2beta1NamespacedHorizontalPodAutoscalerStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -106997,7 +106997,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v2beta2_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v2beta2_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified HorizontalPodAutoscaler"""
   replaceAutoscalingV2beta2NamespacedHorizontalPodAutoscaler(
     """object name and auth scope, such as for teams and projects"""
@@ -107039,7 +107039,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_autoscaling_v2beta2_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_autoscaling_v2beta2_HorizontalPodAutoscaler @httpOperation(subgraph: "Kubernetes", path: "/apis/autoscaling/v2beta2/namespaces/{args.namespace}/horizontalpodautoscalers/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified HorizontalPodAutoscaler"""
   replaceAutoscalingV2beta2NamespacedHorizontalPodAutoscalerStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -107184,7 +107184,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_batch_v1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/cronjobs/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_batch_v1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/cronjobs/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CronJob"""
   replaceBatchV1NamespacedCronJob(
     """object name and auth scope, such as for teams and projects"""
@@ -107226,7 +107226,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_batch_v1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/cronjobs/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_batch_v1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/cronjobs/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified CronJob"""
   replaceBatchV1NamespacedCronJobStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -107371,7 +107371,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_batch_v1_Job @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/jobs/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_batch_v1_Job @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/jobs/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Job"""
   replaceBatchV1NamespacedJob(
     """object name and auth scope, such as for teams and projects"""
@@ -107413,7 +107413,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_batch_v1_Job @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/jobs/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_batch_v1_Job @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1/namespaces/{args.namespace}/jobs/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Job"""
   replaceBatchV1NamespacedJobStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -107558,7 +107558,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_batch_v1beta1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/namespaces/{args.namespace}/cronjobs/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_batch_v1beta1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/namespaces/{args.namespace}/cronjobs/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CronJob"""
   replaceBatchV1beta1NamespacedCronJob(
     """object name and auth scope, such as for teams and projects"""
@@ -107600,7 +107600,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_batch_v1beta1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/namespaces/{args.namespace}/cronjobs/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_batch_v1beta1_CronJob @httpOperation(subgraph: "Kubernetes", path: "/apis/batch/v1beta1/namespaces/{args.namespace}/cronjobs/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified CronJob"""
   replaceBatchV1beta1NamespacedCronJobStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -107737,7 +107737,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_certificates_v1_CertificateSigningRequest @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_certificates_v1_CertificateSigningRequest @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CertificateSigningRequest"""
   replaceCertificatesV1CertificateSigningRequest(
     """name of the CertificateSigningRequest"""
@@ -107775,7 +107775,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_certificates_v1_CertificateSigningRequest @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/{args.name}/approval", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_certificates_v1_CertificateSigningRequest @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/{args.name}/approval", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace approval of the specified CertificateSigningRequest"""
   replaceCertificatesV1CertificateSigningRequestApproval(
     """name of the CertificateSigningRequest"""
@@ -107813,7 +107813,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_certificates_v1_CertificateSigningRequest @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_certificates_v1_CertificateSigningRequest @httpOperation(subgraph: "Kubernetes", path: "/apis/certificates.k8s.io/v1/certificatesigningrequests/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified CertificateSigningRequest"""
   replaceCertificatesV1CertificateSigningRequestStatus(
     """name of the CertificateSigningRequest"""
@@ -107956,7 +107956,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_coordination_v1_Lease @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/v1/namespaces/{args.namespace}/leases/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_coordination_v1_Lease @httpOperation(subgraph: "Kubernetes", path: "/apis/coordination.k8s.io/v1/namespaces/{args.namespace}/leases/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Lease"""
   replaceCoordinationV1NamespacedLease(
     """object name and auth scope, such as for teams and projects"""
@@ -108101,7 +108101,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_discovery_v1_EndpointSlice @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1/namespaces/{args.namespace}/endpointslices/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_discovery_v1_EndpointSlice @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1/namespaces/{args.namespace}/endpointslices/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified EndpointSlice"""
   replaceDiscoveryV1NamespacedEndpointSlice(
     """object name and auth scope, such as for teams and projects"""
@@ -108246,7 +108246,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_discovery_v1beta1_EndpointSlice @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1beta1/namespaces/{args.namespace}/endpointslices/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_discovery_v1beta1_EndpointSlice @httpOperation(subgraph: "Kubernetes", path: "/apis/discovery.k8s.io/v1beta1/namespaces/{args.namespace}/endpointslices/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified EndpointSlice"""
   replaceDiscoveryV1beta1NamespacedEndpointSlice(
     """object name and auth scope, such as for teams and projects"""
@@ -108391,7 +108391,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_events_v1_Event @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_events_v1_Event @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Event"""
   replaceEventsV1NamespacedEvent(
     """object name and auth scope, such as for teams and projects"""
@@ -108536,7 +108536,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_events_v1beta1_Event @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1beta1/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_events_v1beta1_Event @httpOperation(subgraph: "Kubernetes", path: "/apis/events.k8s.io/v1beta1/namespaces/{args.namespace}/events/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Event"""
   replaceEventsV1beta1NamespacedEvent(
     """object name and auth scope, such as for teams and projects"""
@@ -108673,7 +108673,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_flowcontrol_v1beta1_FlowSchema @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_flowcontrol_v1beta1_FlowSchema @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified FlowSchema"""
   replaceFlowcontrolApiserverV1beta1FlowSchema(
     """name of the FlowSchema"""
@@ -108711,7 +108711,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_flowcontrol_v1beta1_FlowSchema @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_flowcontrol_v1beta1_FlowSchema @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified FlowSchema"""
   replaceFlowcontrolApiserverV1beta1FlowSchemaStatus(
     """name of the FlowSchema"""
@@ -108846,7 +108846,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_flowcontrol_v1beta1_PriorityLevelConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_flowcontrol_v1beta1_PriorityLevelConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PriorityLevelConfiguration"""
   replaceFlowcontrolApiserverV1beta1PriorityLevelConfiguration(
     """name of the PriorityLevelConfiguration"""
@@ -108884,7 +108884,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_flowcontrol_v1beta1_PriorityLevelConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_flowcontrol_v1beta1_PriorityLevelConfiguration @httpOperation(subgraph: "Kubernetes", path: "/apis/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified PriorityLevelConfiguration"""
   replaceFlowcontrolApiserverV1beta1PriorityLevelConfigurationStatus(
     """name of the PriorityLevelConfiguration"""
@@ -109019,7 +109019,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apiserverinternal_v1alpha1_StorageVersion @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apiserverinternal_v1alpha1_StorageVersion @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified StorageVersion"""
   replaceInternalApiserverV1alpha1StorageVersion(
     """name of the StorageVersion"""
@@ -109057,7 +109057,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_apiserverinternal_v1alpha1_StorageVersion @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_apiserverinternal_v1alpha1_StorageVersion @httpOperation(subgraph: "Kubernetes", path: "/apis/internal.apiserver.k8s.io/v1alpha1/storageversions/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified StorageVersion"""
   replaceInternalApiserverV1alpha1StorageVersionStatus(
     """name of the StorageVersion"""
@@ -109192,7 +109192,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_networking_v1_IngressClass @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/ingressclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_networking_v1_IngressClass @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/ingressclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified IngressClass"""
   replaceNetworkingV1IngressClass(
     """name of the IngressClass"""
@@ -109335,7 +109335,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_networking_v1_Ingress @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/namespaces/{args.namespace}/ingresses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_networking_v1_Ingress @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/namespaces/{args.namespace}/ingresses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Ingress"""
   replaceNetworkingV1NamespacedIngress(
     """object name and auth scope, such as for teams and projects"""
@@ -109377,7 +109377,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_networking_v1_Ingress @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/namespaces/{args.namespace}/ingresses/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_networking_v1_Ingress @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/namespaces/{args.namespace}/ingresses/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified Ingress"""
   replaceNetworkingV1NamespacedIngressStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -109522,7 +109522,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_networking_v1_NetworkPolicy @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/namespaces/{args.namespace}/networkpolicies/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_networking_v1_NetworkPolicy @httpOperation(subgraph: "Kubernetes", path: "/apis/networking.k8s.io/v1/namespaces/{args.namespace}/networkpolicies/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified NetworkPolicy"""
   replaceNetworkingV1NamespacedNetworkPolicy(
     """object name and auth scope, such as for teams and projects"""
@@ -109659,7 +109659,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_node_v1_RuntimeClass @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_node_v1_RuntimeClass @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified RuntimeClass"""
   replaceNodeV1RuntimeClass(
     """name of the RuntimeClass"""
@@ -109794,7 +109794,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_node_v1alpha1_RuntimeClass @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1alpha1/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_node_v1alpha1_RuntimeClass @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1alpha1/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified RuntimeClass"""
   replaceNodeV1alpha1RuntimeClass(
     """name of the RuntimeClass"""
@@ -109929,7 +109929,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_node_v1beta1_RuntimeClass @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1beta1/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_node_v1beta1_RuntimeClass @httpOperation(subgraph: "Kubernetes", path: "/apis/node.k8s.io/v1beta1/runtimeclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified RuntimeClass"""
   replaceNodeV1beta1RuntimeClass(
     """name of the RuntimeClass"""
@@ -110072,7 +110072,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_policy_v1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_policy_v1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PodDisruptionBudget"""
   replacePolicyV1NamespacedPodDisruptionBudget(
     """object name and auth scope, such as for teams and projects"""
@@ -110114,7 +110114,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_policy_v1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_policy_v1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified PodDisruptionBudget"""
   replacePolicyV1NamespacedPodDisruptionBudgetStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -110259,7 +110259,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_policy_v1beta1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_policy_v1beta1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PodDisruptionBudget"""
   replacePolicyV1beta1NamespacedPodDisruptionBudget(
     """object name and auth scope, such as for teams and projects"""
@@ -110301,7 +110301,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_policy_v1beta1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_policy_v1beta1_PodDisruptionBudget @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/namespaces/{args.namespace}/poddisruptionbudgets/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified PodDisruptionBudget"""
   replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus(
     """object name and auth scope, such as for teams and projects"""
@@ -110438,7 +110438,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_policy_v1beta1_PodSecurityPolicy @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/podsecuritypolicies/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_policy_v1beta1_PodSecurityPolicy @httpOperation(subgraph: "Kubernetes", path: "/apis/policy/v1beta1/podsecuritypolicies/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PodSecurityPolicy"""
   replacePolicyV1beta1PodSecurityPolicy(
     """name of the PodSecurityPolicy"""
@@ -110573,7 +110573,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1_ClusterRoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1_ClusterRoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ClusterRoleBinding"""
   replaceRbacAuthorizationV1ClusterRoleBinding(
     """name of the ClusterRoleBinding"""
@@ -110708,7 +110708,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1_ClusterRole @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/clusterroles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1_ClusterRole @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/clusterroles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ClusterRole"""
   replaceRbacAuthorizationV1ClusterRole(
     """name of the ClusterRole"""
@@ -110851,7 +110851,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1_RoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/namespaces/{args.namespace}/rolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1_RoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/namespaces/{args.namespace}/rolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified RoleBinding"""
   replaceRbacAuthorizationV1NamespacedRoleBinding(
     """object name and auth scope, such as for teams and projects"""
@@ -110996,7 +110996,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1_Role @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/namespaces/{args.namespace}/roles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1_Role @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1/namespaces/{args.namespace}/roles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Role"""
   replaceRbacAuthorizationV1NamespacedRole(
     """object name and auth scope, such as for teams and projects"""
@@ -111133,7 +111133,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1alpha1_ClusterRoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1alpha1_ClusterRoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ClusterRoleBinding"""
   replaceRbacAuthorizationV1alpha1ClusterRoleBinding(
     """name of the ClusterRoleBinding"""
@@ -111268,7 +111268,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1alpha1_ClusterRole @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1alpha1_ClusterRole @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified ClusterRole"""
   replaceRbacAuthorizationV1alpha1ClusterRole(
     """name of the ClusterRole"""
@@ -111411,7 +111411,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1alpha1_RoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{args.namespace}/rolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1alpha1_RoleBinding @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{args.namespace}/rolebindings/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified RoleBinding"""
   replaceRbacAuthorizationV1alpha1NamespacedRoleBinding(
     """object name and auth scope, such as for teams and projects"""
@@ -111556,7 +111556,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_rbac_v1alpha1_Role @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{args.namespace}/roles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_rbac_v1alpha1_Role @httpOperation(subgraph: "Kubernetes", path: "/apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{args.namespace}/roles/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified Role"""
   replaceRbacAuthorizationV1alpha1NamespacedRole(
     """object name and auth scope, such as for teams and projects"""
@@ -111693,7 +111693,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_scheduling_v1_PriorityClass @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1/priorityclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_scheduling_v1_PriorityClass @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1/priorityclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PriorityClass"""
   replaceSchedulingV1PriorityClass(
     """name of the PriorityClass"""
@@ -111828,7 +111828,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_scheduling_v1alpha1_PriorityClass @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_scheduling_v1alpha1_PriorityClass @httpOperation(subgraph: "Kubernetes", path: "/apis/scheduling.k8s.io/v1alpha1/priorityclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified PriorityClass"""
   replaceSchedulingV1alpha1PriorityClass(
     """name of the PriorityClass"""
@@ -111963,7 +111963,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1_CSIDriver @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/csidrivers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1_CSIDriver @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/csidrivers/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CSIDriver"""
   replaceStorageV1CSIDriver(
     """name of the CSIDriver"""
@@ -112098,7 +112098,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1_CSINode @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/csinodes/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1_CSINode @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/csinodes/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CSINode"""
   replaceStorageV1CSINode(
     """name of the CSINode"""
@@ -112233,7 +112233,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1_StorageClass @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/storageclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1_StorageClass @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/storageclasses/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified StorageClass"""
   replaceStorageV1StorageClass(
     """name of the StorageClass"""
@@ -112368,7 +112368,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1_VolumeAttachment @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/volumeattachments/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1_VolumeAttachment @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/volumeattachments/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified VolumeAttachment"""
   replaceStorageV1VolumeAttachment(
     """name of the VolumeAttachment"""
@@ -112406,7 +112406,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1_VolumeAttachment @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/volumeattachments/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1_VolumeAttachment @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1/volumeattachments/{args.name}/status", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace status of the specified VolumeAttachment"""
   replaceStorageV1VolumeAttachmentStatus(
     """name of the VolumeAttachment"""
@@ -112549,7 +112549,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1alpha1_CSIStorageCapacity @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/namespaces/{args.namespace}/csistoragecapacities/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1alpha1_CSIStorageCapacity @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/namespaces/{args.namespace}/csistoragecapacities/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CSIStorageCapacity"""
   replaceStorageV1alpha1NamespacedCSIStorageCapacity(
     """object name and auth scope, such as for teams and projects"""
@@ -112686,7 +112686,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1alpha1_VolumeAttachment @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/volumeattachments/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1alpha1_VolumeAttachment @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1alpha1/volumeattachments/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified VolumeAttachment"""
   replaceStorageV1alpha1VolumeAttachment(
     """name of the VolumeAttachment"""
@@ -112829,7 +112829,7 @@ type Mutation {
     force: Boolean
     input: JSON
     body: JSON!
-  ): io_k8s_api_storage_v1beta1_CSIStorageCapacity @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1beta1/namespaces/{args.namespace}/csistoragecapacities/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json, application/apply-patch+yaml"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
+  ): io_k8s_api_storage_v1beta1_CSIStorageCapacity @httpOperation(subgraph: "Kubernetes", path: "/apis/storage.k8s.io/v1beta1/namespaces/{args.namespace}/csistoragecapacities/{args.name}", operationSpecificHeaders: [["Content-Type", "application/json-patch+json"], ["Accept", "application/json, application/yaml, application/vnd.kubernetes.protobuf"]], httpMethod: PATCH, queryParamArgMap: "{\\"pretty\\":\\"pretty\\",\\"dryRun\\":\\"dryRun\\",\\"fieldManager\\":\\"fieldManager\\",\\"force\\":\\"force\\"}")
   """replace the specified CSIStorageCapacity"""
   replaceStorageV1beta1NamespacedCSIStorageCapacity(
     """object name and auth scope, such as for teams and projects"""
@@ -124444,7 +124444,7 @@ type Query {
     token: String!
     """The channel to get preferences for."""
     channel_id: String!
-  ): admin_conversations_getConversationPrefs_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.getConversationPrefs", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"channel_id\\":\\"channel_id\\"}")
+  ): admin_conversations_getConversationPrefs_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.getConversationPrefs", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"channel_id\\":\\"channel_id\\"}")
   """
   Get all the workspaces a given public or private channel is connected to within this Enterprise org.
   """
@@ -124463,7 +124463,7 @@ type Query {
     The maximum number of items to return. Must be between 1 - 1000 both inclusive.
     """
     limit: Int
-  ): admin_conversations_getTeams_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.getTeams", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"channel_id\\":\\"channel_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
+  ): admin_conversations_getTeams_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.getTeams", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"channel_id\\":\\"channel_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
   """List all IDP Groups linked to a channel"""
   admin_conversations_restrictAccess_listGroups(
     """Authentication token. Requires scope: \`admin.conversations:read\`"""
@@ -124504,7 +124504,7 @@ type Query {
     Sort direction. Possible values are \`asc\` for ascending order like (1, 2, 3) or (a, b, c), and \`desc\` for descending order like (3, 2, 1) or (c, b, a)
     """
     sort_dir: String
-  ): admin_conversations_search_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.search", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_ids\\":\\"team_ids\\",\\"query\\":\\"query\\",\\"limit\\":\\"limit\\",\\"cursor\\":\\"cursor\\",\\"search_channel_types\\":\\"search_channel_types\\",\\"sort\\":\\"sort\\",\\"sort_dir\\":\\"sort_dir\\"}")
+  ): admin_conversations_search_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.search", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_ids\\":\\"team_ids\\",\\"query\\":\\"query\\",\\"limit\\":\\"limit\\",\\"cursor\\":\\"cursor\\",\\"search_channel_types\\":\\"search_channel_types\\",\\"sort\\":\\"sort\\",\\"sort_dir\\":\\"sort_dir\\"}")
   """List emoji for an Enterprise Grid organization."""
   admin_emoji_list(
     """Authentication token. Requires scope: \`admin.teams:read\`"""
@@ -124532,7 +124532,7 @@ type Query {
     The number of results that will be returned by the API on each invocation. Must be between 1 - 1000, both inclusive
     """
     limit: Int
-  ): admin_inviteRequests_approved_list_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.approved.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
+  ): admin_inviteRequests_approved_list_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.approved.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
   """List all denied workspace invite requests."""
   admin_inviteRequests_denied_list(
     """Authentication token. Requires scope: \`admin.invites:read\`"""
@@ -124547,7 +124547,7 @@ type Query {
     The number of results that will be returned by the API on each invocation. Must be between 1 - 1000 both inclusive
     """
     limit: Int
-  ): admin_inviteRequests_denied_list_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.denied.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
+  ): admin_inviteRequests_denied_list_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.denied.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
   """List all pending workspace invite requests."""
   admin_inviteRequests_list(
     """Authentication token. Requires scope: \`admin.invites:read\`"""
@@ -124562,7 +124562,7 @@ type Query {
     The number of results that will be returned by the API on each invocation. Must be between 1 - 1000, both inclusive
     """
     limit: Int
-  ): admin_inviteRequests_list_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
+  ): admin_inviteRequests_list_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
   """List all of the admins on a given workspace."""
   admin_teams_admins_list(
     """Authentication token. Requires scope: \`admin.teams:read\`"""
@@ -124587,7 +124587,7 @@ type Query {
     Set \`cursor\` to \`next_cursor\` returned by the previous call to list items in the next page.
     """
     cursor: String
-  ): admin_teams_list_response @httpOperation(subgraph: "Slack", path: "/admin.teams.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"limit\\":\\"limit\\",\\"cursor\\":\\"cursor\\"}")
+  ): admin_teams_list_response @httpOperation(subgraph: "Slack", path: "/admin.teams.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"limit\\":\\"limit\\",\\"cursor\\":\\"cursor\\"}")
   """List all of the owners on a given workspace."""
   admin_teams_owners_list(
     """Authentication token. Requires scope: \`admin.teams:read\`"""
@@ -124607,7 +124607,7 @@ type Query {
     """Authentication token. Requires scope: \`admin.teams:read\`"""
     token: String!
     team_id: String!
-  ): admin_teams_settings_info_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.info", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\"}")
+  ): admin_teams_settings_info_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.info", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\"}")
   """List the channels linked to an org-level IDP group (user group)."""
   admin_usergroups_listChannels(
     """Authentication token. Requires scope: \`admin.usergroups:read\`"""
@@ -124618,7 +124618,7 @@ type Query {
     team_id: String
     """Flag to include or exclude the count of members per channel."""
     include_num_members: Boolean
-  ): admin_usergroups_listChannels_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.listChannels", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"usergroup_id\\":\\"usergroup_id\\",\\"team_id\\":\\"team_id\\",\\"include_num_members\\":\\"include_num_members\\"}")
+  ): admin_usergroups_listChannels_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.listChannels", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"usergroup_id\\":\\"usergroup_id\\",\\"team_id\\":\\"team_id\\",\\"include_num_members\\":\\"include_num_members\\"}")
   """List users on a workspace"""
   admin_users_list(
     """Authentication token. Requires scope: \`admin.users:read\`"""
@@ -124631,14 +124631,14 @@ type Query {
     cursor: String
     """Limit for how many users to be retrieved per page"""
     limit: Int
-  ): admin_users_list_response @httpOperation(subgraph: "Slack", path: "/admin.users.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
+  ): admin_users_list_response @httpOperation(subgraph: "Slack", path: "/admin.users.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"team_id\\":\\"team_id\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
   """Checks API calling code."""
   api_test(
     """Error response to return"""
     error: String
     """example property to return"""
     foo: String
-  ): api_test_response @httpOperation(subgraph: "Slack", path: "/api.test", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"error\\":\\"error\\",\\"foo\\":\\"foo\\"}")
+  ): api_test_response @httpOperation(subgraph: "Slack", path: "/api.test", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"error\\":\\"error\\",\\"foo\\":\\"foo\\"}")
   """
   Get a list of authorizations for the given event context. Each authorization represents an app installation that the event is visible to.
   """
@@ -124648,7 +124648,7 @@ type Query {
     event_context: String!
     cursor: String
     limit: Int
-  ): apps_event_authorizations_list_response @httpOperation(subgraph: "Slack", path: "/apps.event.authorizations.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"event_context\\":\\"event_context\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
+  ): apps_event_authorizations_list_response @httpOperation(subgraph: "Slack", path: "/apps.event.authorizations.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"event_context\\":\\"event_context\\",\\"cursor\\":\\"cursor\\",\\"limit\\":\\"limit\\"}")
   """Returns list of permissions this app has on a team."""
   apps_permissions_info(
     """Authentication token. Requires scope: \`none\`"""
@@ -124701,7 +124701,7 @@ type Query {
   auth_test(
     """Authentication token. Requires scope: \`none\`"""
     token: String!
-  ): auth_test_response @httpOperation(subgraph: "Slack", path: "/auth.test", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET)
+  ): auth_test_response @httpOperation(subgraph: "Slack", path: "/auth.test", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET)
   """Gets information about a bot user."""
   bots_info(
     """Authentication token. Requires scope: \`users:read\`"""
@@ -124717,7 +124717,7 @@ type Query {
     \`id\` of the Call returned by the [\`calls.add\`](/methods/calls.add) method.
     """
     id: String!
-  ): calls_info_response @httpOperation(subgraph: "Slack", path: "/calls.info", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"id\\":\\"id\\"}")
+  ): calls_info_response @httpOperation(subgraph: "Slack", path: "/calls.info", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"id\\":\\"id\\"}")
   """Retrieve a permalink URL for a specific extant message"""
   chat_getPermalink(
     """Authentication token. Requires scope: \`none\`"""
@@ -124743,7 +124743,7 @@ type Query {
     For pagination purposes, this is the \`cursor\` value returned from a previous call to \`chat.scheduledmessages.list\` indicating where you want to start this call from.
     """
     cursor: String
-  ): chat_scheduledMessages_list_response @httpOperation(subgraph: "Slack", path: "/chat.scheduledMessages.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"channel\\":\\"channel\\",\\"latest\\":\\"latest\\",\\"oldest\\":\\"oldest\\",\\"limit\\":\\"limit\\",\\"cursor\\":\\"cursor\\"}")
+  ): chat_scheduledMessages_list_response @httpOperation(subgraph: "Slack", path: "/chat.scheduledMessages.list", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"channel\\":\\"channel\\",\\"latest\\":\\"latest\\",\\"oldest\\":\\"oldest\\",\\"limit\\":\\"limit\\",\\"cursor\\":\\"cursor\\"}")
   """Fetches a conversation's history of messages and events."""
   conversations_history(
     """Authentication token. Requires scope: \`conversations:history\`"""
@@ -124851,7 +124851,7 @@ type Query {
     dialog: String!
     """Exchange a trigger to post to the user."""
     trigger_id: String!
-  ): dialog_open_response @httpOperation(subgraph: "Slack", path: "/dialog.open", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"dialog\\":\\"dialog\\",\\"trigger_id\\":\\"trigger_id\\"}")
+  ): dialog_open_response @httpOperation(subgraph: "Slack", path: "/dialog.open", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"dialog\\":\\"dialog\\",\\"trigger_id\\":\\"trigger_id\\"}")
   """Retrieves a user's current Do Not Disturb status."""
   dnd_info(
     """Authentication token. Requires scope: \`dnd:read\`"""
@@ -125259,7 +125259,7 @@ type Query {
     A [view payload](/reference/surfaces/views). This must be a JSON-encoded string.
     """
     view: String!
-  ): views_open_response @httpOperation(subgraph: "Slack", path: "/views.open", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"trigger_id\\":\\"trigger_id\\",\\"view\\":\\"view\\"}")
+  ): views_open_response @httpOperation(subgraph: "Slack", path: "/views.open", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"trigger_id\\":\\"trigger_id\\",\\"view\\":\\"view\\"}")
   """Publish a static view for a User."""
   views_publish(
     """Authentication token. Requires scope: \`none\`"""
@@ -125274,7 +125274,7 @@ type Query {
     A string that represents view state to protect against possible race conditions.
     """
     hash: String
-  ): views_publish_response @httpOperation(subgraph: "Slack", path: "/views.publish", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"user_id\\":\\"user_id\\",\\"view\\":\\"view\\",\\"hash\\":\\"hash\\"}")
+  ): views_publish_response @httpOperation(subgraph: "Slack", path: "/views.publish", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"user_id\\":\\"user_id\\",\\"view\\":\\"view\\",\\"hash\\":\\"hash\\"}")
   """Push a view onto the stack of a root view."""
   views_push(
     """Authentication token. Requires scope: \`none\`"""
@@ -125285,7 +125285,7 @@ type Query {
     A [view payload](/reference/surfaces/views). This must be a JSON-encoded string.
     """
     view: String!
-  ): views_push_response @httpOperation(subgraph: "Slack", path: "/views.push", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"trigger_id\\":\\"trigger_id\\",\\"view\\":\\"view\\"}")
+  ): views_push_response @httpOperation(subgraph: "Slack", path: "/views.push", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"trigger_id\\":\\"trigger_id\\",\\"view\\":\\"view\\"}")
   """Update an existing view."""
   views_update(
     """Authentication token. Requires scope: \`none\`"""
@@ -125306,7 +125306,7 @@ type Query {
     A string that represents view state to protect against possible race conditions.
     """
     hash: String
-  ): views_update_response @httpOperation(subgraph: "Slack", path: "/views.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"view_id\\":\\"view_id\\",\\"external_id\\":\\"external_id\\",\\"view\\":\\"view\\",\\"hash\\":\\"hash\\"}")
+  ): views_update_response @httpOperation(subgraph: "Slack", path: "/views.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"view_id\\":\\"view_id\\",\\"external_id\\":\\"external_id\\",\\"view\\":\\"view\\",\\"hash\\":\\"hash\\"}")
   """Indicate that an app's step in a workflow completed execution."""
   workflows_stepCompleted(
     """Authentication token. Requires scope: \`workflow.steps:execute\`"""
@@ -125317,7 +125317,7 @@ type Query {
     Key-value object of outputs from your step. Keys of this object reflect the configured \`key\` properties of your [\`outputs\`](/reference/workflows/workflow_step#output) array from your \`workflow_step\` object.
     """
     outputs: String
-  ): workflows_stepCompleted_response @httpOperation(subgraph: "Slack", path: "/workflows.stepCompleted", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"workflow_step_execute_id\\":\\"workflow_step_execute_id\\",\\"outputs\\":\\"outputs\\"}")
+  ): workflows_stepCompleted_response @httpOperation(subgraph: "Slack", path: "/workflows.stepCompleted", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"workflow_step_execute_id\\":\\"workflow_step_execute_id\\",\\"outputs\\":\\"outputs\\"}")
   """Indicate that an app's step in a workflow failed to execute."""
   workflows_stepFailed(
     """Authentication token. Requires scope: \`workflow.steps:execute\`"""
@@ -125328,7 +125328,7 @@ type Query {
     A JSON-based object with a \`message\` property that should contain a human readable error message.
     """
     error: String!
-  ): workflows_stepFailed_response @httpOperation(subgraph: "Slack", path: "/workflows.stepFailed", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"workflow_step_execute_id\\":\\"workflow_step_execute_id\\",\\"error\\":\\"error\\"}")
+  ): workflows_stepFailed_response @httpOperation(subgraph: "Slack", path: "/workflows.stepFailed", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"workflow_step_execute_id\\":\\"workflow_step_execute_id\\",\\"error\\":\\"error\\"}")
   """Update the configuration for a workflow extension step."""
   workflows_updateStep(
     """Authentication token. Requires scope: \`workflow.steps:execute\`"""
@@ -125353,7 +125353,7 @@ type Query {
     An optional field that can be used to override app image that is shown in the Workflow Builder.
     """
     step_image_url: String
-  ): workflows_updateStep_response @httpOperation(subgraph: "Slack", path: "/workflows.updateStep", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"workflow_step_edit_id\\":\\"workflow_step_edit_id\\",\\"inputs\\":\\"inputs\\",\\"outputs\\":\\"outputs\\",\\"step_name\\":\\"step_name\\",\\"step_image_url\\":\\"step_image_url\\"}")
+  ): workflows_updateStep_response @httpOperation(subgraph: "Slack", path: "/workflows.updateStep", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: GET, queryParamArgMap: "{\\"workflow_step_edit_id\\":\\"workflow_step_edit_id\\",\\"inputs\\":\\"inputs\\",\\"outputs\\":\\"outputs\\",\\"step_name\\":\\"step_name\\",\\"step_image_url\\":\\"step_image_url\\"}")
 }
 
 union admin_apps_approved_list_response @statusCodeTypeName(subgraph: "Slack", statusCode: "200", typeName: "Default_success_template") @statusCodeTypeName(subgraph: "Slack", statusCode: "default", typeName: "Default_error_template") = Default_success_template | Default_error_template
@@ -128285,57 +128285,57 @@ type Mutation {
   admin_apps_approve(
     """Authentication token. Requires scope: \`admin.apps:write\`"""
     token: String!
-  ): admin_apps_approve_response @httpOperation(subgraph: "Slack", path: "/admin.apps.approve", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_apps_approve_response @httpOperation(subgraph: "Slack", path: "/admin.apps.approve", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Restrict an app for installation on a workspace."""
   admin_apps_restrict(
     """Authentication token. Requires scope: \`admin.apps:write\`"""
     token: String!
-  ): admin_apps_restrict_response @httpOperation(subgraph: "Slack", path: "/admin.apps.restrict", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_apps_restrict_response @httpOperation(subgraph: "Slack", path: "/admin.apps.restrict", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Archive a public or private channel."""
   admin_conversations_archive(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
-  ): admin_conversations_archive_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.archive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_archive_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.archive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Convert a public channel to a private channel."""
   admin_conversations_convertToPrivate(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
-  ): admin_conversations_convertToPrivate_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.convertToPrivate", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_convertToPrivate_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.convertToPrivate", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Create a public or private channel-based conversation."""
   admin_conversations_create(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     name: JSON!
     is_private: JSON!
-  ): admin_conversations_create_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_create_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Delete a public or private channel."""
   admin_conversations_delete(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
-  ): admin_conversations_delete_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_delete_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Disconnect a connected channel from one or more workspaces."""
   admin_conversations_disconnectShared(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
-  ): admin_conversations_disconnectShared_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.disconnectShared", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_disconnectShared_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.disconnectShared", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Invite a user to a public or private channel."""
   admin_conversations_invite(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     user_ids: JSON!
     channel_id: JSON!
-  ): admin_conversations_invite_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.invite", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_invite_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.invite", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Rename a public or private channel."""
   admin_conversations_rename(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
     name: JSON!
-  ): admin_conversations_rename_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.rename", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_rename_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.rename", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Add an allowlist of IDP groups for accessing a channel"""
   admin_conversations_restrictAccess_addGroup: admin_conversations_restrictAccess_addGroup_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.restrictAccess.addGroup", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Remove a linked IDP group linked from a private channel"""
@@ -128346,7 +128346,7 @@ type Mutation {
     token: String!
     channel_id: JSON!
     prefs: JSON!
-  ): admin_conversations_setConversationPrefs_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.setConversationPrefs", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_setConversationPrefs_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.setConversationPrefs", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """
   Set the workspaces in an Enterprise grid org that connect to a public or private channel.
   """
@@ -128354,13 +128354,13 @@ type Mutation {
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
-  ): admin_conversations_setTeams_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.setTeams", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_setTeams_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.setTeams", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Unarchive a public or private channel."""
   admin_conversations_unarchive(
     """Authentication token. Requires scope: \`admin.conversations:write\`"""
     token: String!
     channel_id: JSON!
-  ): admin_conversations_unarchive_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.unarchive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_conversations_unarchive_response @httpOperation(subgraph: "Slack", path: "/admin.conversations.unarchive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Add an emoji."""
   admin_emoji_add: admin_emoji_add_response @httpOperation(subgraph: "Slack", path: "/admin.emoji.add", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Add an emoji alias."""
@@ -128374,20 +128374,20 @@ type Mutation {
     """Authentication token. Requires scope: \`admin.invites:write\`"""
     token: String!
     invite_request_id: JSON!
-  ): admin_inviteRequests_approve_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.approve", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_inviteRequests_approve_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.approve", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Deny a workspace invite request."""
   admin_inviteRequests_deny(
     """Authentication token. Requires scope: \`admin.invites:write\`"""
     token: String!
     invite_request_id: JSON!
-  ): admin_inviteRequests_deny_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.deny", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_inviteRequests_deny_response @httpOperation(subgraph: "Slack", path: "/admin.inviteRequests.deny", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Create an Enterprise team."""
   admin_teams_create(
     """Authentication token. Requires scope: \`admin.teams:write\`"""
     token: String!
     team_domain: JSON!
     team_name: JSON!
-  ): admin_teams_create_response @httpOperation(subgraph: "Slack", path: "/admin.teams.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_teams_create_response @httpOperation(subgraph: "Slack", path: "/admin.teams.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set the default channels of a workspace."""
   admin_teams_settings_setDefaultChannels: admin_teams_settings_setDefaultChannels_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setDefaultChannels", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set the description of a given workspace."""
@@ -128396,7 +128396,7 @@ type Mutation {
     token: String!
     team_id: JSON!
     description: JSON!
-  ): admin_teams_settings_setDescription_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setDescription", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_teams_settings_setDescription_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setDescription", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """
   An API method that allows admins to set the discoverability of a given workspace
   """
@@ -128405,7 +128405,7 @@ type Mutation {
     token: String!
     team_id: JSON!
     discoverability: JSON!
-  ): admin_teams_settings_setDiscoverability_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setDiscoverability", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_teams_settings_setDiscoverability_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setDiscoverability", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Sets the icon of a workspace."""
   admin_teams_settings_setIcon: admin_teams_settings_setIcon_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setIcon", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set the name of a given workspace."""
@@ -128414,14 +128414,14 @@ type Mutation {
     token: String!
     team_id: JSON!
     name: JSON!
-  ): admin_teams_settings_setName_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setName", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_teams_settings_setName_response @httpOperation(subgraph: "Slack", path: "/admin.teams.settings.setName", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Add one or more default channels to an IDP group."""
   admin_usergroups_addChannels(
     """Authentication token. Requires scope: \`admin.usergroups:write\`"""
     token: String!
     usergroup_id: JSON!
     channel_ids: JSON!
-  ): admin_usergroups_addChannels_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.addChannels", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_usergroups_addChannels_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.addChannels", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """
   Associate one or more default workspaces with an organization-wide IDP group.
   """
@@ -128430,7 +128430,7 @@ type Mutation {
     token: String!
     usergroup_id: JSON!
     team_ids: JSON!
-  ): admin_usergroups_addTeams_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.addTeams", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_usergroups_addTeams_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.addTeams", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """
   Remove one or more default channels from an org-level IDP group (user group).
   """
@@ -128439,14 +128439,14 @@ type Mutation {
     token: String!
     usergroup_id: JSON!
     channel_ids: JSON!
-  ): admin_usergroups_removeChannels_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.removeChannels", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_usergroups_removeChannels_response @httpOperation(subgraph: "Slack", path: "/admin.usergroups.removeChannels", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Add an Enterprise user to a workspace."""
   admin_users_assign(
     """Authentication token. Requires scope: \`admin.users:write\`"""
     token: String!
     team_id: JSON!
     user_id: JSON!
-  ): admin_users_assign_response @httpOperation(subgraph: "Slack", path: "/admin.users.assign", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_assign_response @httpOperation(subgraph: "Slack", path: "/admin.users.assign", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Invite a user to a workspace."""
   admin_users_invite(
     """Authentication token. Requires scope: \`admin.users:write\`"""
@@ -128454,34 +128454,34 @@ type Mutation {
     team_id: JSON!
     email: JSON!
     channel_ids: JSON!
-  ): admin_users_invite_response @httpOperation(subgraph: "Slack", path: "/admin.users.invite", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_invite_response @httpOperation(subgraph: "Slack", path: "/admin.users.invite", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Remove a user from a workspace."""
   admin_users_remove(
     """Authentication token. Requires scope: \`admin.users:write\`"""
     token: String!
     team_id: JSON!
     user_id: JSON!
-  ): admin_users_remove_response @httpOperation(subgraph: "Slack", path: "/admin.users.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_remove_response @httpOperation(subgraph: "Slack", path: "/admin.users.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Invalidate a single session for a user by session_id"""
   admin_users_session_invalidate(
     """Authentication token. Requires scope: \`admin.users:write\`"""
     token: String!
     team_id: JSON!
     session_id: JSON!
-  ): admin_users_session_invalidate_response @httpOperation(subgraph: "Slack", path: "/admin.users.session.invalidate", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_session_invalidate_response @httpOperation(subgraph: "Slack", path: "/admin.users.session.invalidate", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Wipes all valid sessions on all devices for a given user"""
   admin_users_session_reset(
     """Authentication token. Requires scope: \`admin.users:write\`"""
     token: String!
     user_id: JSON!
-  ): admin_users_session_reset_response @httpOperation(subgraph: "Slack", path: "/admin.users.session.reset", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_session_reset_response @httpOperation(subgraph: "Slack", path: "/admin.users.session.reset", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set an existing guest, regular user, or owner to be an admin user."""
   admin_users_setAdmin(
     """Authentication token. Requires scope: \`admin.users:write\`"""
     token: String!
     team_id: JSON!
     user_id: JSON!
-  ): admin_users_setAdmin_response @httpOperation(subgraph: "Slack", path: "/admin.users.setAdmin", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_setAdmin_response @httpOperation(subgraph: "Slack", path: "/admin.users.setAdmin", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set an expiration for a guest user"""
   admin_users_setExpiration(
     """Authentication token. Requires scope: \`admin.users:write\`"""
@@ -128489,7 +128489,7 @@ type Mutation {
     team_id: JSON!
     user_id: JSON!
     expiration_ts: JSON!
-  ): admin_users_setExpiration_response @httpOperation(subgraph: "Slack", path: "/admin.users.setExpiration", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_setExpiration_response @httpOperation(subgraph: "Slack", path: "/admin.users.setExpiration", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """
   Set an existing guest, regular user, or admin user to be a workspace owner.
   """
@@ -128498,171 +128498,171 @@ type Mutation {
     token: String!
     team_id: JSON!
     user_id: JSON!
-  ): admin_users_setOwner_response @httpOperation(subgraph: "Slack", path: "/admin.users.setOwner", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_setOwner_response @httpOperation(subgraph: "Slack", path: "/admin.users.setOwner", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set an existing guest user, admin user, or owner to be a regular user."""
   admin_users_setRegular(
     """Authentication token. Requires scope: \`admin.users:write\`"""
     token: String!
     team_id: JSON!
     user_id: JSON!
-  ): admin_users_setRegular_response @httpOperation(subgraph: "Slack", path: "/admin.users.setRegular", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): admin_users_setRegular_response @httpOperation(subgraph: "Slack", path: "/admin.users.setRegular", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Registers a new Call."""
   calls_add(
     """Authentication token. Requires scope: \`calls:write\`"""
     token: String!
     external_unique_id: JSON!
     join_url: JSON!
-  ): calls_add_response @httpOperation(subgraph: "Slack", path: "/calls.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): calls_add_response @httpOperation(subgraph: "Slack", path: "/calls.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Ends a Call."""
   calls_end(
     """Authentication token. Requires scope: \`calls:write\`"""
     token: String!
     id: JSON!
-  ): calls_end_response @httpOperation(subgraph: "Slack", path: "/calls.end", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): calls_end_response @httpOperation(subgraph: "Slack", path: "/calls.end", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Registers new participants added to a Call."""
   calls_participants_add(
     """Authentication token. Requires scope: \`calls:write\`"""
     token: String!
     id: JSON!
     users: JSON!
-  ): calls_participants_add_response @httpOperation(subgraph: "Slack", path: "/calls.participants.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): calls_participants_add_response @httpOperation(subgraph: "Slack", path: "/calls.participants.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Registers participants removed from a Call."""
   calls_participants_remove(
     """Authentication token. Requires scope: \`calls:write\`"""
     token: String!
     id: JSON!
     users: JSON!
-  ): calls_participants_remove_response @httpOperation(subgraph: "Slack", path: "/calls.participants.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): calls_participants_remove_response @httpOperation(subgraph: "Slack", path: "/calls.participants.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Updates information about a Call."""
   calls_update(
     """Authentication token. Requires scope: \`calls:write\`"""
     token: String!
     id: JSON!
-  ): calls_update_response @httpOperation(subgraph: "Slack", path: "/calls.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): calls_update_response @httpOperation(subgraph: "Slack", path: "/calls.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Deletes a message."""
   chat_delete(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String
-  ): chat_delete_response @httpOperation(subgraph: "Slack", path: "/chat.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_delete_response @httpOperation(subgraph: "Slack", path: "/chat.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Deletes a pending scheduled message from the queue."""
   chat_deleteScheduledMessage(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String!
     channel: JSON!
     scheduled_message_id: JSON!
-  ): chat_deleteScheduledMessage_response @httpOperation(subgraph: "Slack", path: "/chat.deleteScheduledMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_deleteScheduledMessage_response @httpOperation(subgraph: "Slack", path: "/chat.deleteScheduledMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Share a me message into a channel."""
   chat_meMessage(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String
-  ): chat_meMessage_response @httpOperation(subgraph: "Slack", path: "/chat.meMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_meMessage_response @httpOperation(subgraph: "Slack", path: "/chat.meMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Sends an ephemeral message to a user in a channel."""
   chat_postEphemeral(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String!
     channel: JSON!
     user: JSON!
-  ): chat_postEphemeral_response @httpOperation(subgraph: "Slack", path: "/chat.postEphemeral", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_postEphemeral_response @httpOperation(subgraph: "Slack", path: "/chat.postEphemeral", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Sends a message to a channel."""
   chat_postMessage(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String!
     channel: JSON!
-  ): chat_postMessage_response @httpOperation(subgraph: "Slack", path: "/chat.postMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_postMessage_response @httpOperation(subgraph: "Slack", path: "/chat.postMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Schedules a message to be sent to a channel."""
   chat_scheduleMessage(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String
-  ): chat_scheduleMessage_response @httpOperation(subgraph: "Slack", path: "/chat.scheduleMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_scheduleMessage_response @httpOperation(subgraph: "Slack", path: "/chat.scheduleMessage", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Provide custom unfurl behavior for user-posted URLs"""
   chat_unfurl(
     """Authentication token. Requires scope: \`links:write\`"""
     token: String!
     channel: JSON!
     ts: JSON!
-  ): chat_unfurl_response @httpOperation(subgraph: "Slack", path: "/chat.unfurl", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_unfurl_response @httpOperation(subgraph: "Slack", path: "/chat.unfurl", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Updates a message."""
   chat_update(
     """Authentication token. Requires scope: \`chat:write\`"""
     token: String!
     channel: JSON!
     ts: JSON!
-  ): chat_update_response @httpOperation(subgraph: "Slack", path: "/chat.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): chat_update_response @httpOperation(subgraph: "Slack", path: "/chat.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Archives a conversation."""
   conversations_archive(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_archive_response @httpOperation(subgraph: "Slack", path: "/conversations.archive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_archive_response @httpOperation(subgraph: "Slack", path: "/conversations.archive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Closes a direct message or multi-person direct message."""
   conversations_close(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_close_response @httpOperation(subgraph: "Slack", path: "/conversations.close", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_close_response @httpOperation(subgraph: "Slack", path: "/conversations.close", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Initiates a public or private channel-based conversation"""
   conversations_create(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_create_response @httpOperation(subgraph: "Slack", path: "/conversations.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_create_response @httpOperation(subgraph: "Slack", path: "/conversations.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Invites users to a channel."""
   conversations_invite(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_invite_response @httpOperation(subgraph: "Slack", path: "/conversations.invite", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_invite_response @httpOperation(subgraph: "Slack", path: "/conversations.invite", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Joins an existing conversation."""
   conversations_join(
     """Authentication token. Requires scope: \`channels:write\`"""
     token: String
-  ): conversations_join_response @httpOperation(subgraph: "Slack", path: "/conversations.join", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_join_response @httpOperation(subgraph: "Slack", path: "/conversations.join", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Removes a user from a conversation."""
   conversations_kick(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_kick_response @httpOperation(subgraph: "Slack", path: "/conversations.kick", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_kick_response @httpOperation(subgraph: "Slack", path: "/conversations.kick", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Leaves a conversation."""
   conversations_leave(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_leave_response @httpOperation(subgraph: "Slack", path: "/conversations.leave", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_leave_response @httpOperation(subgraph: "Slack", path: "/conversations.leave", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Sets the read cursor in a channel."""
   conversations_mark(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_mark_response @httpOperation(subgraph: "Slack", path: "/conversations.mark", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_mark_response @httpOperation(subgraph: "Slack", path: "/conversations.mark", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Opens or resumes a direct message or multi-person direct message."""
   conversations_open(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_open_response @httpOperation(subgraph: "Slack", path: "/conversations.open", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_open_response @httpOperation(subgraph: "Slack", path: "/conversations.open", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Renames a conversation."""
   conversations_rename(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_rename_response @httpOperation(subgraph: "Slack", path: "/conversations.rename", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_rename_response @httpOperation(subgraph: "Slack", path: "/conversations.rename", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Sets the purpose for a conversation."""
   conversations_setPurpose(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_setPurpose_response @httpOperation(subgraph: "Slack", path: "/conversations.setPurpose", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_setPurpose_response @httpOperation(subgraph: "Slack", path: "/conversations.setPurpose", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Sets the topic for a conversation."""
   conversations_setTopic(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_setTopic_response @httpOperation(subgraph: "Slack", path: "/conversations.setTopic", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_setTopic_response @httpOperation(subgraph: "Slack", path: "/conversations.setTopic", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Reverses conversation archival."""
   conversations_unarchive(
     """Authentication token. Requires scope: \`conversations:write\`"""
     token: String
-  ): conversations_unarchive_response @httpOperation(subgraph: "Slack", path: "/conversations.unarchive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): conversations_unarchive_response @httpOperation(subgraph: "Slack", path: "/conversations.unarchive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Ends the current user's Do Not Disturb session immediately."""
   dnd_endDnd(
     """Authentication token. Requires scope: \`dnd:write\`"""
     token: String!
-  ): dnd_endDnd_response @httpOperation(subgraph: "Slack", path: "/dnd.endDnd", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): dnd_endDnd_response @httpOperation(subgraph: "Slack", path: "/dnd.endDnd", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Ends the current user's snooze mode immediately."""
   dnd_endSnooze(
     """Authentication token. Requires scope: \`dnd:write\`"""
     token: String!
-  ): dnd_endSnooze_response @httpOperation(subgraph: "Slack", path: "/dnd.endSnooze", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): dnd_endSnooze_response @httpOperation(subgraph: "Slack", path: "/dnd.endSnooze", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """
   Turns on Do Not Disturb mode for the current user, or changes its duration.
   """
@@ -128671,12 +128671,12 @@ type Mutation {
   files_comments_delete(
     """Authentication token. Requires scope: \`files:write:user\`"""
     token: String
-  ): files_comments_delete_response @httpOperation(subgraph: "Slack", path: "/files.comments.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): files_comments_delete_response @httpOperation(subgraph: "Slack", path: "/files.comments.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Deletes a file."""
   files_delete(
     """Authentication token. Requires scope: \`files:write:user\`"""
     token: String
-  ): files_delete_response @httpOperation(subgraph: "Slack", path: "/files.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): files_delete_response @httpOperation(subgraph: "Slack", path: "/files.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Adds a file from a remote service"""
   files_remote_add: files_remote_add_response @httpOperation(subgraph: "Slack", path: "/files.remote.add", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Remove a remote file."""
@@ -128687,12 +128687,12 @@ type Mutation {
   files_revokePublicURL(
     """Authentication token. Requires scope: \`files:write:user\`"""
     token: String
-  ): files_revokePublicURL_response @httpOperation(subgraph: "Slack", path: "/files.revokePublicURL", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): files_revokePublicURL_response @httpOperation(subgraph: "Slack", path: "/files.revokePublicURL", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Enables a file for public/external sharing."""
   files_sharedPublicURL(
     """Authentication token. Requires scope: \`files:write:user\`"""
     token: String
-  ): files_sharedPublicURL_response @httpOperation(subgraph: "Slack", path: "/files.sharedPublicURL", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): files_sharedPublicURL_response @httpOperation(subgraph: "Slack", path: "/files.sharedPublicURL", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Uploads or creates a file."""
   files_upload: files_upload_response @httpOperation(subgraph: "Slack", path: "/files.upload", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Pins an item to a channel."""
@@ -128700,13 +128700,13 @@ type Mutation {
     """Authentication token. Requires scope: \`pins:write\`"""
     token: String!
     channel: JSON!
-  ): pins_add_response @httpOperation(subgraph: "Slack", path: "/pins.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): pins_add_response @httpOperation(subgraph: "Slack", path: "/pins.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Un-pins an item from a channel."""
   pins_remove(
     """Authentication token. Requires scope: \`pins:write\`"""
     token: String!
     channel: JSON!
-  ): pins_remove_response @httpOperation(subgraph: "Slack", path: "/pins.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): pins_remove_response @httpOperation(subgraph: "Slack", path: "/pins.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Adds a reaction to an item."""
   reactions_add(
     """Authentication token. Requires scope: \`reactions:write\`"""
@@ -128714,83 +128714,83 @@ type Mutation {
     channel: JSON!
     name: JSON!
     timestamp: JSON!
-  ): reactions_add_response @httpOperation(subgraph: "Slack", path: "/reactions.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): reactions_add_response @httpOperation(subgraph: "Slack", path: "/reactions.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Removes a reaction from an item."""
   reactions_remove(
     """Authentication token. Requires scope: \`reactions:write\`"""
     token: String!
     name: JSON!
-  ): reactions_remove_response @httpOperation(subgraph: "Slack", path: "/reactions.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): reactions_remove_response @httpOperation(subgraph: "Slack", path: "/reactions.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Creates a reminder."""
   reminders_add(
     """Authentication token. Requires scope: \`reminders:write\`"""
     token: String!
     text: JSON!
     time: JSON!
-  ): reminders_add_response @httpOperation(subgraph: "Slack", path: "/reminders.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): reminders_add_response @httpOperation(subgraph: "Slack", path: "/reminders.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Marks a reminder as complete."""
   reminders_complete(
     """Authentication token. Requires scope: \`reminders:write\`"""
     token: String
-  ): reminders_complete_response @httpOperation(subgraph: "Slack", path: "/reminders.complete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): reminders_complete_response @httpOperation(subgraph: "Slack", path: "/reminders.complete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Deletes a reminder."""
   reminders_delete(
     """Authentication token. Requires scope: \`reminders:write\`"""
     token: String
-  ): reminders_delete_response @httpOperation(subgraph: "Slack", path: "/reminders.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): reminders_delete_response @httpOperation(subgraph: "Slack", path: "/reminders.delete", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Adds a star to an item."""
   stars_add(
     """Authentication token. Requires scope: \`stars:write\`"""
     token: String!
-  ): stars_add_response @httpOperation(subgraph: "Slack", path: "/stars.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): stars_add_response @httpOperation(subgraph: "Slack", path: "/stars.add", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Removes a star from an item."""
   stars_remove(
     """Authentication token. Requires scope: \`stars:write\`"""
     token: String!
-  ): stars_remove_response @httpOperation(subgraph: "Slack", path: "/stars.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): stars_remove_response @httpOperation(subgraph: "Slack", path: "/stars.remove", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Create a User Group"""
   usergroups_create(
     """Authentication token. Requires scope: \`usergroups:write\`"""
     token: String!
     name: JSON!
-  ): usergroups_create_response @httpOperation(subgraph: "Slack", path: "/usergroups.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): usergroups_create_response @httpOperation(subgraph: "Slack", path: "/usergroups.create", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Disable an existing User Group"""
   usergroups_disable(
     """Authentication token. Requires scope: \`usergroups:write\`"""
     token: String!
     usergroup: JSON!
-  ): usergroups_disable_response @httpOperation(subgraph: "Slack", path: "/usergroups.disable", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): usergroups_disable_response @httpOperation(subgraph: "Slack", path: "/usergroups.disable", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Enable a User Group"""
   usergroups_enable(
     """Authentication token. Requires scope: \`usergroups:write\`"""
     token: String!
     usergroup: JSON!
-  ): usergroups_enable_response @httpOperation(subgraph: "Slack", path: "/usergroups.enable", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): usergroups_enable_response @httpOperation(subgraph: "Slack", path: "/usergroups.enable", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Update an existing User Group"""
   usergroups_update(
     """Authentication token. Requires scope: \`usergroups:write\`"""
     token: String!
     usergroup: JSON!
-  ): usergroups_update_response @httpOperation(subgraph: "Slack", path: "/usergroups.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): usergroups_update_response @httpOperation(subgraph: "Slack", path: "/usergroups.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Update the list of users for a User Group"""
   usergroups_users_update(
     """Authentication token. Requires scope: \`usergroups:write\`"""
     token: String!
     usergroup: JSON!
     users: JSON!
-  ): usergroups_users_update_response @httpOperation(subgraph: "Slack", path: "/usergroups.users.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): usergroups_users_update_response @httpOperation(subgraph: "Slack", path: "/usergroups.users.update", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Delete the user profile photo"""
   users_deletePhoto: users_deletePhoto_response @httpOperation(subgraph: "Slack", path: "/users.deletePhoto", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set the profile information for a user."""
   users_profile_set(
     """Authentication token. Requires scope: \`users.profile:write\`"""
     token: String!
-  ): users_profile_set_response @httpOperation(subgraph: "Slack", path: "/users.profile.set", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): users_profile_set_response @httpOperation(subgraph: "Slack", path: "/users.profile.set", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Marked a user as active. Deprecated and non-functional."""
   users_setActive(
     """Authentication token. Requires scope: \`users:write\`"""
     token: String!
-  ): users_setActive_response @httpOperation(subgraph: "Slack", path: "/users.setActive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): users_setActive_response @httpOperation(subgraph: "Slack", path: "/users.setActive", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Set the user profile photo"""
   users_setPhoto: users_setPhoto_response @httpOperation(subgraph: "Slack", path: "/users.setPhoto", operationSpecificHeaders: [["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
   """Manually sets user presence."""
@@ -128798,7 +128798,7 @@ type Mutation {
     """Authentication token. Requires scope: \`users:write\`"""
     token: String!
     presence: JSON!
-  ): users_setPresence_response @httpOperation(subgraph: "Slack", path: "/users.setPresence", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded, application/json"], ["Accept", "application/json"]], httpMethod: POST)
+  ): users_setPresence_response @httpOperation(subgraph: "Slack", path: "/users.setPresence", operationSpecificHeaders: [["token", "{args.token}"], ["Content-Type", "application/x-www-form-urlencoded"], ["Accept", "application/json"]], httpMethod: POST)
 }
 
 union admin_apps_approve_response @statusCodeTypeName(subgraph: "Slack", statusCode: "200", typeName: "Default_success_template") @statusCodeTypeName(subgraph: "Slack", statusCode: "default", typeName: "Default_error_template") = Default_success_template | Default_error_template

--- a/packages/loaders/openapi/tests/reprod-9106.test.ts
+++ b/packages/loaders/openapi/tests/reprod-9106.test.ts
@@ -1,35 +1,60 @@
 import type { GraphQLSchema } from 'graphql';
+import { execute, parse } from 'graphql';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 import loadGraphQLSchemaFromOpenAPI from '@omnigraph/openapi';
 
 describe('Reproduction #9106', () => {
   let createdSchema: GraphQLSchema;
+  let lastRequest: { url: string; contentType: string | null; body: string } | undefined;
   beforeAll(async () => {
     createdSchema = await loadGraphQLSchemaFromOpenAPI('test', {
       source: './fixtures/reprod-9106.yml',
       cwd: __dirname,
       ignoreErrorResponses: true,
-      async fetch(url) {
-        if (url === 'pets/1') {
-          return Response.json({
-            petType: 'Dog',
-            dog_exclusive: 'DOG_EXCLUSIVE',
-          });
-        }
-        if (url === 'pets/2') {
-          return Response.json({
-            petType: 'Cat',
-            cat_exclusive: 'CAT_EXCLUSIVE',
-          });
-        }
-        return new Response(null, {
-          status: 404,
+      async fetch(url, init) {
+        lastRequest = {
+          url: String(url),
+          contentType: new Headers(init?.headers).get('content-type'),
+          body: typeof init?.body === 'string' ? init.body : String(init?.body ?? ''),
+        };
+        return Response.json({
+          access_token: 'token',
+          expires_in: 3600,
+          token_type: 'Bearer',
         });
       },
-      // It is not possible to provide a union type with File scalar
     });
   });
   it('should generate correct schema', () => {
     expect(printSchemaWithDirectives(createdSchema)).toMatchSnapshot('reprod-9106');
+  });
+  it('serializes discriminator oneOf bodies as form-urlencoded when that content type is listed first', async () => {
+    lastRequest = undefined;
+    const result = await execute({
+      schema: createdSchema,
+      document: parse(/* GraphQL */ `
+        mutation {
+          post_token(
+            input: {
+              OAuth_Client_Credentials_Request_Input: {
+                grant_type: client_credentials
+                client_id: "id"
+                client_secret: "secret"
+              }
+            }
+          ) {
+            ... on Provider_specific_Access_Token_Response {
+              access_token
+            }
+          }
+        }
+      `),
+    });
+    expect(result.errors).toBeUndefined();
+    expect(lastRequest?.contentType).toBe('application/x-www-form-urlencoded');
+    expect(lastRequest?.body).toContain('grant_type=client_credentials');
+    expect(lastRequest?.body).toContain('client_id=id');
+    expect(lastRequest?.body).toContain('client_secret=secret');
+    expect(lastRequest?.body).not.toContain('OAuth_Client_Credentials_Request_Input');
   });
 });


### PR DESCRIPTION
## Summary
- Prefer `application/x-www-form-urlencoded` when it is listed before JSON so OAuth `oneOf` + discriminator token requests are sent as form fields instead of JSON
- Normalize relative JSON Schema `$ref` paths (`utils.json` vs `../../utils.json`) so the same definition is reused instead of `Type2` / `Type3`

Fixes #9106
Fixes #9019

## Test plan
- [x] `yarn jest packages/loaders/openapi/tests/reprod-9106.test.ts`
- [x] `yarn jest packages/loaders/json-schema/test/reprod-9019.test.ts`
- [x] `yarn jest packages/loaders/openapi/tests packages/json-machete/tests packages/loaders/json-schema/test`