### PR TITLE
fix(cli): emit ESM index.js when package.json is type module

### DIFF
--- a/.changeset/fix-hello-world-esm-artifacts.md
+++ b/.changeset/fix-hello-world-esm-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@graphql-mesh/cli": patch
+---
+
+When `package.json` is `"type": "module"`, emit Mesh artifacts as ESM `index.js` (not CJS, and not a missing `index.mjs`) so examples like hello-world-esm can start.

--- a/examples/hello-world-esm/index.ts
+++ b/examples/hello-world-esm/index.ts
@@ -1,4 +1,4 @@
-import { getMeshSDK } from './.mesh/index.mjs';
+import { getMeshSDK } from './.mesh/index.js';
 
 async function main() {
   const sdk = getMeshSDK();

--- a/examples/hello-world-esm/package.json
+++ b/examples/hello-world-esm/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "prestart": "mesh build --fileType js",
-    "start": "ts-node index.ts",
+    "start": "tsx index.ts",
     "test": "jest"
   },
   "dependencies": {
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/node": "^26.2.0",
     "jest": "30.4.2",
-    "ts-node": "^10.9.2",
+    "tsx": "^4.23.12",
     "typescript": "^6.0.3"
   }
 }

--- a/examples/hello-world-esm/tsconfig.json
+++ b/examples/hello-world-esm/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
+    "module": "ES2022",
+    "target": "ES2022",
+    "moduleResolution": "bundler",
     "rootDir": "./",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }

--- a/packages/legacy/cli/src/commands/ts-artifacts.ts
+++ b/packages/legacy/cli/src/commands/ts-artifacts.ts
@@ -87,26 +87,22 @@ export function getMeshArtifactEmitPlan({
 
 export function getMeshArtifactsPackageJson(
   moduleType: 'module' | 'commonjs',
-  esmEntry: 'index.js' | 'index.mjs' = 'index.mjs',
+  esmEntry?: 'index.js' | 'index.mjs',
 ) {
-  const pureEsmJs = moduleType === 'module' && esmEntry === 'index.js';
+  const dualPackage = esmEntry === 'index.mjs';
   return {
     name: 'mesh-artifacts',
     private: true,
     type: moduleType,
     main: 'index.js',
-    module: esmEntry,
+    ...(esmEntry ? { module: esmEntry } : {}),
     sideEffects: false,
     typings: 'index.d.ts',
     typescript: {
       definition: 'index.d.ts',
     },
-    exports: pureEsmJs
+    exports: dualPackage
       ? {
-          '.': './index.js',
-          './*': './*.js',
-        }
-      : {
           '.': {
             require: './index.js',
             import: './index.mjs',
@@ -115,6 +111,10 @@ export function getMeshArtifactsPackageJson(
             require: './*.js',
             import: './*.mjs',
           },
+        }
+      : {
+          '.': './index.js',
+          './*': './*.js',
         },
   };
 }
@@ -459,27 +459,33 @@ const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url
   };
 
   const packageJsonJob =
-    (moduleType: 'module' | 'commonjs', esmEntry: 'index.js' | 'index.mjs' = 'index.mjs') =>
-    () =>
+    (moduleType: 'module' | 'commonjs', esmEntry?: 'index.js' | 'index.mjs') => () =>
       writeJSON(
         pathModule.join(artifactsDir, 'package.json'),
         getMeshArtifactsPackageJson(moduleType, esmEntry),
       );
 
-  const rootDir = pathModule.resolve('./');
-  const tsConfigPath = pathModule.join(rootDir, 'tsconfig.json');
-  const packageJsonPath = pathModule.join(rootDir, 'package.json');
+  const tsConfigPath = pathModule.join(baseDir, 'tsconfig.json');
+  const packageJsonPath = pathModule.join(baseDir, 'package.json');
   const hasTsConfig = await pathExists(tsConfigPath);
   const hasPackageJson = await pathExists(packageJsonPath);
   let tsConfigModule: string | undefined;
   let packageJsonType: string | undefined;
   if (hasTsConfig) {
-    const tsConfig = JSON5.parse(await fs.promises.readFile(tsConfigPath, 'utf-8'));
-    tsConfigModule = tsConfig?.compilerOptions?.module;
+    try {
+      const tsConfig = JSON5.parse(await fs.promises.readFile(tsConfigPath, 'utf-8'));
+      tsConfigModule = tsConfig?.compilerOptions?.module;
+    } catch {
+      // Keep the default emit plan if tsconfig cannot be read.
+    }
   }
   if (hasPackageJson) {
-    const packageJson = JSON5.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'));
-    packageJsonType = packageJson?.type;
+    try {
+      const packageJson = JSON5.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'));
+      packageJsonType = packageJson?.type;
+    } catch {
+      // Keep the default emit plan if package.json cannot be read.
+    }
   }
   const plan = getMeshArtifactEmitPlan({
     hasTsConfig,
@@ -496,7 +502,10 @@ const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url
   }
   if (plan.artifactsPackageType) {
     jobs.push(
-      packageJsonJob(plan.artifactsPackageType, plan.esmExt === 'js' ? 'index.js' : 'index.mjs'),
+      packageJsonJob(
+        plan.artifactsPackageType,
+        plan.esmExt ? (`index.${plan.esmExt}` as 'index.js' | 'index.mjs') : undefined,
+      ),
     );
   }
 

--- a/packages/legacy/cli/src/commands/ts-artifacts.ts
+++ b/packages/legacy/cli/src/commands/ts-artifacts.ts
@@ -1,3 +1,4 @@
+import { getTsconfig } from 'get-tsconfig';
 import type { GraphQLSchema } from 'graphql';
 import JSON5 from 'json5';
 import ts from 'typescript';
@@ -117,6 +118,23 @@ export function getMeshArtifactsPackageJson(
           './*': './*.js',
         },
   };
+}
+
+/**
+ * Load `compilerOptions.module` from the project's `tsconfig.json`, including
+ * values inherited via `extends`. Returns `undefined` when there is no
+ * tsconfig in `projectDir` itself (parent configs are ignored).
+ */
+export function readResolvedTsConfigModule(projectDir: string): string | undefined {
+  const tsconfig = getTsconfig(projectDir, 'tsconfig.json');
+  if (!tsconfig) {
+    return undefined;
+  }
+  if (pathModule.resolve(pathModule.dirname(tsconfig.path)) !== pathModule.resolve(projectDir)) {
+    return undefined;
+  }
+  const moduleOption = tsconfig.config.compilerOptions?.module;
+  return typeof moduleOption === 'string' ? moduleOption : undefined;
 }
 
 async function loadTypeScriptCodegenPlugin() {
@@ -473,8 +491,7 @@ const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url
   let packageJsonType: string | undefined;
   if (hasTsConfig) {
     try {
-      const tsConfig = JSON5.parse(await fs.promises.readFile(tsConfigPath, 'utf-8'));
-      tsConfigModule = tsConfig?.compilerOptions?.module;
+      tsConfigModule = readResolvedTsConfigModule(baseDir);
     } catch {
       // Keep the default emit plan if tsconfig cannot be read.
     }

--- a/packages/legacy/cli/src/commands/ts-artifacts.ts
+++ b/packages/legacy/cli/src/commands/ts-artifacts.ts
@@ -60,11 +60,21 @@ export function getMeshArtifactEmitPlan({
     artifactsPackageType: fileType === 'ts' ? undefined : 'commonjs',
   });
 
-  const dualCjsPackage = (): ReturnType<typeof getMeshArtifactEmitPlan> => ({
-    esmExt: 'mjs',
-    cjs: fileType !== 'js',
-    artifactsPackageType: fileType === 'js' ? 'module' : 'commonjs',
-  });
+  const dualCjsPackage = (): ReturnType<typeof getMeshArtifactEmitPlan> => {
+    // `fileType: 'ts'` keeps the source artifact only — dual esm+cjs jobs would
+    // both write `index.ts` and package metadata would point at missing JS files.
+    if (fileType === 'ts') {
+      return {
+        cjs: true,
+        artifactsPackageType: undefined,
+      };
+    }
+    return {
+      esmExt: 'mjs',
+      cjs: fileType !== 'js',
+      artifactsPackageType: fileType === 'js' ? 'module' : 'commonjs',
+    };
+  };
 
   if (hasTsConfig) {
     if (tsModule.startsWith('es')) {
@@ -89,13 +99,16 @@ export function getMeshArtifactEmitPlan({
 export function getMeshArtifactsPackageJson(
   moduleType: 'module' | 'commonjs',
   esmEntry?: 'index.js' | 'index.mjs',
+  options: { emitCjs?: boolean } = {},
 ) {
-  const dualPackage = esmEntry === 'index.mjs';
+  const emitCjs = options.emitCjs ?? esmEntry !== 'index.mjs';
+  const dualPackage = esmEntry === 'index.mjs' && emitCjs;
+  const mjsOnly = esmEntry === 'index.mjs' && !emitCjs;
   return {
     name: 'mesh-artifacts',
     private: true,
     type: moduleType,
-    main: 'index.js',
+    main: mjsOnly ? 'index.mjs' : 'index.js',
     ...(esmEntry ? { module: esmEntry } : {}),
     sideEffects: false,
     typings: 'index.d.ts',
@@ -113,10 +126,15 @@ export function getMeshArtifactsPackageJson(
             import: './*.mjs',
           },
         }
-      : {
-          '.': './index.js',
-          './*': './*.js',
-        },
+      : mjsOnly
+        ? {
+            '.': './index.mjs',
+            './*': './*.mjs',
+          }
+        : {
+            '.': './index.js',
+            './*': './*.js',
+          },
   };
 }
 
@@ -477,10 +495,15 @@ const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url
   };
 
   const packageJsonJob =
-    (moduleType: 'module' | 'commonjs', esmEntry?: 'index.js' | 'index.mjs') => () =>
+    (
+      moduleType: 'module' | 'commonjs',
+      esmEntry?: 'index.js' | 'index.mjs',
+      options?: { emitCjs?: boolean },
+    ) =>
+    () =>
       writeJSON(
         pathModule.join(artifactsDir, 'package.json'),
-        getMeshArtifactsPackageJson(moduleType, esmEntry),
+        getMeshArtifactsPackageJson(moduleType, esmEntry, options),
       );
 
   const tsConfigPath = pathModule.join(baseDir, 'tsconfig.json');
@@ -522,6 +545,7 @@ const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url
       packageJsonJob(
         plan.artifactsPackageType,
         plan.esmExt ? (`index.${plan.esmExt}` as 'index.js' | 'index.mjs') : undefined,
+        { emitCjs: plan.cjs },
       ),
     );
   }

--- a/packages/legacy/cli/src/commands/ts-artifacts.ts
+++ b/packages/legacy/cli/src/commands/ts-artifacts.ts
@@ -26,6 +26,99 @@ import { generateOperations } from './generate-operations.js';
 
 const BASEDIR_ASSIGNMENT_COMMENT = `/* BASEDIR_ASSIGNMENT */`;
 
+export type MeshArtifactEsmExt = 'js' | 'mjs';
+
+export function getMeshArtifactEmitPlan({
+  hasTsConfig,
+  tsConfigModule,
+  hasPackageJson,
+  packageJsonType,
+  fileType,
+}: {
+  hasTsConfig: boolean;
+  tsConfigModule?: string;
+  hasPackageJson: boolean;
+  packageJsonType?: string;
+  fileType: 'ts' | 'json' | 'js';
+}): {
+  esmExt?: MeshArtifactEsmExt;
+  cjs: boolean;
+  artifactsPackageType?: 'module' | 'commonjs';
+} {
+  const tsModule = tsConfigModule?.toLowerCase() ?? '';
+  const isPackageModule = packageJsonType === 'module';
+
+  const esmAsJs = (): ReturnType<typeof getMeshArtifactEmitPlan> => ({
+    esmExt: 'js',
+    cjs: false,
+    artifactsPackageType: fileType === 'ts' ? undefined : 'module',
+  });
+
+  const cjsOnly = (): ReturnType<typeof getMeshArtifactEmitPlan> => ({
+    cjs: true,
+    artifactsPackageType: fileType === 'ts' ? undefined : 'commonjs',
+  });
+
+  const dualCjsPackage = (): ReturnType<typeof getMeshArtifactEmitPlan> => ({
+    esmExt: 'mjs',
+    cjs: fileType !== 'js',
+    artifactsPackageType: fileType === 'js' ? 'module' : 'commonjs',
+  });
+
+  if (hasTsConfig) {
+    if (tsModule.startsWith('es')) {
+      return esmAsJs();
+    }
+    if (tsModule.startsWith('node') && hasPackageJson) {
+      return isPackageModule ? esmAsJs() : cjsOnly();
+    }
+    // `"type": "module"` means Node loads `.js` as ESM; emitting CJS artifacts
+    // into that package (hello-world-esm) makes `exports is not defined`.
+    if (hasPackageJson && isPackageModule) {
+      return esmAsJs();
+    }
+    return cjsOnly();
+  }
+  if (hasPackageJson && isPackageModule) {
+    return esmAsJs();
+  }
+  return dualCjsPackage();
+}
+
+export function getMeshArtifactsPackageJson(
+  moduleType: 'module' | 'commonjs',
+  esmEntry: 'index.js' | 'index.mjs' = 'index.mjs',
+) {
+  const pureEsmJs = moduleType === 'module' && esmEntry === 'index.js';
+  return {
+    name: 'mesh-artifacts',
+    private: true,
+    type: moduleType,
+    main: 'index.js',
+    module: esmEntry,
+    sideEffects: false,
+    typings: 'index.d.ts',
+    typescript: {
+      definition: 'index.d.ts',
+    },
+    exports: pureEsmJs
+      ? {
+          '.': './index.js',
+          './*': './*.js',
+        }
+      : {
+          '.': {
+            require: './index.js',
+            import: './index.mjs',
+          },
+          './*': {
+            require: './*.js',
+            import: './*.mjs',
+          },
+        },
+  };
+}
+
 async function loadTypeScriptCodegenPlugin() {
   return defaultImportFn('@graphql-codegen/typescript');
 }
@@ -365,99 +458,46 @@ const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url
     }
   };
 
-  const packageJsonJob = (module: string) => () =>
-    writeJSON(pathModule.join(artifactsDir, 'package.json'), {
-      name: 'mesh-artifacts',
-      private: true,
-      type: module,
-      main: 'index.js',
-      module: 'index.mjs',
-      sideEffects: false,
-      typings: 'index.d.ts',
-      typescript: {
-        definition: 'index.d.ts',
-      },
-      exports: {
-        '.': {
-          require: './index.js',
-          import: './index.mjs',
-        },
-        './*': {
-          require: './*.js',
-          import: './*.mjs',
-        },
-      },
-    });
+  const packageJsonJob =
+    (moduleType: 'module' | 'commonjs', esmEntry: 'index.js' | 'index.mjs' = 'index.mjs') =>
+    () =>
+      writeJSON(
+        pathModule.join(artifactsDir, 'package.json'),
+        getMeshArtifactsPackageJson(moduleType, esmEntry),
+      );
 
-  function setTsConfigDefault() {
-    jobs.push(cjsJob);
-    if (fileType !== 'ts') {
-      jobs.push(packageJsonJob('commonjs'));
-    }
-  }
   const rootDir = pathModule.resolve('./');
   const tsConfigPath = pathModule.join(rootDir, 'tsconfig.json');
   const packageJsonPath = pathModule.join(rootDir, 'package.json');
-  if (await pathExists(tsConfigPath)) {
-    // case tsconfig exists
-    const tsConfigStr = await fs.promises.readFile(tsConfigPath, 'utf-8');
-    const tsConfig = JSON5.parse(tsConfigStr);
-    if (tsConfig?.compilerOptions?.module?.toLowerCase()?.startsWith('es')) {
-      // case tsconfig set to esm
-      jobs.push(esmJob('js'));
-      if (fileType !== 'ts') {
-        jobs.push(packageJsonJob('module'));
-      }
-    } else if (
-      tsConfig?.compilerOptions?.module?.toLowerCase()?.startsWith('node') &&
-      (await pathExists(packageJsonPath))
-    ) {
-      // case tsconfig set to node* and package.json exists
-      const packageJsonStr = await fs.promises.readFile(packageJsonPath, 'utf-8');
-      const packageJson = JSON5.parse(packageJsonStr);
-      if (packageJson?.type === 'module') {
-        // case package.json set to esm
-        jobs.push(esmJob('js'));
-        if (fileType !== 'ts') {
-          jobs.push(packageJsonJob('module'));
-        }
-      } else {
-        // case package.json set to cjs or not set
-        setTsConfigDefault();
-      }
-    } else {
-      // case tsconfig set to cjs or set to node* with no package.json
-      setTsConfigDefault();
-    }
-  } else if (await pathExists(packageJsonPath)) {
-    // case package.json exists
-    const packageJsonStr = await fs.promises.readFile(packageJsonPath, 'utf-8');
-    const packageJson = JSON5.parse(packageJsonStr);
-    if (packageJson?.type === 'module') {
-      // case package.json set to esm
-      jobs.push(esmJob('js'));
-      if (fileType !== 'ts') {
-        jobs.push(packageJsonJob('module'));
-      }
-    } else {
-      // case package.json set to cjs or not set
-      jobs.push(esmJob('mjs'));
-      if (fileType === 'js') {
-        jobs.push(packageJsonJob('module'));
-      } else {
-        jobs.push(cjsJob);
-        jobs.push(packageJsonJob('commonjs'));
-      }
-    }
-  } else {
-    // case no tsconfig and no package.json
-    jobs.push(esmJob('mjs'));
-    if (fileType === 'js') {
-      jobs.push(packageJsonJob('module'));
-    } else {
-      jobs.push(cjsJob);
-      jobs.push(packageJsonJob('commonjs'));
-    }
+  const hasTsConfig = await pathExists(tsConfigPath);
+  const hasPackageJson = await pathExists(packageJsonPath);
+  let tsConfigModule: string | undefined;
+  let packageJsonType: string | undefined;
+  if (hasTsConfig) {
+    const tsConfig = JSON5.parse(await fs.promises.readFile(tsConfigPath, 'utf-8'));
+    tsConfigModule = tsConfig?.compilerOptions?.module;
+  }
+  if (hasPackageJson) {
+    const packageJson = JSON5.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'));
+    packageJsonType = packageJson?.type;
+  }
+  const plan = getMeshArtifactEmitPlan({
+    hasTsConfig,
+    tsConfigModule,
+    hasPackageJson,
+    packageJsonType,
+    fileType,
+  });
+  if (plan.esmExt) {
+    jobs.push(esmJob(plan.esmExt));
+  }
+  if (plan.cjs) {
+    jobs.push(cjsJob);
+  }
+  if (plan.artifactsPackageType) {
+    jobs.push(
+      packageJsonJob(plan.artifactsPackageType, plan.esmExt === 'js' ? 'index.js' : 'index.mjs'),
+    );
   }
 
   for (const job of jobs) {

--- a/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
+++ b/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
@@ -1,6 +1,10 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   getMeshArtifactEmitPlan,
   getMeshArtifactsPackageJson,
+  readResolvedTsConfigModule,
 } from '../src/commands/ts-artifacts.js';
 
 describe('getMeshArtifactEmitPlan', () => {
@@ -175,5 +179,26 @@ describe('getMeshArtifactsPackageJson', () => {
         },
       },
     });
+  });
+});
+
+describe('readResolvedTsConfigModule', () => {
+  it('inherits compilerOptions.module from tsconfig extends', () => {
+    const root = mkdtempSync(join(tmpdir(), 'mesh-tsconfig-'));
+    const projectDir = join(root, 'app');
+    mkdirSync(projectDir);
+    writeFileSync(
+      join(root, 'tsconfig.base.json'),
+      JSON.stringify({ compilerOptions: { module: 'ES2022' } }),
+    );
+    writeFileSync(
+      join(projectDir, 'tsconfig.json'),
+      JSON.stringify({ extends: '../tsconfig.base.json', compilerOptions: { rootDir: './' } }),
+    );
+    try {
+      expect(readResolvedTsConfigModule(projectDir)?.toLowerCase()).toBe('es2022');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
+++ b/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
@@ -1,0 +1,66 @@
+import {
+  getMeshArtifactEmitPlan,
+  getMeshArtifactsPackageJson,
+} from '../src/commands/ts-artifacts.js';
+
+describe('getMeshArtifactEmitPlan', () => {
+  it('emits ESM as index.js when package.json is type module even if tsconfig is CommonJS (#5193)', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'commonjs',
+        hasPackageJson: true,
+        packageJsonType: 'module',
+        fileType: 'js',
+      }),
+    ).toEqual({
+      esmExt: 'js',
+      cjs: false,
+      artifactsPackageType: 'module',
+    });
+  });
+
+  it('keeps CJS artifacts for a CommonJS tsconfig without type module', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'commonjs',
+        hasPackageJson: true,
+        packageJsonType: undefined,
+        fileType: 'js',
+      }),
+    ).toEqual({
+      cjs: true,
+      artifactsPackageType: 'commonjs',
+    });
+  });
+
+  it('emits ESM as index.js when tsconfig module is ES2022', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'ES2022',
+        hasPackageJson: true,
+        packageJsonType: 'module',
+        fileType: 'js',
+      }),
+    ).toEqual({
+      esmExt: 'js',
+      cjs: false,
+      artifactsPackageType: 'module',
+    });
+  });
+});
+
+describe('getMeshArtifactsPackageJson', () => {
+  it('points import/module at index.js when ESM is emitted as .js', () => {
+    expect(getMeshArtifactsPackageJson('module', 'index.js')).toMatchObject({
+      type: 'module',
+      main: 'index.js',
+      module: 'index.js',
+      exports: {
+        '.': './index.js',
+      },
+    });
+  });
+});

--- a/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
+++ b/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
@@ -50,6 +50,95 @@ describe('getMeshArtifactEmitPlan', () => {
       artifactsPackageType: 'module',
     });
   });
+
+  it('keeps the historical es* tsconfig plan without package.json type module', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'ESNext',
+        hasPackageJson: true,
+        packageJsonType: undefined,
+        fileType: 'js',
+      }),
+    ).toEqual({
+      esmExt: 'js',
+      cjs: false,
+      artifactsPackageType: 'module',
+    });
+  });
+
+  it('does not write artifacts package.json for fileType ts', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'commonjs',
+        hasPackageJson: true,
+        packageJsonType: undefined,
+        fileType: 'ts',
+      }),
+    ).toEqual({
+      cjs: true,
+      artifactsPackageType: undefined,
+    });
+  });
+
+  it('uses node16 + type module as ESM index.js', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'node16',
+        hasPackageJson: true,
+        packageJsonType: 'module',
+        fileType: 'js',
+      }),
+    ).toEqual({
+      esmExt: 'js',
+      cjs: false,
+      artifactsPackageType: 'module',
+    });
+  });
+
+  it('uses nodenext without type module as CJS', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: true,
+        tsConfigModule: 'nodenext',
+        hasPackageJson: true,
+        packageJsonType: undefined,
+        fileType: 'js',
+      }),
+    ).toEqual({
+      cjs: true,
+      artifactsPackageType: 'commonjs',
+    });
+  });
+
+  it('emits dual CJS + mjs when there is no tsconfig and package.json is not module', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: false,
+        hasPackageJson: true,
+        packageJsonType: undefined,
+        fileType: 'js',
+      }),
+    ).toEqual({
+      esmExt: 'mjs',
+      cjs: false,
+      artifactsPackageType: 'module',
+    });
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: false,
+        hasPackageJson: true,
+        packageJsonType: undefined,
+        fileType: 'json',
+      }),
+    ).toEqual({
+      esmExt: 'mjs',
+      cjs: true,
+      artifactsPackageType: 'commonjs',
+    });
+  });
 });
 
 describe('getMeshArtifactsPackageJson', () => {
@@ -60,6 +149,30 @@ describe('getMeshArtifactsPackageJson', () => {
       module: 'index.js',
       exports: {
         '.': './index.js',
+      },
+    });
+  });
+
+  it('does not advertise a missing index.mjs for CJS-only artifacts', () => {
+    expect(getMeshArtifactsPackageJson('commonjs')).toMatchObject({
+      type: 'commonjs',
+      main: 'index.js',
+      exports: {
+        '.': './index.js',
+        './*': './*.js',
+      },
+    });
+    expect(getMeshArtifactsPackageJson('commonjs')).not.toHaveProperty('module');
+  });
+
+  it('keeps dual-package import paths when .mjs is emitted', () => {
+    expect(getMeshArtifactsPackageJson('commonjs', 'index.mjs')).toMatchObject({
+      module: 'index.mjs',
+      exports: {
+        '.': {
+          require: './index.js',
+          import: './index.mjs',
+        },
       },
     });
   });

--- a/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
+++ b/packages/legacy/cli/test/ts-artifacts-emit-plan.test.ts
@@ -143,6 +143,19 @@ describe('getMeshArtifactEmitPlan', () => {
       artifactsPackageType: 'commonjs',
     });
   });
+
+  it('keeps a TypeScript-only plan for fileType ts without tsconfig', () => {
+    expect(
+      getMeshArtifactEmitPlan({
+        hasTsConfig: false,
+        hasPackageJson: false,
+        fileType: 'ts',
+      }),
+    ).toEqual({
+      cjs: true,
+      artifactsPackageType: undefined,
+    });
+  });
 });
 
 describe('getMeshArtifactsPackageJson', () => {
@@ -169,14 +182,26 @@ describe('getMeshArtifactsPackageJson', () => {
     expect(getMeshArtifactsPackageJson('commonjs')).not.toHaveProperty('module');
   });
 
-  it('keeps dual-package import paths when .mjs is emitted', () => {
-    expect(getMeshArtifactsPackageJson('commonjs', 'index.mjs')).toMatchObject({
+  it('keeps dual-package import paths when .mjs and CJS are both emitted', () => {
+    expect(getMeshArtifactsPackageJson('commonjs', 'index.mjs', { emitCjs: true })).toMatchObject({
       module: 'index.mjs',
       exports: {
         '.': {
           require: './index.js',
           import: './index.mjs',
         },
+      },
+    });
+  });
+
+  it('does not advertise require→index.js when only .mjs is emitted', () => {
+    expect(getMeshArtifactsPackageJson('module', 'index.mjs', { emitCjs: false })).toMatchObject({
+      type: 'module',
+      main: 'index.mjs',
+      module: 'index.mjs',
+      exports: {
+        '.': './index.mjs',
+        './*': './*.mjs',
       },
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6480,7 +6480,7 @@ __metadata:
     "@types/node": "npm:^26.2.0"
     graphql: "npm:16.14.0"
     jest: "npm:30.4.2"
-    ts-node: "npm:^10.9.2"
+    tsx: "npm:^4.23.12"
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
- When `package.json` is `"type": "module"`, Mesh artifacts are now ESM `index.js` even if `tsconfig` says CommonJS, and artifact `package.json` no longer points at a missing `index.mjs`.
- Artifact metadata matches what is actually emitted: CJS-only no longer advertises `index.mjs`; `.mjs`-only no longer advertises `require → index.js`; `fileType: 'ts'` without a usable dual JS emit stays TypeScript-only (no double `index.ts` write / missing `.js` refs).
- `compilerOptions.module` is resolved via `get-tsconfig` (including `extends`), reading config from the Mesh `baseDir` rather than `cwd`.
- `hello-world-esm` imports `./.mesh/index.js`, uses an ESM tsconfig, and starts with `tsx` instead of `ts-node`.

Fixes #5193

## Test plan
- [x] Unit tests for artifact emit plan / package.json shape (including mjs-only, CJS-only, `fileType: 'ts'`, and `extends`)
- [ ] `cd examples/hello-world-esm && yarn prestart && yarn start`