### PR TITLE
fix(json-schema): reuse one scalar for format+pattern nullable $refs

### DIFF
--- a/.changeset/fix-nullable-uuid-format-pattern.md
+++ b/.changeset/fix-nullable-uuid-format-pattern.md
@@ -2,4 +2,4 @@
 "@omnigraph/json-schema": patch
 ---
 
-Reuse a single scalar when a shared primitive `$ref` has both `format` and `pattern` whose GraphQL names would collide (e.g. SmallRye UUID), including nullable `anyOf`/`oneOf` wrappers. Keep `@regexp` when the names differ.
+Reuse a single scalar when a shared primitive `$ref` has both `format` and `pattern` whose GraphQL names would collide, including nullable `anyOf`/`oneOf` wrappers. Keep `@regexp` when the names differ.

--- a/.changeset/fix-nullable-uuid-format-pattern.md
+++ b/.changeset/fix-nullable-uuid-format-pattern.md
@@ -1,0 +1,5 @@
+---
+"@omnigraph/json-schema": patch
+---
+
+Reuse a single format scalar when a shared primitive `$ref` has both `format` and `pattern`, including nullable `anyOf`/`oneOf` wrappers (e.g. SmallRye UUID).

--- a/.changeset/fix-nullable-uuid-format-pattern.md
+++ b/.changeset/fix-nullable-uuid-format-pattern.md
@@ -2,4 +2,4 @@
 "@omnigraph/json-schema": patch
 ---
 
-Reuse a single format scalar when a shared primitive `$ref` has both `format` and `pattern`, including nullable `anyOf`/`oneOf` wrappers (e.g. SmallRye UUID).
+Reuse a single scalar when a shared primitive `$ref` has both `format` and `pattern` whose GraphQL names would collide (e.g. SmallRye UUID), including nullable `anyOf`/`oneOf` wrappers. Keep `@regexp` when the names differ.

--- a/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
@@ -306,53 +306,16 @@ export function getComposerFromJSONSchema({
         }
       }
 
-      // OpenAPI 3.1 / JSON Schema: `anyOf`/`oneOf` with a `{ type: 'null' }` branch means nullable.
-      // Must run before `pattern`/`format` so a shared `$ref` and a nullable wrapper take the
-      // same scalar path (e.g. UUID with both format and pattern — SmallRye / #9637).
-      for (const unionKey of ['anyOf', 'oneOf'] as const) {
-        if (
-          subSchema[unionKey] &&
-          !subSchema.properties &&
-          !subSchema.allOf &&
-          !subSchema.additionalProperties
-        ) {
-          const unionArr = subSchema[unionKey] as JSONSchemaObject[];
-          const nonNullUnion = unionArr.filter(s => s.type !== 'null');
-          if (nonNullUnion.length === unionArr.length) {
-            continue;
-          }
-          if (nonNullUnion.length === 0) {
-            const typeComposer = schemaComposer.getAnyTC(GraphQLVoid);
-            return {
-              input: typeComposer,
-              output: typeComposer,
-              nullable: true,
-              description: subSchema.description,
-              readOnly: subSchema.readOnly,
-              writeOnly: subSchema.writeOnly,
-              default: subSchema.default,
-              deprecated: subSchema.deprecated,
-            };
-          }
-          subSchema.nullable = true;
-          if (nonNullUnion.length === 1 && isJsonPrimitiveSchema(nonNullUnion[0])) {
-            Object.assign(subSchema, nonNullUnion[0]);
-            delete (subSchema as any)[unionKey];
-          } else {
-            (subSchema as any)[unionKey] = nonNullUnion;
-          }
-          break;
-        }
-      }
-
       if (subSchema.pattern) {
-        // Prefer a known `format` scalar when both are present so a `$ref` usage
-        // (pattern branch) and a collapsed nullable wrapper (format branch) do
-        // not mint two different GraphQL types named e.g. `UUID`.
-        if (subSchema.format) {
+        // A `$ref` with both `format` and `pattern` takes this branch (named from `title`),
+        // while a nullable `anyOf`/`oneOf` wrapper of the same `$ref` takes the format
+        // branch after collapse. Reuse the format scalar only when those names would
+        // collide (e.g. title `UUID` + `format: uuid` → two types named `UUID`). Other
+        // pairs such as title `endpoint` + `format: uri-template` keep `@regexp`.
+        if (subSchema.format && subSchema.title) {
           const formatScalar =
             getScalarForFormat?.(subSchema.format) || getDefaultScalarForFormat(subSchema.format);
-          if (formatScalar) {
+          if (formatScalar && sanitizeNameForGraphQL(subSchema.title) === formatScalar.name) {
             const typeComposer = schemaComposer.getAnyTC(formatScalar);
             return {
               input: typeComposer,
@@ -537,6 +500,50 @@ export function getComposerFromJSONSchema({
           default: subSchema.default,
           deprecated: subSchema.deprecated,
         };
+      }
+
+      // OpenAPI 3.1 / JSON Schema: `anyOf`/`oneOf` with a `{ type: 'null' }` branch means nullable.
+      // Run before format/`switch (type)` so a remaining primitive (e.g. string+format) is handled normally.
+      // Remaining object/$ref members are left as a 1-element union so `leave` can reuse that type
+      // instead of cloning it as `Title2`. Keep this after `pattern` so pattern-only nullable
+      // wrappers do not mint a second regexp scalar (Slack Bot_User_ID / #9637 CI).
+      for (const unionKey of ['anyOf', 'oneOf'] as const) {
+        if (
+          subSchema[unionKey] &&
+          !subSchema.properties &&
+          !subSchema.allOf &&
+          !subSchema.additionalProperties
+        ) {
+          const unionArr = subSchema[unionKey] as JSONSchemaObject[];
+          const nonNullUnion = unionArr.filter(s => s.type !== 'null');
+          if (nonNullUnion.length === unionArr.length) {
+            continue;
+          }
+          if (nonNullUnion.length === 0) {
+            const typeComposer = schemaComposer.getAnyTC(GraphQLVoid);
+            return {
+              input: typeComposer,
+              output: typeComposer,
+              nullable: true,
+              description: subSchema.description,
+              readOnly: subSchema.readOnly,
+              writeOnly: subSchema.writeOnly,
+              default: subSchema.default,
+              deprecated: subSchema.deprecated,
+            };
+          }
+          subSchema.nullable = true;
+          if (nonNullUnion.length === 1 && isJsonPrimitiveSchema(nonNullUnion[0])) {
+            Object.assign(subSchema, nonNullUnion[0]);
+            delete (subSchema as any)[unionKey];
+            // The referenced primitive may carry `nullable: false`; the `null` union
+            // member still permits null even when the field is required.
+            subSchema.nullable = true;
+          } else {
+            (subSchema as any)[unionKey] = nonNullUnion;
+          }
+          break;
+        }
       }
 
       if (Array.isArray(subSchema.type)) {

--- a/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
+++ b/packages/loaders/json-schema/src/getComposerFromJSONSchema.ts
@@ -305,7 +305,67 @@ export function getComposerFromJSONSchema({
           };
         }
       }
+
+      // OpenAPI 3.1 / JSON Schema: `anyOf`/`oneOf` with a `{ type: 'null' }` branch means nullable.
+      // Must run before `pattern`/`format` so a shared `$ref` and a nullable wrapper take the
+      // same scalar path (e.g. UUID with both format and pattern — SmallRye / #9637).
+      for (const unionKey of ['anyOf', 'oneOf'] as const) {
+        if (
+          subSchema[unionKey] &&
+          !subSchema.properties &&
+          !subSchema.allOf &&
+          !subSchema.additionalProperties
+        ) {
+          const unionArr = subSchema[unionKey] as JSONSchemaObject[];
+          const nonNullUnion = unionArr.filter(s => s.type !== 'null');
+          if (nonNullUnion.length === unionArr.length) {
+            continue;
+          }
+          if (nonNullUnion.length === 0) {
+            const typeComposer = schemaComposer.getAnyTC(GraphQLVoid);
+            return {
+              input: typeComposer,
+              output: typeComposer,
+              nullable: true,
+              description: subSchema.description,
+              readOnly: subSchema.readOnly,
+              writeOnly: subSchema.writeOnly,
+              default: subSchema.default,
+              deprecated: subSchema.deprecated,
+            };
+          }
+          subSchema.nullable = true;
+          if (nonNullUnion.length === 1 && isJsonPrimitiveSchema(nonNullUnion[0])) {
+            Object.assign(subSchema, nonNullUnion[0]);
+            delete (subSchema as any)[unionKey];
+          } else {
+            (subSchema as any)[unionKey] = nonNullUnion;
+          }
+          break;
+        }
+      }
+
       if (subSchema.pattern) {
+        // Prefer a known `format` scalar when both are present so a `$ref` usage
+        // (pattern branch) and a collapsed nullable wrapper (format branch) do
+        // not mint two different GraphQL types named e.g. `UUID`.
+        if (subSchema.format) {
+          const formatScalar =
+            getScalarForFormat?.(subSchema.format) || getDefaultScalarForFormat(subSchema.format);
+          if (formatScalar) {
+            const typeComposer = schemaComposer.getAnyTC(formatScalar);
+            return {
+              input: typeComposer,
+              output: typeComposer,
+              description: subSchema.description,
+              nullable: subSchema.nullable,
+              readOnly: subSchema.readOnly,
+              writeOnly: subSchema.writeOnly,
+              default: subSchema.default,
+              deprecated: subSchema.deprecated,
+            };
+          }
+        }
         let typeScriptType: string;
         switch (subSchema.type) {
           case 'number':
@@ -477,46 +537,6 @@ export function getComposerFromJSONSchema({
           default: subSchema.default,
           deprecated: subSchema.deprecated,
         };
-      }
-
-      // OpenAPI 3.1 / JSON Schema: `anyOf`/`oneOf` with a `{ type: 'null' }` branch means nullable.
-      // Run before format/`switch (type)` so a remaining primitive (e.g. string+format) is handled normally.
-      // Remaining object/$ref members are left as a 1-element union so `leave` can reuse that type
-      // instead of cloning it as `Title2`.
-      for (const unionKey of ['anyOf', 'oneOf'] as const) {
-        if (
-          subSchema[unionKey] &&
-          !subSchema.properties &&
-          !subSchema.allOf &&
-          !subSchema.additionalProperties
-        ) {
-          const unionArr = subSchema[unionKey] as JSONSchemaObject[];
-          const nonNullUnion = unionArr.filter(s => s.type !== 'null');
-          if (nonNullUnion.length === unionArr.length) {
-            continue;
-          }
-          if (nonNullUnion.length === 0) {
-            const typeComposer = schemaComposer.getAnyTC(GraphQLVoid);
-            return {
-              input: typeComposer,
-              output: typeComposer,
-              nullable: true,
-              description: subSchema.description,
-              readOnly: subSchema.readOnly,
-              writeOnly: subSchema.writeOnly,
-              default: subSchema.default,
-              deprecated: subSchema.deprecated,
-            };
-          }
-          subSchema.nullable = true;
-          if (nonNullUnion.length === 1 && isJsonPrimitiveSchema(nonNullUnion[0])) {
-            Object.assign(subSchema, nonNullUnion[0]);
-            delete (subSchema as any)[unionKey];
-          } else {
-            (subSchema as any)[unionKey] = nonNullUnion;
-          }
-          break;
-        }
       }
 
       if (Array.isArray(subSchema.type)) {

--- a/packages/loaders/json-schema/test/getComposerFromSchema.test.ts
+++ b/packages/loaders/json-schema/test/getComposerFromSchema.test.ts
@@ -31,6 +31,7 @@ import {
   GraphQLJSON,
   GraphQLTime,
   GraphQLURL,
+  GraphQLUUID,
 } from 'graphql-scalars';
 import type { JSONSchemaObject } from 'json-machete';
 import { processDirectives, processScalarType } from '@graphql-mesh/transport-rest';
@@ -1534,6 +1535,38 @@ ${printType(GraphQLString)}
     expect(groupType).toBe(maybeGroupType);
     expect(output.getFieldNames()).not.toContain('LightningObsGroup2');
     expect(output.schemaComposer.has('LightningObsGroup2')).toBe(false);
+  });
+  it('should reuse one UUID scalar for a format+pattern $ref and a nullable anyOf of the same $ref (#9637)', async () => {
+    const uuidSchema: JSONSchemaObject = {
+      title: 'UUID',
+      type: 'string',
+      format: 'uuid',
+      pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}',
+    };
+    const inputSchema: JSONSchema = {
+      type: 'object',
+      title: 'Item',
+      properties: {
+        id: uuidSchema,
+        parent_id: {
+          type: ['string', 'null'],
+          anyOf: [uuidSchema, { type: 'null' }],
+        },
+      },
+    };
+    const result = await getComposerFromJSONSchema({
+      subgraphName: 'Test',
+      schema: inputSchema,
+      logger,
+    });
+    const output = result.output as ObjectTypeComposer;
+    const idType = (output.getField('id').type as any).getUnwrappedTC() as ScalarTypeComposer;
+    const parentIdType = (
+      output.getField('parent_id').type as any
+    ).getUnwrappedTC() as ScalarTypeComposer;
+    expect(idType.getType()).toBe(GraphQLUUID);
+    expect(parentIdType.getType()).toBe(GraphQLUUID);
+    expect(output.schemaComposer.has('UUID2')).toBe(false);
   });
   it('should treat oneOf[X, null] as nullable X (issue #8719)', async () => {
     const inputSchema: JSONSchema = {

--- a/packages/loaders/json-schema/test/getComposerFromSchema.test.ts
+++ b/packages/loaders/json-schema/test/getComposerFromSchema.test.ts
@@ -1,5 +1,6 @@
 import {
   execute,
+  getNamedType,
   GraphQLBoolean,
   GraphQLFloat,
   GraphQLInt,
@@ -1542,10 +1543,12 @@ ${printType(GraphQLString)}
       type: 'string',
       format: 'uuid',
       pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}',
+      nullable: false,
     };
     const inputSchema: JSONSchema = {
       type: 'object',
       title: 'Item',
+      required: ['id', 'parent_id'],
       properties: {
         id: uuidSchema,
         parent_id: {
@@ -1560,13 +1563,37 @@ ${printType(GraphQLString)}
       logger,
     });
     const output = result.output as ObjectTypeComposer;
-    const idType = (output.getField('id').type as any).getUnwrappedTC() as ScalarTypeComposer;
-    const parentIdType = (
-      output.getField('parent_id').type as any
-    ).getUnwrappedTC() as ScalarTypeComposer;
-    expect(idType.getType()).toBe(GraphQLUUID);
-    expect(parentIdType.getType()).toBe(GraphQLUUID);
+    const idField = output.getField('id');
+    const parentIdField = output.getField('parent_id');
+    expect(getNamedType(idField.type.getType())).toBe(GraphQLUUID);
+    expect(getNamedType(parentIdField.type.getType())).toBe(GraphQLUUID);
+    expect(idField.type.getTypeName()).toBe('UUID!');
+    expect(parentIdField.type.getTypeName()).toBe('UUID');
+    expect(isNonNullType(idField.type.getType())).toBe(true);
+    expect(isNonNullType(parentIdField.type.getType())).toBe(false);
     expect(output.schemaComposer.has('UUID2')).toBe(false);
+  });
+  it('should keep a regexp scalar when format and pattern names do not collide', async () => {
+    const inputSchema: JSONSchema = {
+      type: 'object',
+      title: 'Operation',
+      properties: {
+        endpoint: {
+          title: 'endpoint',
+          type: 'string',
+          format: 'uri-template',
+          pattern: '^/.*$',
+        },
+      },
+    };
+    const result = await getComposerFromJSONSchema({
+      subgraphName: 'Test',
+      schema: inputSchema,
+      logger,
+    });
+    const output = result.output as ObjectTypeComposer;
+    expect(output.getField('endpoint').type.getTypeName()).toBe('endpoint');
+    expect(output.schemaComposer.has('UriTemplate')).toBe(false);
   });
   it('should treat oneOf[X, null] as nullable X (issue #8719)', async () => {
     const inputSchema: JSONSchema = {

--- a/packages/loaders/openapi/tests/__snapshots__/schemas.test.ts.snap
+++ b/packages/loaders/openapi/tests/__snapshots__/schemas.test.ts.snap
@@ -130616,6 +130616,44 @@ enum HTTPMethod {
 }"
 `;
 
+exports[`Schemas SmallRye UUID 1`] = `
+"schema @transport(subgraph: "SmallRye UUID", kind: "rest", location: "https://example.com") {
+  query: Query
+}
+
+directive @httpOperation(subgraph: String, path: String, operationSpecificHeaders: [[String]], httpMethod: HTTPMethod, isBinary: Boolean, requestBaseBody: ObjMap, queryParamArgMap: ObjMap, queryStringOptionsByParam: ObjMap, jsonApiFields: Boolean, queryStringOptions: ObjMap) on FIELD_DEFINITION
+
+directive @transport(subgraph: String, kind: String, location: String, headers: [[String]], queryStringOptions: ObjMap, queryParams: [[String]]) repeatable on SCHEMA
+
+type Query {
+  getItem: Item @httpOperation(subgraph: "SmallRye UUID", path: "/items", operationSpecificHeaders: [["accept", "application/json"]], httpMethod: GET)
+}
+
+type Item {
+  id: UUID!
+  parent_id: UUID
+}
+
+"""
+A field whose value is a generic Universally Unique Identifier: https://en.wikipedia.org/wiki/Universally_unique_identifier.
+"""
+scalar UUID
+
+enum HTTPMethod {
+  GET
+  HEAD
+  POST
+  PUT
+  DELETE
+  CONNECT
+  OPTIONS
+  TRACE
+  PATCH
+}
+
+scalar ObjMap"
+`;
+
 exports[`Schemas StackExchange 1`] = `
 "schema @transport(subgraph: "StackExchange", kind: "rest", location: "https://api.stackexchange.com/2.2") {
   query: Query

--- a/packages/loaders/openapi/tests/fixtures/reprod-9637.yml
+++ b/packages/loaders/openapi/tests/fixtures/reprod-9637.yml
@@ -1,0 +1,35 @@
+openapi: 3.1.0
+info:
+  title: repro
+  version: '1'
+servers:
+  - url: https://example.com
+paths:
+  /items:
+    get:
+      operationId: getItem
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    UUID:
+      type: string
+      format: uuid
+      pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
+    Item:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        parent_id:
+          type:
+            - string
+            - 'null'
+          anyOf:
+            - $ref: '#/components/schemas/UUID'
+            - type: 'null'

--- a/packages/loaders/openapi/tests/fixtures/reprod-9637.yml
+++ b/packages/loaders/openapi/tests/fixtures/reprod-9637.yml
@@ -23,6 +23,9 @@ components:
       pattern: '[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}'
     Item:
       type: object
+      required:
+        - id
+        - parent_id
       properties:
         id:
           $ref: '#/components/schemas/UUID'

--- a/packages/loaders/openapi/tests/reprod-9637.test.ts
+++ b/packages/loaders/openapi/tests/reprod-9637.test.ts
@@ -1,0 +1,22 @@
+import { assertObjectType, getNamedType, printSchema } from 'graphql';
+import loadGraphQLSchemaFromOpenAPI from '@omnigraph/openapi';
+
+describe('Reproduction #9637', () => {
+  it('reuses one UUID scalar for nullable and non-null $ref to format+pattern UUID', async () => {
+    const schema = await loadGraphQLSchemaFromOpenAPI('repro', {
+      endpoint: 'https://example.com',
+      source: './fixtures/reprod-9637.yml',
+      cwd: __dirname,
+    });
+
+    expect(() => printSchema(schema)).not.toThrow();
+    const queryType = assertObjectType(schema.getQueryType());
+    const itemType = assertObjectType(getNamedType(queryType.getFields().getItem.type));
+    const idType = getNamedType(itemType.getFields().id.type);
+    const parentIdType = getNamedType(itemType.getFields().parent_id.type);
+    expect(idType.name).toBe('UUID');
+    expect(parentIdType.name).toBe('UUID');
+    expect(idType).toBe(parentIdType);
+    expect(schema.getType('UUID2')).toBeUndefined();
+  });
+});

--- a/packages/loaders/openapi/tests/reprod-9637.test.ts
+++ b/packages/loaders/openapi/tests/reprod-9637.test.ts
@@ -1,4 +1,4 @@
-import { assertObjectType, getNamedType, printSchema } from 'graphql';
+import { assertObjectType, getNamedType, isNonNullType, printSchema } from 'graphql';
 import loadGraphQLSchemaFromOpenAPI from '@omnigraph/openapi';
 
 describe('Reproduction #9637', () => {
@@ -12,11 +12,15 @@ describe('Reproduction #9637', () => {
     expect(() => printSchema(schema)).not.toThrow();
     const queryType = assertObjectType(schema.getQueryType());
     const itemType = assertObjectType(getNamedType(queryType.getFields().getItem.type));
-    const idType = getNamedType(itemType.getFields().id.type);
-    const parentIdType = getNamedType(itemType.getFields().parent_id.type);
+    const idField = itemType.getFields().id;
+    const parentIdField = itemType.getFields().parent_id;
+    const idType = getNamedType(idField.type);
+    const parentIdType = getNamedType(parentIdField.type);
     expect(idType.name).toBe('UUID');
     expect(parentIdType.name).toBe('UUID');
     expect(idType).toBe(parentIdType);
+    expect(isNonNullType(idField.type)).toBe(true);
+    expect(isNonNullType(parentIdField.type)).toBe(false);
     expect(schema.getType('UUID2')).toBeUndefined();
   });
 });

--- a/packages/loaders/openapi/tests/schemas.test.ts
+++ b/packages/loaders/openapi/tests/schemas.test.ts
@@ -30,6 +30,7 @@ const schemas: Record<string, string> = {
   YouTrack: 'youtrack.json',
   DefaultValues: 'default-values.json',
   Slack: 'slack.json',
+  'SmallRye UUID': 'reprod-9637.yml',
 };
 
 describe('Schemas', () => {


### PR DESCRIPTION
## Summary
- When a shared primitive schema has both `format` and `pattern`, a plain `$ref` took the pattern branch (custom scalar named from `title`) while a nullable `anyOf` wrapper took the format branch (`graphql-scalars` `UUID`), so `buildSchema` threw `multiple types named "UUID"`.
- Reuse the format scalar only when those GraphQL names would collide. Other `format`+`pattern` pairs keep `@regexp` (e.g. Cloudflare `endpoint` / `uri-template`).
- After collapsing a primitive `anyOf`/`oneOf` with `null`, keep `nullable: true` so a required field can still be `null`.

Fixes #9637

## Test plan
- [x] Composer unit test: shared UUID + required nullable anyOf (`id: UUID!`, `parent_id: UUID`)
- [x] Composer unit test: `format: uri-template` + pattern keeps the regexp scalar
- [x] OpenAPI repro fixture matching the issue document
- [x] Schemas snapshot for that document (`id: UUID!`, `parent_id: UUID`, one `UUID` scalar)
- [x] CloudFlare and Slack schema snapshots