### PR TITLE
fix(renovate): avoid Mend OOM on yarn lockfile updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": ["github>the-guild-org/shared-config:renovate"],
   "automerge": true,
   "rebaseWhen": "conflicted",
+  "prConcurrentLimit": 2,
+  "branchConcurrentLimit": 2,
+  "toolSettings": {
+    "nodeMaxMemory": 1536
+  },
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
## Summary
- Cap yarn/node heap via toolSettings.nodeMaxMemory (1536)
- Lower concurrent PR/branch limits so Renovate jobs fit in 3GB

## Test plan
- [ ] Merge to master
- [ ] Retry Renovate job on Mend portal
- [ ] Confirm job completes without kernel-out-of-memory